### PR TITLE
Add seamless infinite scroll to discovery sections

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/network-discovery.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/network-discovery.js
@@ -20,7 +20,6 @@
     let hasMorePages = true;
     let currentTvNetworkId = null;
     let currentCompanyId = null;
-    let currentStudioName = null;
 
     // Separate page tracking for TV and Movies
     let tvCurrentPage = 1;
@@ -31,6 +30,9 @@
     // Cached results for filter switching (avoid refetch)
     let cachedTvResults = [];
     let cachedMovieResults = [];
+
+    // Deduplicator for infinite scroll (prevents duplicate cards)
+    let itemDeduplicator = null;
 
     // Abort controller for cancellation
     let currentAbortController = null;
@@ -345,17 +347,8 @@
         const itemsContainer = document.querySelector('.jellyseerr-network-discovery-section .itemsContainer');
         if (!itemsContainer) return;
 
-        // Clear existing cards
-        itemsContainer.innerHTML = '';
-
-        // Get filtered results
-        const filtered = getFilteredResults(newMode);
-
-        // Render cards
-        const fragment = createCardsFragment(filtered.slice(0, 20));
-        if (fragment.childNodes.length > 0) {
-            itemsContainer.appendChild(fragment);
-        }
+        // Use fast CSS-based visibility (no DOM rebuild)
+        JE.discoveryFilter.applyFilterVisibility(itemsContainer, newMode);
 
         // Update hasMorePages based on filter mode
         updateHasMorePages(newMode);
@@ -429,7 +422,7 @@
 
             const results = await Promise.all(promises);
 
-            if (signal?.aborted) return;
+            if (signal?.aborted) { isLoading = false; return; }
 
             let newTvResults = [];
             let newMovieResults = [];
@@ -465,6 +458,15 @@
                 return;
             }
 
+            // Deduplicate items using deduplicator (if available)
+            if (itemDeduplicator) {
+                itemsToAdd = itemDeduplicator.filter(itemsToAdd);
+                if (itemsToAdd.length === 0) {
+                    isLoading = false;
+                    return;
+                }
+            }
+
             const itemsContainer = document.querySelector('.jellyseerr-network-discovery-section .itemsContainer');
             if (itemsContainer) {
                 const fragment = createCardsFragment(itemsToAdd);
@@ -475,6 +477,7 @@
         } catch (error) {
             if (error.name === 'AbortError') return;
             console.error(`${logPrefix} Error loading more items:`, error);
+            throw error; // Re-throw for seamlessScroll retry handling
         }
 
         isLoading = false;
@@ -571,11 +574,14 @@
             movieHasMorePages = true;
             currentTvNetworkId = tvNetworkId;
             currentCompanyId = companyId;
-            currentStudioName = studioInfo.name;
+
 
             // Clear cached results
             cachedTvResults = [];
             cachedMovieResults = [];
+
+            // Initialize deduplicator for infinite scroll
+            itemDeduplicator = JE.seamlessScroll?.createDeduplicator() || null;
 
             // Fetch TV and Movies separately (only if IDs available)
             const fetchPromises = [];
@@ -638,10 +644,15 @@
             const section = createSectionContainer(sectionTitle, hasBoth, handleFilterChange);
             const itemsContainer = section.querySelector('.itemsContainer');
 
-            const fragment = createCardsFragment(displayResults.slice(0, 20));
+            const fragment = createCardsFragment(displayResults);
             if (fragment.childNodes.length === 0) return;
 
             itemsContainer.appendChild(fragment);
+
+            // Seed deduplicator with initial items to prevent duplicates on scroll
+            if (itemDeduplicator) {
+                displayResults.forEach(item => itemDeduplicator.add(item));
+            }
 
             const parentContainer = listPage.closest('.verticalSection') || listPage.parentElement;
             if (parentContainer?.parentElement) {
@@ -693,12 +704,18 @@
         movieHasMorePages = true;
         currentTvNetworkId = null;
         currentCompanyId = null;
-        currentStudioName = null;
+
         currentRenderingPageKey = null;
 
         // Clear cached results
         cachedTvResults = [];
         cachedMovieResults = [];
+
+        // Clear deduplicator
+        if (itemDeduplicator) {
+            itemDeduplicator.clear();
+        }
+        itemDeduplicator = null;
     }
 
     /**

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/seamless-scroll.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/seamless-scroll.js
@@ -1,0 +1,299 @@
+// /js/jellyseerr/seamless-scroll.js
+// Seamless infinite scroll utility with prefetch, deduplication, retry, and batched rendering
+(function(JE) {
+    'use strict';
+
+    const logPrefix = '🪼 Jellyfin Enhanced: Seamless Scroll:';
+
+    // ============================================================================
+    // CONFIGURATION
+    // ============================================================================
+    const CONFIG = {
+        // Prefetch when user is within this many pixels of the end
+        // ~2 viewport heights provides smooth experience
+        prefetchThresholdPx: Math.max(window.innerHeight * 2, 1200),
+
+        // Retry configuration
+        retry: {
+            maxAttempts: 3,
+            baseDelayMs: 1000,
+            maxDelayMs: 8000,
+            jitterFactor: 0.25
+        }
+    };
+
+    // ============================================================================
+    // UTILITY FUNCTIONS
+    // ============================================================================
+
+
+    function sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    function calculateBackoff(attempt) {
+        const { baseDelayMs, maxDelayMs, jitterFactor } = CONFIG.retry;
+        const exponentialDelay = baseDelayMs * Math.pow(2, attempt - 1);
+        const clampedDelay = Math.min(exponentialDelay, maxDelayMs);
+        const jitter = clampedDelay * jitterFactor * (Math.random() * 2 - 1);
+        return Math.max(0, Math.round(clampedDelay + jitter));
+    }
+
+    // ============================================================================
+    // DEDUPLICATION HELPER
+    // ============================================================================
+
+    /**
+     * Creates a deduplication tracker for managing seen items across pages
+     * @returns {object} Deduplication tracker
+     */
+    function createDeduplicator() {
+        const seen = new Set();
+
+        return {
+            /**
+             * Checks if item has been seen and marks it as seen
+             * @param {object} item - Item to check
+             * @param {Function} [getKey] - Custom key function
+             * @returns {boolean} True if item is new (not a duplicate)
+             */
+            add(item, getKey = (i) => `${i.mediaType}-${i.id}`) {
+                const key = getKey(item);
+                if (seen.has(key)) {
+                    return false;
+                }
+                seen.add(key);
+                return true;
+            },
+
+            /**
+             * Filters array to only include new items
+             * @param {Array} items - Items to filter
+             * @param {Function} [getKey] - Custom key function
+             * @returns {Array} Filtered items
+             */
+            filter(items, getKey = (i) => `${i.mediaType}-${i.id}`) {
+                return items.filter(item => this.add(item, getKey));
+            },
+
+            /**
+             * Clears all seen items
+             */
+            clear() {
+                seen.clear();
+            },
+
+            /**
+             * Gets count of seen items
+             * @returns {number}
+             */
+            get size() {
+                return seen.size;
+            }
+        };
+    }
+
+    // ============================================================================
+    // SIMPLE INFINITE SCROLL (backward compatible)
+    // ============================================================================
+
+    /**
+     * Simplified infinite scroll setup that replaces the old implementation
+     * Uses the full controller internally but provides simpler API
+     * @param {object} state - State object with activeScrollObserver property
+     * @param {string} sectionSelector - CSS selector for the section
+     * @param {Function} loadMoreFn - Function to call when more items needed
+     * @param {Function} hasMoreCheck - Function that returns whether more pages exist
+     * @param {Function} isLoadingCheck - Function that returns whether currently loading
+     * @param {object} [options] - Additional options
+     */
+    function setupInfiniteScroll(state, sectionSelector, loadMoreFn, hasMoreCheck, isLoadingCheck, options = {}) {
+        // Clean up previous observer
+        if (state.activeScrollObserver) {
+            state.activeScrollObserver.disconnect();
+            state.activeScrollObserver = null;
+        }
+
+        // Also clean up any legacy sentinel
+        if (state.scrollController) {
+            state.scrollController.destroy();
+            state.scrollController = null;
+        }
+
+        const section = document.querySelector(sectionSelector);
+        if (!section) return;
+
+        // Remove old sentinels
+        const oldSentinels = section.querySelectorAll('.jellyseerr-scroll-sentinel, .je-scroll-sentinel');
+        oldSentinels.forEach(s => s.remove());
+
+        // Create new sentinel
+        const sentinel = document.createElement('div');
+        sentinel.className = 'je-scroll-sentinel';
+        sentinel.style.cssText = 'height:1px;width:100%;pointer-events:none;';
+        section.appendChild(sentinel);
+
+        // Track state for retry UI
+        let retryCount = 0;
+        let retryRow = null;
+
+        const removeRetryRow = () => {
+            if (retryRow) {
+                retryRow.remove();
+                retryRow = null;
+            }
+        };
+
+        const showRetryRow = () => {
+            if (retryRow) return;
+
+            retryRow = document.createElement('div');
+            retryRow.className = 'je-retry-row';
+            retryRow.style.cssText = `
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                padding: 1.5em;
+                width: 100%;
+                box-sizing: border-box;
+            `;
+
+            const retryButton = document.createElement('button');
+            retryButton.type = 'button';
+            retryButton.textContent = '⟳ Tap to retry';
+            retryButton.style.cssText = `
+                padding: 0.8em 1.5em;
+                border-radius: 4px;
+                background: rgba(255,255,255,0.1);
+                color: rgba(255,255,255,0.8);
+                border: 1px solid rgba(255,255,255,0.2);
+                cursor: pointer;
+                font-size: 1em;
+            `;
+
+            retryButton.addEventListener('click', async () => {
+                retryCount = 0;
+                removeRetryRow();
+                await wrappedLoad();
+            });
+
+            retryRow.appendChild(retryButton);
+            sentinel.parentNode.insertBefore(retryRow, sentinel);
+        };
+
+        // Wrap loadMoreFn with retry logic
+        const wrappedLoad = async () => {
+            if (!hasMoreCheck() || isLoadingCheck()) return;
+
+            removeRetryRow();
+
+            try {
+                await loadMoreFn();
+                retryCount = 0;
+            } catch (error) {
+                if (error.name === 'AbortError') return;
+
+                retryCount++;
+                if (retryCount >= CONFIG.retry.maxAttempts) {
+                    showRetryRow();
+                } else {
+                    // Auto-retry with backoff
+                    const delay = calculateBackoff(retryCount);
+                    await sleep(delay);
+                    if (hasMoreCheck() && !isLoadingCheck()) {
+                        await wrappedLoad();
+                    }
+                }
+            }
+        };
+
+        // Create observer with prefetch threshold
+        state.activeScrollObserver = new IntersectionObserver(
+            (entries) => {
+                if (entries[0].isIntersecting && hasMoreCheck() && !isLoadingCheck()) {
+                    wrappedLoad();
+                }
+            },
+            { rootMargin: `${CONFIG.prefetchThresholdPx}px` }
+        );
+
+        state.activeScrollObserver.observe(sentinel);
+
+        // Scroll event fallback (use JE.helpers.throttle if available, otherwise inline)
+        const throttleFn = JE.helpers?.throttle || ((fn, wait) => {
+            let lastCall = 0;
+            return (...args) => {
+                const now = Date.now();
+                if (now - lastCall >= wait) {
+                    lastCall = now;
+                    fn(...args);
+                }
+            };
+        });
+        const scrollHandler = throttleFn(() => {
+            if (!hasMoreCheck() || isLoadingCheck()) return;
+
+            const rect = sentinel.getBoundingClientRect();
+            const distanceFromBottom = rect.top - window.innerHeight;
+
+            if (distanceFromBottom < CONFIG.prefetchThresholdPx) {
+                wrappedLoad();
+            }
+        }, 150);
+
+        // Store for cleanup
+        state._scrollHandler = scrollHandler;
+        state._sentinel = sentinel;
+        state._removeRetryRow = removeRetryRow;
+
+        window.addEventListener('scroll', scrollHandler, { passive: true });
+    }
+
+    /**
+     * Cleanup infinite scroll
+     * @param {object} state - State object
+     */
+    function cleanupInfiniteScroll(state) {
+        if (state.activeScrollObserver) {
+            state.activeScrollObserver.disconnect();
+            state.activeScrollObserver = null;
+        }
+
+        if (state.scrollController) {
+            state.scrollController.destroy();
+            state.scrollController = null;
+        }
+
+        if (state._scrollHandler) {
+            window.removeEventListener('scroll', state._scrollHandler);
+            state._scrollHandler = null;
+        }
+
+        if (state._sentinel) {
+            state._sentinel.remove();
+            state._sentinel = null;
+        }
+
+        if (state._removeRetryRow) {
+            state._removeRetryRow();
+            state._removeRetryRow = null;
+        }
+    }
+
+    // ============================================================================
+    // EXPOSE API
+    // ============================================================================
+
+    JE.seamlessScroll = {
+        // Helpers
+        createDeduplicator,
+
+        // Simple API (backward compatible)
+        setupInfiniteScroll,
+        cleanupInfiniteScroll,
+
+        // Configuration (can be modified at runtime)
+        CONFIG
+    };
+
+})(window.JellyfinEnhanced || (window.JellyfinEnhanced = {}));

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/tag-discovery.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/tag-discovery.js
@@ -13,7 +13,6 @@
     let isLoading = false;
     let hasMorePages = true;
     let currentKeywordId = null;
-    let currentTagName = null;
 
     // Separate page tracking for TV and Movies
     let tvCurrentPage = 1;
@@ -24,6 +23,9 @@
     // Cached results for filter switching (avoid refetch)
     let cachedTvResults = [];
     let cachedMovieResults = [];
+
+    // Deduplicator for infinite scroll (prevents duplicate cards)
+    let itemDeduplicator = null;
 
     // Abort controller for cancellation
     let currentAbortController = null;
@@ -215,17 +217,8 @@
         const itemsContainer = document.querySelector('.jellyseerr-tag-discovery-section .itemsContainer');
         if (!itemsContainer) return;
 
-        // Clear existing cards
-        itemsContainer.innerHTML = '';
-
-        // Get filtered results
-        const filtered = getFilteredResults(newMode);
-
-        // Render cards
-        const fragment = createCardsFragment(filtered.slice(0, 20));
-        if (fragment.childNodes.length > 0) {
-            itemsContainer.appendChild(fragment);
-        }
+        // Use fast CSS-based visibility (no DOM rebuild)
+        JE.discoveryFilter.applyFilterVisibility(itemsContainer, newMode);
 
         // Update hasMorePages based on filter mode
         updateHasMorePages(newMode);
@@ -297,7 +290,7 @@
 
             const results = await Promise.all(promises);
 
-            if (signal?.aborted) return;
+            if (signal?.aborted) { isLoading = false; return; }
 
             let newTvResults = [];
             let newMovieResults = [];
@@ -333,6 +326,15 @@
                 return;
             }
 
+            // Deduplicate items using deduplicator (if available)
+            if (itemDeduplicator) {
+                itemsToAdd = itemDeduplicator.filter(itemsToAdd);
+                if (itemsToAdd.length === 0) {
+                    isLoading = false;
+                    return;
+                }
+            }
+
             const itemsContainer = document.querySelector('.jellyseerr-tag-discovery-section .itemsContainer');
             if (itemsContainer) {
                 const fragment = createCardsFragment(itemsToAdd);
@@ -343,6 +345,7 @@
         } catch (error) {
             if (error.name === 'AbortError') return;
             console.error(`${logPrefix} Error loading more items:`, error);
+            throw error; // Re-throw for seamlessScroll retry handling
         }
 
         isLoading = false;
@@ -430,11 +433,14 @@
             tvHasMorePages = true;
             movieHasMorePages = true;
             currentKeywordId = keywordId;
-            currentTagName = tagName;
+
 
             // Clear cached results
             cachedTvResults = [];
             cachedMovieResults = [];
+
+            // Initialize deduplicator for infinite scroll
+            itemDeduplicator = JE.seamlessScroll?.createDeduplicator() || null;
 
             // Fetch TV and Movies separately
             const [tvResponse, movieResponse, listPage] = await Promise.all([
@@ -479,10 +485,15 @@
             const section = createSectionContainer(sectionTitle, hasBoth, handleFilterChange);
             const itemsContainer = section.querySelector('.itemsContainer');
 
-            const fragment = createCardsFragment(displayResults.slice(0, 20));
+            const fragment = createCardsFragment(displayResults);
             if (fragment.childNodes.length === 0) return;
 
             itemsContainer.appendChild(fragment);
+
+            // Seed deduplicator with initial items to prevent duplicates on scroll
+            if (itemDeduplicator) {
+                displayResults.forEach(item => itemDeduplicator.add(item));
+            }
 
             const parentContainer = listPage.closest('.verticalSection') || listPage.parentElement;
             if (parentContainer?.parentElement) {
@@ -532,12 +543,18 @@
         tvHasMorePages = true;
         movieHasMorePages = true;
         currentKeywordId = null;
-        currentTagName = null;
+
         currentRenderingPageKey = null;
 
         // Clear cached results
         cachedTvResults = [];
         cachedMovieResults = [];
+
+        // Clear deduplicator
+        if (itemDeduplicator) {
+            itemDeduplicator.clear();
+        }
+        itemDeduplicator = null;
     }
 
     /**

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -596,6 +596,7 @@
                 'enhanced/playback.js', 'enhanced/features.js', 'enhanced/bookmarks.js', 'enhanced/bookmarks-library.js', 'enhanced/events.js', 'enhanced/osd-rating.js',
                 'elsewhere.js',
                 'jellyseerr/request-manager.js',
+                'jellyseerr/seamless-scroll.js',
                 'jellyseerr/api.js',
                 'jellyseerr/modal.js',
                 'jellyseerr/more-info-modal.js',


### PR DESCRIPTION
## Summary

- Adds seamless infinite scroll that loads all results until exhausted (no more 20-item limit)
- Implements fast CSS-based filter switching (instant even with 800+ items)
- Includes deduplication to prevent duplicate cards
- Adds retry UI with exponential backoff on network failures
- Proper cleanup on navigation using AbortController

## Changes

| File | Description |
|------|-------------|
| `seamless-scroll.js` | New module for infinite scroll logic with retry UI |
| `discovery-filter-utils.js` | Added `data-media-type` attributes and `applyFilterVisibility()` for instant CSS filtering |
| `genre-discovery.js` | Integrated seamless scroll, fixed isLoading state on abort |
| `network-discovery.js` | Integrated seamless scroll, fixed isLoading state on abort |
| `tag-discovery.js` | Integrated seamless scroll, fixed isLoading state on abort |
| `person-discovery.js` | Integrated seamless scroll, fixed isLoading state on abort |
| `plugin.js` | Added seamless-scroll.js to resource loader |

## Performance

- Filter switching (All/Movies/Series) now uses CSS visibility instead of DOM rebuild
- Handles 800+ items without slowdown when switching filters
- Initial render shows all fetched results instead of limiting to 20

## Test plan

- [ ] Test infinite scroll on genre discovery pages (e.g., Comedy)
- [ ] Test infinite scroll on studio/network pages (e.g., Netflix, ABC)
- [ ] Test filter switching with 100+ items loaded
- [ ] Test navigation away and back (cleanup/abort)
- [ ] Test retry UI on network failure

🤖 Generated with [Claude Code](https://claude.ai/code)