### PR TITLE
fix: replace '&' (ampersand) with 'and' in series name for Sonarr link

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr-links.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr-links.js
@@ -86,6 +86,7 @@
                     .toString()
                     .normalize('NFD')
                     .replace(/[\u0300-\u036f]/g, '')
+                    .replace(/&/g, 'and')
                     .toLowerCase()
                     .trim()
                     .replace(/\s+/g, '-')


### PR DESCRIPTION
For Series with an '&' ampersand in the title (e.g. "Georgie & Mandy's First Marriage", "Law & Order: Special Victims Unit") the generated link to Sonarr is not correct.
This fixes it by replacing '&' with 'and' before the whitespace-to-dash, etc.