### PR TITLE
Fix LanguageTagsEnabled not resetting when using ResetAllUserSettings

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -701,6 +701,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                 ShowAudioLanguages = defaultConfig.ShowAudioLanguages,
                 QualityTagsEnabled = defaultConfig.QualityTagsEnabled,
                 GenreTagsEnabled = defaultConfig.GenreTagsEnabled,
+                LanguageTagsEnabled = defaultConfig.LanguageTagsEnabled,
                 RemoveContinueWatchingEnabled = defaultConfig.RemoveContinueWatchingEnabled,
                 ReviewsExpandedByDefault = defaultConfig.ReviewsExpandedByDefault,
                 LastOpenedTab = "shortcuts"


### PR DESCRIPTION
Noticed that the language tag setting wasn't being reset to my default config when I used the "Reset All User Settings to Defaults".
I simply added the missing line in the controller.