### PR TITLE
Clear local storage setting

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
@@ -16,6 +16,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             DEFAULT_REGION = "US";
             DEFAULT_PROVIDERS = "";
             IGNORE_PROVIDERS = "";
+
+            ClearLocalStorageTimestamp = 0;
         }
 
         // Jellyfin Enhanced Settings
@@ -28,5 +30,6 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public string DEFAULT_REGION { get; set; }
         public string DEFAULT_PROVIDERS { get; set; }
         public string IGNORE_PROVIDERS { get; set; }
+        public long ClearLocalStorageTimestamp { get; set; }
     }
 }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -38,6 +38,12 @@
                         <div class="fieldDescription">How long to hold Shift+B to clear all bookmarks.</div>
                     </div>
                 </div>
+                <br>
+                <div>
+                    <button id="clearLocalStorageBtn" class="raised button-cancel block emby-button" is="emby-button" type="button">
+                        <span>Reset Jellyfin Enhanced Settings for all users</span>
+                    </button>
+                </div>
             </fieldset>
                 <!-- Jellyfin Elsewhere Settings -->
                 <fieldset class="verticalSection-extrabottompadding">
@@ -81,6 +87,7 @@
             const pluginId = 'f69e946a-4b3c-4e9a-8f0a-8d7c1b2c4d9b';
             const page = document.querySelector('#JellyfinEnhancedPage');
             const form = document.querySelector('#JellyfinEnhancedForm');
+            const clearLocalStorageBtn = document.querySelector('#clearLocalStorageBtn');
 
             function loadConfig() {
                 Dashboard.showLoadingMsg();
@@ -120,9 +127,21 @@
                 return false;
             }
 
+            function clearLocalStorage() {
+                if (confirm("Are you sure?\n\nThis will reset Jellyfin Enhanced settings for all users to defaults on next load.")) {
+                    Dashboard.showLoadingMsg();
+                    ApiClient.getPluginConfiguration(pluginId).then((config) => {
+                        config.ClearLocalStorageTimestamp = Date.now();
+                        ApiClient.updatePluginConfiguration(pluginId, config).then((result) => {
+                            Dashboard.processPluginConfigurationUpdateResult(result);
+                        });
+                    });
+                }
+            }
+
             page.addEventListener('pageshow', loadConfig);
             form.addEventListener('submit', saveConfig);
-
+            clearLocalStorageBtn.addEventListener('click', clearLocalStorage);
         })();
     </script>
 </div>

--- a/Jellyfin.Plugin.JellyfinEnhanced/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/plugin.js
@@ -24,19 +24,6 @@
             if (config) {
                 pluginConfig = { ...pluginConfig, ...config };
                 console.log('🪼 Jellyfin Enhanced: Plugin configuration loaded', pluginConfig);
-                // Check if we need to clear local storage
-                const serverClearTimestamp = config.ClearLocalStorageTimestamp || 0;
-                const localClearedTimestamp = parseInt(localStorage.getItem('jellyfinEnhancedLastCleared') || '0', 10);
-
-                if (serverClearTimestamp > localClearedTimestamp) {
-                    localStorage.removeItem('jellyfinEnhancedSettings');
-                    // Update the local timestamp to prevent clearing again
-                    localStorage.setItem('jellyfinEnhancedLastCleared', serverClearTimestamp.toString());
-                    console.log(`🪼 Jellyfin Enhanced: Reset triggered by admin at ${new Date(serverClearTimestamp).toLocaleString()}.`);
-                    setTimeout(() => {
-                        toast('⚙️ Settings have been reset by the server admin.');
-                    }, 2000); // 2-second delay
-                }
             }
         }).catch(err => {
             console.warn('🪼 Jellyfin Enhanced: Could not load plugin configuration, using defaults', err);
@@ -1885,6 +1872,19 @@
         };
 
         // --- SCRIPT INITIALIZATION ---
+        // Check if we need to clear local storage
+        const serverClearTimestamp = pluginConfig.ClearLocalStorageTimestamp || 0;
+        const localClearedTimestamp = parseInt(localStorage.getItem('jellyfinEnhancedLastCleared') || '0', 10);
+
+        if (serverClearTimestamp > localClearedTimestamp) {
+            localStorage.removeItem('jellyfinEnhancedSettings');
+            localStorage.setItem('jellyfinEnhancedLastCleared', serverClearTimestamp.toString());
+
+            setTimeout(() => {
+                console.log(`🪼 Jellyfin Enhanced: Local storage cleared by admin request.`);
+                toast('⚙️ All settings have been reset by the server admin.', 5000); //Show toast for 5 seconds
+            }, 2000); // Delay of 2 seconds to allow any initial UI to load
+        }
         injectRandomButtonStyles();
         addPluginMenuButton();
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/plugin.js
@@ -24,6 +24,19 @@
             if (config) {
                 pluginConfig = { ...pluginConfig, ...config };
                 console.log('🪼 Jellyfin Enhanced: Plugin configuration loaded', pluginConfig);
+                // Check if we need to clear local storage
+                const serverClearTimestamp = config.ClearLocalStorageTimestamp || 0;
+                const localClearedTimestamp = parseInt(localStorage.getItem('jellyfinEnhancedLastCleared') || '0', 10);
+
+                if (serverClearTimestamp > localClearedTimestamp) {
+                    localStorage.removeItem('jellyfinEnhancedSettings');
+                    // Update the local timestamp to prevent clearing again
+                    localStorage.setItem('jellyfinEnhancedLastCleared', serverClearTimestamp.toString());
+                    console.log(`🪼 Jellyfin Enhanced: Reset triggered by admin at ${new Date(serverClearTimestamp).toLocaleString()}.`);
+                    setTimeout(() => {
+                        toast('⚙️ Settings have been reset by the server admin.');
+                    }, 2000); // 2-second delay
+                }
             }
         }).catch(err => {
             console.warn('🪼 Jellyfin Enhanced: Could not load plugin configuration, using defaults', err);
@@ -286,7 +299,7 @@
                 });
 
                 pluginSettingsSection.appendChild(jellyfinEnhancedLink);
-                console.log('Jellyfin Enhanced: Menu button added to existing Plugin Settings section');
+                console.log('🪼 Jellyfin Enhanced: Menu button added to existing Plugin Settings section');
             }
         };
 


### PR DESCRIPTION
Add an option in the plugin settings to clear localstorage of all devices. Once invoked, the local storage and settings of all users will be reset to defaults upon next reload.

Fix for #5 