### PR TITLE
feat: file size info for shows and seasons

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/features.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/features.js
@@ -184,9 +184,12 @@
         }
 
         try {
-            const item = await ApiClient.getItem(ApiClient.getCurrentUserId(), itemId);
-            const sources = item?.MediaSources || [];
-            const totalSize = sources.reduce((sum, source) => sum + (source.Size || 0), 0);
+            const itemResult = await ApiClient.ajax({
+                type: 'GET',
+                url: ApiClient.getUrl(`/JellyfinEnhanced/file-size/${ApiClient.getCurrentUserId()}/${itemId}`),
+                dataType: 'json'
+            });
+            const totalSize = itemResult?.size ?? 0;
 
             if (totalSize > 0) {
                 placeholder.title = JE.t('file_size_tooltip');
@@ -328,6 +331,11 @@
                             if (itemId) {
                                 if (JE.currentSettings.showFileSizes) {
                                     displayItemSize(itemId, container);
+
+                                    // show itemMiscInfo if hidden like on season pages
+                                    if (container.classList.contains('hide')) {
+                                        container.classList.remove('hide')
+                                    }
                                 }
                                 if (JE.currentSettings.showAudioLanguages) {
                                     displayAudioLanguages(itemId, container);


### PR DESCRIPTION
This PR moves the current file size calculation to the Backend.
This allows us to calculate file sizes for shows and seasons.
Other types like Videos/Folders could be added later, for now they will follow the same behaviour as in the old implementation