### PR TITLE
Fix person page missing TV shows/episodes sections

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/person-discovery.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/person-discovery.js
@@ -1,45 +1,82 @@
 // /js/jellyseerr/person-discovery.js
-// Adds "More from [Actor]" section to person detail pages using Jellyseerr API
+// Adds "More from [Actor]" section using Jellyseerr API
+// Fixes missing Shows/Episodes sections (jellyfin-web ItemCounts bug workaround)
 (function(JE) {
     'use strict';
 
-    const logPrefix = '🪼 Jellyfin Enhanced: Person Discovery:';
+    const LOG_PREFIX = '🪼 JE Person:';
+    const ITEMS_PER_PAGE = 40;
 
-    // Cache for person ID mappings (personName -> TMDB personId)
+    // Caches
     const personIdCache = new Map();
     const personInfoCache = new Map();
     const processedPages = new Set();
+    const fixProcessedPages = new Set();
 
-    // Pagination state
-    let currentPage = 1;
+    // Pagination state for infinite scroll
     let isLoading = false;
-    let hasMorePages = true;
-    let currentPersonId = null;
-    let currentPersonName = null;
+    let hasMoreItems = true;
+    let allPersonCredits = [];
+    let currentDisplayCount = 0;
 
-    /**
-     * Extracts person ID from the current URL (detail page)
-     */
+    // =========================================================================
+    // UTILITY FUNCTIONS
+    // =========================================================================
+
     function getPersonIdFromUrl() {
         const hash = window.location.hash;
-        if (!hash.includes('/details') || !hash.includes('id=')) {
-            return null;
-        }
+        if (!hash.includes('/details') || !hash.includes('id=')) return null;
         try {
-            const params = new URLSearchParams(hash.split('?')[1]);
-            return params.get('id');
-        } catch (error) {
+            return new URLSearchParams(hash.split('?')[1]).get('id');
+        } catch {
             return null;
         }
     }
 
-    /**
-     * Gets person information from Jellyfin (with caching)
-     */
-    async function getPersonInfo(personId) {
-        if (personInfoCache.has(personId)) {
-            return personInfoCache.get(personId);
+    function getServerIdFromUrl() {
+        try {
+            return new URLSearchParams(window.location.hash.split('?')[1]).get('serverId');
+        } catch {
+            return null;
         }
+    }
+
+    async function isPersonPage(itemId) {
+        try {
+            const item = await ApiClient.getItem(ApiClient.getCurrentUserId(), itemId);
+            return item?.Type === 'Person';
+        } catch {
+            return false;
+        }
+    }
+
+    function waitForPageReady() {
+        return new Promise((resolve) => {
+            const selector = '.itemDetailPage:not(.hide) .detailPageContent, .itemDetailPage:not(.hide)';
+            if (document.querySelector(selector)) {
+                resolve();
+                return;
+            }
+
+            const observer = new MutationObserver((_, obs) => {
+                if (document.querySelector(selector)) {
+                    obs.disconnect();
+                    resolve();
+                }
+            });
+
+            observer.observe(document.body, { childList: true, subtree: true });
+            setTimeout(() => { observer.disconnect(); resolve(); }, 3000);
+        });
+    }
+
+    // =========================================================================
+    // API FUNCTIONS
+    // =========================================================================
+
+    async function getPersonInfo(personId) {
+        if (personInfoCache.has(personId)) return personInfoCache.get(personId);
+
         try {
             const response = await ApiClient.ajax({
                 type: 'GET',
@@ -47,35 +84,16 @@
                 headers: { 'X-Jellyfin-User-Id': ApiClient.getCurrentUserId() },
                 dataType: 'json'
             });
-            if (response) {
-                personInfoCache.set(personId, response);
-            }
+            if (response) personInfoCache.set(personId, response);
             return response;
-        } catch (error) {
+        } catch {
             return null;
         }
     }
 
-    /**
-     * Check if current page is a Person detail page
-     */
-    async function isPersonPage(itemId) {
-        try {
-            const item = await ApiClient.getItem(ApiClient.getCurrentUserId(), itemId);
-            return item && item.Type === 'Person';
-        } catch {
-            return false;
-        }
-    }
-
-    /**
-     * Searches for TMDB person ID by name
-     */
     async function searchTmdbPerson(personName) {
         const cacheKey = personName.toLowerCase().trim();
-        if (personIdCache.has(cacheKey)) {
-            return personIdCache.get(cacheKey);
-        }
+        if (personIdCache.has(cacheKey)) return personIdCache.get(cacheKey);
 
         try {
             const response = await ApiClient.ajax({
@@ -85,27 +103,17 @@
                 dataType: 'json'
             });
 
-            if (response?.results?.length > 0) {
-                // Find person results
-                const personResults = response.results.filter(r => r.mediaType === 'person');
-                if (personResults.length > 0) {
-                    const exactMatch = personResults.find(r =>
-                        r.name?.toLowerCase() === personName.toLowerCase()
-                    );
-                    const personId = exactMatch ? exactMatch.id : personResults[0].id;
-                    personIdCache.set(cacheKey, personId);
-                    return personId;
-                }
+            const personResults = response?.results?.filter(r => r.mediaType === 'person') || [];
+            if (personResults.length > 0) {
+                const exactMatch = personResults.find(r => r.name?.toLowerCase() === personName.toLowerCase());
+                const personId = exactMatch?.id || personResults[0].id;
+                personIdCache.set(cacheKey, personId);
+                return personId;
             }
-        } catch (error) {
-            // Silent fail
-        }
+        } catch {}
         return null;
     }
 
-    /**
-     * Fetches person credits from Jellyseerr
-     */
     async function fetchPersonCredits(personId) {
         try {
             const response = await ApiClient.ajax({
@@ -116,45 +124,66 @@
             });
             return response || { cast: [], crew: [] };
         } catch (error) {
-            console.error(`${logPrefix} Error fetching credits:`, error);
+            console.error(`${LOG_PREFIX} Error fetching credits:`, error);
             return { cast: [], crew: [] };
         }
     }
 
-    /**
-     * Creates cards and returns a DocumentFragment for batch DOM insertion
-     */
+    async function queryItemsByPerson(personId, itemTypes) {
+        try {
+            const result = await ApiClient.getItems(ApiClient.getCurrentUserId(), {
+                PersonIds: personId,
+                IncludeItemTypes: itemTypes,
+                Recursive: true,
+                Fields: 'PrimaryImageAspectRatio',
+                SortBy: 'SortName',
+                SortOrder: 'Ascending',
+                Limit: 100
+            });
+            return result?.Items || [];
+        } catch (error) {
+            console.error(`${LOG_PREFIX} Error querying ${itemTypes}:`, error);
+            return [];
+        }
+    }
+
+    // =========================================================================
+    // JELLYSEERR PERSON DISCOVERY SECTION
+    // =========================================================================
+
+    function interleaveArrays(arr1, arr2) {
+        const result = [];
+        const maxLen = Math.max(arr1.length, arr2.length);
+        for (let i = 0; i < maxLen; i++) {
+            if (i < arr1.length) result.push(arr1[i]);
+            if (i < arr2.length) result.push(arr2[i]);
+        }
+        return result;
+    }
+
     function createCardsFragment(results) {
         const fragment = document.createDocumentFragment();
         const excludeLibraryItems = JE.pluginConfig?.JellyseerrExcludeLibraryItems === true;
         const seen = new Set();
 
-        for (let i = 0; i < results.length; i++) {
-            const item = results[i];
-
-            // Deduplicate by TMDB ID
+        for (const item of results) {
             const key = `${item.mediaType}-${item.id}`;
             if (seen.has(key)) continue;
             seen.add(key);
 
-            // Skip library items if configured
-            if (excludeLibraryItems && item.mediaInfo?.jellyfinMediaId) {
-                continue;
-            }
+            if (excludeLibraryItems && item.mediaInfo?.jellyfinMediaId) continue;
 
             const card = JE.jellyseerrUI?.createJellyseerrCard?.(item, true, true);
             if (!card) continue;
 
-            // Use overflowPortraitCard to match native person page card sizing
-            const classList = card.classList;
-            classList.remove('portraitCard');
-            classList.add('overflowPortraitCard');
+            card.classList.remove('portraitCard');
+            card.classList.add('overflowPortraitCard');
 
             const jellyfinMediaId = item.mediaInfo?.jellyfinMediaId;
             if (jellyfinMediaId) {
                 card.setAttribute('data-library-item', 'true');
                 card.setAttribute('data-jellyfin-media-id', jellyfinMediaId);
-                classList.add('jellyseerr-card-in-library');
+                card.classList.add('jellyseerr-card-in-library');
 
                 const titleLink = card.querySelector('.cardText-first a');
                 if (titleLink) {
@@ -173,22 +202,17 @@
         return fragment;
     }
 
-    /**
-     * Creates the section container - matching native Jellyfin person page styling
-     */
-    function createSectionContainer(title) {
+    function createDiscoverySection(title) {
         const section = document.createElement('div');
         section.className = 'verticalSection jellyseerr-person-discovery-section';
-        section.setAttribute('data-jellyseerr-person-discovery', 'true');
         section.style.cssText = 'margin-top:2em;padding-top:1em;border-top:1px solid rgba(255,255,255,0.1)';
 
-        const titleElement = document.createElement('h2');
-        titleElement.className = 'sectionTitle sectionTitle-cards';
-        titleElement.textContent = title;
-        titleElement.style.marginBottom = '1em';
-        section.appendChild(titleElement);
+        const h2 = document.createElement('h2');
+        h2.className = 'sectionTitle sectionTitle-cards';
+        h2.textContent = title;
+        h2.style.marginBottom = '1em';
+        section.appendChild(h2);
 
-        // Match native container: itemsContainer padded-right vertical-wrap
         const itemsContainer = document.createElement('div');
         itemsContainer.setAttribute('is', 'emby-itemscontainer');
         itemsContainer.className = 'itemsContainer padded-right vertical-wrap';
@@ -197,181 +221,287 @@
         return section;
     }
 
-    /**
-     * Loads more items for infinite scroll
-     */
-    async function loadMoreItems() {
-        if (isLoading || !hasMorePages || !currentPersonId) return;
+    function loadMoreItems() {
+        if (isLoading || !hasMoreItems || !allPersonCredits.length) return;
 
         isLoading = true;
-        currentPage++;
-
-        try {
-            const credits = await fetchPersonCredits(currentPersonId, currentPage);
-            const allResults = [...(credits.cast || []), ...(credits.crew || [])];
-
-            hasMorePages = allResults.length >= 20;
-
-            if (allResults.length === 0) {
-                hasMorePages = false;
-                isLoading = false;
-                return;
-            }
-
-            const itemsContainer = document.querySelector('.jellyseerr-person-discovery-section .itemsContainer');
-            if (itemsContainer) {
-                const fragment = createCardsFragment(allResults);
-                if (fragment.childNodes.length > 0) {
-                    itemsContainer.appendChild(fragment);
-                }
-            }
-        } catch (error) {
-            console.error(`${logPrefix} Error loading more items:`, error);
+        const container = document.querySelector('.jellyseerr-person-discovery-section .itemsContainer');
+        if (!container) {
+            isLoading = false;
+            return;
         }
 
+        const nextBatch = allPersonCredits.slice(currentDisplayCount, currentDisplayCount + ITEMS_PER_PAGE);
+        if (!nextBatch.length) {
+            hasMoreItems = false;
+            isLoading = false;
+            return;
+        }
+
+        const fragment = createCardsFragment(nextBatch);
+        if (fragment.childNodes.length) {
+            container.appendChild(fragment);
+            currentDisplayCount += nextBatch.length;
+        }
+
+        hasMoreItems = currentDisplayCount < allPersonCredits.length;
         isLoading = false;
     }
 
-    /**
-     * Sets up infinite scroll observer
-     */
     function setupInfiniteScroll() {
         const section = document.querySelector('.jellyseerr-person-discovery-section');
         if (!section) return;
+
+        section.querySelector('.jellyseerr-scroll-sentinel')?.remove();
 
         const sentinel = document.createElement('div');
         sentinel.className = 'jellyseerr-scroll-sentinel';
         sentinel.style.cssText = 'height:20px;width:100%';
         section.appendChild(sentinel);
 
-        const observer = new IntersectionObserver((entries) => {
-            if (entries[0].isIntersecting && hasMorePages && !isLoading) {
+        new IntersectionObserver((entries) => {
+            if (entries[0].isIntersecting && hasMoreItems && !isLoading) {
                 loadMoreItems();
             }
-        }, { rootMargin: '200px' });
-
-        observer.observe(sentinel);
+        }, { rootMargin: '200px' }).observe(sentinel);
     }
 
-    /**
-     * Main function to render the person discovery section
-     */
     async function renderPersonDiscovery() {
         const itemId = getPersonIdFromUrl();
         if (!itemId) return;
 
-        const pageKey = `person-${itemId}-${window.location.hash}`;
+        const pageKey = `discovery-${itemId}`;
         if (processedPages.has(pageKey)) return;
         processedPages.add(pageKey);
 
         if (JE.pluginConfig?.JellyseerrShowPersonDiscovery === false) return;
+        if (!await isPersonPage(itemId)) return;
 
-        // Check if this is a person page
-        const isPerson = await isPersonPage(itemId);
-        if (!isPerson) return;
-
-        const personInfoPromise = getPersonInfo(itemId);
-        const statusPromise = JE.jellyseerrAPI?.checkUserStatus();
-
-        const [personInfo, status] = await Promise.all([personInfoPromise, statusPromise]);
+        const [personInfo, status] = await Promise.all([
+            getPersonInfo(itemId),
+            JE.jellyseerrAPI?.checkUserStatus()
+        ]);
 
         if (!status?.active || !personInfo?.name) return;
 
-        // Get TMDB person ID
         const tmdbPersonId = personInfo.tmdbId
             ? parseInt(personInfo.tmdbId)
             : await searchTmdbPerson(personInfo.name);
 
         if (!tmdbPersonId) return;
 
-        // Store for reference
-        currentPersonId = tmdbPersonId;
-        currentPersonName = personInfo.name;
-
-        // Fetch credits
         const credits = await fetchPersonCredits(tmdbPersonId);
-        const allResults = [...(credits.cast || []), ...(credits.crew || [])];
+        const allCredits = [...(credits.cast || []), ...(credits.crew || [])];
+        const movies = allCredits.filter(c => c.mediaType === 'movie');
+        const tvShows = allCredits.filter(c => c.mediaType === 'tv');
 
-        console.log(`${logPrefix} Fetched ${allResults.length} credits for ${personInfo.name}`);
+        allPersonCredits = interleaveArrays(movies, tvShows);
+        currentDisplayCount = 0;
+        hasMoreItems = allPersonCredits.length > ITEMS_PER_PAGE;
 
-        if (allResults.length === 0) return;
+        console.log(`${LOG_PREFIX} ${allPersonCredits.length} credits (${movies.length} movies, ${tvShows.length} TV) for ${personInfo.name}`);
 
-        // Wait for page content
+        if (!allPersonCredits.length) return;
+
         await waitForPageReady();
 
-        // Find insertion point (after the existing content) - only on ACTIVE page (not hidden)
         const detailSection = document.querySelector('.itemDetailPage:not(.hide) .detailPageContent') ||
-                             document.querySelector('.itemDetailPage:not(.hide)') ||
-                             document.querySelector('.page:not(.hide) .detailPageContent');
+                             document.querySelector('.itemDetailPage:not(.hide)');
+        if (!detailSection) return;
 
-        if (!detailSection) {
-            console.log(`${logPrefix} Could not find detail section to insert into`);
-            return;
-        }
+        document.querySelector('.jellyseerr-person-discovery-section')?.remove();
 
-        // Remove existing section
-        const existing = document.querySelector('.jellyseerr-person-discovery-section');
-        if (existing) existing.remove();
+        const section = createDiscoverySection(JE.t('discovery_more_from_person', { person: personInfo.name }));
+        const container = section.querySelector('.itemsContainer');
 
-        // Create and insert section
-        const sectionTitle = JE.t('discovery_more_from_person', { person: personInfo.name });
-        const section = createSectionContainer(sectionTitle);
-        const itemsContainer = section.querySelector('.itemsContainer');
+        const firstBatch = allPersonCredits.slice(0, ITEMS_PER_PAGE);
+        const fragment = createCardsFragment(firstBatch);
+        if (!fragment.childNodes.length) return;
 
-        // Show up to 40 items (no pagination for person credits API)
-        const fragment = createCardsFragment(allResults.slice(0, 40));
-        if (fragment.childNodes.length === 0) {
-            console.log(`${logPrefix} No cards created from results`);
-            return;
-        }
-
-        itemsContainer.appendChild(fragment);
+        currentDisplayCount = firstBatch.length;
+        container.appendChild(fragment);
         detailSection.appendChild(section);
-        console.log(`${logPrefix} Section added with ${fragment.childNodes.length} cards`);
+
+        if (hasMoreItems) setupInfiniteScroll();
     }
 
-    /**
-     * Wait for the page to be ready (active page only, not hidden)
-     */
-    function waitForPageReady() {
-        return new Promise((resolve) => {
-            const detailContent = document.querySelector('.itemDetailPage:not(.hide) .detailPageContent') ||
-                                  document.querySelector('.itemDetailPage:not(.hide)');
-            if (detailContent) {
-                resolve();
-                return;
+    // =========================================================================
+    // NATIVE SECTIONS FIX (Shows/Episodes)
+    // =========================================================================
+
+    function nativeSectionExists(type) {
+        const section = document.querySelector(`.verticalSection[data-type="${type}"]`);
+        return section && !section.classList.contains('hide');
+    }
+
+    function createNativeSection(title, type, items, personId, serverId) {
+        const section = document.createElement('div');
+        section.className = 'verticalSection';
+        section.setAttribute('data-type', type);
+        section.setAttribute('data-je-fix', 'true');
+
+        const titleContainer = document.createElement('div');
+        titleContainer.className = 'sectionTitleContainer sectionTitleContainer-cards';
+
+        const h2 = document.createElement('h2');
+        h2.className = 'sectionTitle sectionTitle-cards';
+        h2.textContent = title;
+        titleContainer.appendChild(h2);
+
+        if (items.length >= 10) {
+            const moreLink = document.createElement('a');
+            moreLink.setAttribute('is', 'emby-linkbutton');
+            moreLink.className = 'clearLink';
+            moreLink.style.cssText = 'margin-left:1em;vertical-align:middle;';
+            moreLink.href = `#!/list?type=${type}&personId=${personId}&serverId=${serverId}`;
+
+            const moreButton = document.createElement('button');
+            moreButton.setAttribute('is', 'emby-button');
+            moreButton.type = 'button';
+            moreButton.className = 'raised more raised-mini noIcon';
+            moreButton.textContent = 'More';
+            moreLink.appendChild(moreButton);
+            titleContainer.appendChild(moreLink);
+        }
+
+        section.appendChild(titleContainer);
+
+        const itemsContainer = document.createElement('div');
+        itemsContainer.setAttribute('is', 'emby-itemscontainer');
+        itemsContainer.className = 'itemsContainer padded-right vertical-wrap';
+
+        const displayItems = items.slice(0, 10);
+        const cardBuilder = window.cardBuilder || window.CardBuilder;
+
+        if (cardBuilder?.getCardsHtml) {
+            try {
+                itemsContainer.innerHTML = cardBuilder.getCardsHtml({
+                    items: displayItems,
+                    shape: type === 'Episode' ? 'overflowBackdrop' : 'overflowPortrait',
+                    showTitle: true,
+                    showYear: type === 'Series',
+                    showParentTitle: type === 'Episode',
+                    centerText: true,
+                    overlayMoreButton: type === 'Series',
+                    overlayPlayButton: type === 'Episode'
+                });
+            } catch {
+                itemsContainer.innerHTML = createFallbackCards(displayItems, type);
             }
+        } else {
+            itemsContainer.innerHTML = createFallbackCards(displayItems, type);
+        }
 
-            const observer = new MutationObserver((mutations, obs) => {
-                const content = document.querySelector('.itemDetailPage:not(.hide) .detailPageContent') ||
-                               document.querySelector('.itemDetailPage:not(.hide)');
-                if (content) {
-                    obs.disconnect();
-                    resolve();
-                }
-            });
+        section.appendChild(itemsContainer);
+        window.imageLoader?.lazyChildren(itemsContainer);
 
-            observer.observe(document.body, { childList: true, subtree: true });
-            setTimeout(() => { observer.disconnect(); resolve(); }, 3000);
-        });
+        return section;
     }
 
-    /**
-     * Handles page navigation
-     */
+    function createFallbackCards(items, type) {
+        const isEpisode = type === 'Episode';
+        const cardClass = isEpisode ? 'overflowBackdropCard backdropCard' : 'overflowPortraitCard portraitCard';
+        const padderClass = isEpisode ? 'cardPadder-backdrop' : 'cardPadder-portrait';
+
+        return items.map(item => {
+            const imageTag = item.ImageTags?.Primary || item.SeriesPrimaryImageTag;
+            const imageId = item.ImageTags?.Primary ? item.Id : item.SeriesId;
+            const imgUrl = imageTag && imageId
+                ? ApiClient.getScaledImageUrl(imageId, { type: 'Primary', maxWidth: isEpisode ? 300 : 200, tag: imageTag })
+                : '';
+
+            const title = item.Name || '';
+            const subtitle = isEpisode ? (item.SeriesName || '') : (item.ProductionYear || '');
+            const imgHtml = imgUrl
+                ? `<div class="cardImageContainer cardImageContainer-dynamic" style="background-image:url('${imgUrl}')"></div>`
+                : `<div class="cardImageContainer cardImageContainer-dynamic defaultCardBackground"></div>`;
+
+            return `
+                <a href="#!/details?id=${item.Id}&serverId=${item.ServerId}" class="card ${cardClass}" data-id="${item.Id}">
+                    <div class="cardBox">
+                        <div class="cardScalable">
+                            <div class="cardPadder ${padderClass}"></div>
+                            <div class="cardContent">${imgHtml}</div>
+                        </div>
+                        <div class="cardFooter">
+                            <div class="cardText cardTextCentered">${title}</div>
+                            ${subtitle ? `<div class="cardText cardText-secondary cardTextCentered">${subtitle}</div>` : ''}
+                        </div>
+                    </div>
+                </a>`;
+        }).join('');
+    }
+
+    function findContentArea() {
+        return document.querySelector('.itemDetailPage:not(.hide) #childrenContent') ||
+               document.querySelector('.itemDetailPage:not(.hide) .detailPageContent');
+    }
+
+    function insertSection(contentArea, section, afterType) {
+        const afterSection = contentArea.querySelector(`.verticalSection[data-type="${afterType}"]`);
+        if (afterSection?.nextSibling) {
+            contentArea.insertBefore(section, afterSection.nextSibling);
+        } else if (afterSection) {
+            contentArea.appendChild(section);
+        } else {
+            contentArea.insertBefore(section, contentArea.firstChild);
+        }
+    }
+
+    async function fixMissingPersonSections(personId) {
+        const fixKey = `fix-${personId}`;
+        if (fixProcessedPages.has(fixKey)) return;
+        fixProcessedPages.add(fixKey);
+
+        if (!await isPersonPage(personId)) return;
+
+        await waitForPageReady();
+        await new Promise(resolve => setTimeout(resolve, 300));
+
+        const contentArea = findContentArea();
+        if (!contentArea) return;
+
+        const serverId = getServerIdFromUrl();
+
+        // Fix Shows section
+        if (!nativeSectionExists('Series')) {
+            const items = await queryItemsByPerson(personId, 'Series');
+            if (items.length) {
+                console.log(`${LOG_PREFIX} Injecting Shows section (${items.length} items)`);
+                const section = createNativeSection('Shows', 'Series', items, personId, serverId || items[0]?.ServerId);
+                insertSection(contentArea, section, 'Movie');
+            }
+        }
+
+        // Fix Episodes section
+        if (!nativeSectionExists('Episode')) {
+            const items = await queryItemsByPerson(personId, 'Episode');
+            if (items.length) {
+                console.log(`${LOG_PREFIX} Injecting Episodes section (${items.length} items)`);
+                const section = createNativeSection('Episodes', 'Episode', items, personId, serverId || items[0]?.ServerId);
+                insertSection(contentArea, section, 'Series');
+            }
+        }
+    }
+
+    // =========================================================================
+    // INITIALIZATION
+    // =========================================================================
+
     function handlePageNavigation() {
         const itemId = getPersonIdFromUrl();
         if (itemId) {
-            requestAnimationFrame(() => renderPersonDiscovery());
+            requestAnimationFrame(() => {
+                renderPersonDiscovery();
+                fixMissingPersonSections(itemId);
+            });
         }
     }
 
-    /**
-     * Initialize
-     */
     function initialize() {
         window.addEventListener('hashchange', () => {
             processedPages.clear();
+            fixProcessedPages.clear();
             handlePageNavigation();
         });
 


### PR DESCRIPTION
## Summary

- Fix jellyfin-web bug where Shows/Episodes sections don't appear on person pages
  - The native jellyfin-web code doesn't request `ItemCounts` when fetching Person items, so `SeriesCount`/`EpisodeCount` are always 0 and those sections never render
  - This fix queries Jellyfin directly for Series/Episode items by PersonId and injects the missing sections with native styling

- Interleave movies and TV shows in the "More with [Actor]" discovery section
  - The Jellyseerr API returns movies sorted before TV shows, so with a 40 item limit, TV shows were being cut off entirely
  - Now alternates between movies and TV shows for better representation

- Add client-side infinite scroll for the discovery section
  - Previously only showed first 40 items
  - Now loads more as you scroll down

- General code cleanup and reorganization

## Test plan

- [x] Navigate to an actor page that appears in both movies and TV shows
- [x] Verify "Shows" section appears with TV series
- [x] Verify "Episodes" section appears (if actor has episode credits)
- [x] Verify "More with [Actor]" section shows both movies and TV shows interleaved
- [x] Verify scrolling loads more items in the discovery section

🤖 Generated with [Claude Code](https://claude.ai/code)