### PR TITLE
Fix calendar range handling (UTC) and pass RFC3339 start/end to Sonarr/Radarr

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -2422,6 +2422,9 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                 (startDate, endDate) = (endDate, startDate);
             }
 
+            var startIso = startDate.ToUniversalTime().ToString("o");
+            var endIso = endDate.ToUniversalTime().ToString("o");
+
             DateTime? ParseDate(object? value)
             {
                 if (value == null)
@@ -2487,7 +2490,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                     client.DefaultRequestHeaders.Add("X-Api-Key", config.SonarrApiKey);
                     client.Timeout = TimeSpan.FromSeconds(30);
 
-                    var response = await client.GetAsync($"{sonarrUrl}/api/v3/calendar?includeSeries=true&start={startDate:yyyy-MM-dd}&end={endDate:yyyy-MM-dd}");
+                    var response = await client.GetAsync($"{sonarrUrl}/api/v3/calendar?includeSeries=true&start={startIso}&end={endIso}");
                     if (response.IsSuccessStatusCode)
                     {
                         var json = await response.Content.ReadAsStringAsync();
@@ -2557,7 +2560,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                     client.DefaultRequestHeaders.Add("X-Api-Key", config.RadarrApiKey);
                     client.Timeout = TimeSpan.FromSeconds(10);
 
-                    var response = await client.GetAsync($"{radarrUrl}/api/v3/calendar?start={startDate:yyyy-MM-dd}&end={endDate:yyyy-MM-dd}");
+                    var response = await client.GetAsync($"{radarrUrl}/api/v3/calendar?start={startIso}&end={endIso}");
                     if (response.IsSuccessStatusCode)
                     {
                         var json = await response.Content.ReadAsStringAsync();

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar-page.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar-page.js
@@ -905,31 +905,40 @@
 
   // Get start and end dates for current view
   function getRangeForView(anchorDate, viewMode) {
-    const start = new Date(anchorDate);
-    start.setHours(0, 0, 0, 0);
+    const start = new Date(Date.UTC(
+      anchorDate.getUTCFullYear(),
+      anchorDate.getUTCMonth(),
+      anchorDate.getUTCDate(),
+      0, 0, 0, 0
+    ));
 
     if (viewMode === "month") {
-      start.setDate(1);
-      const end = new Date(start.getFullYear(), start.getMonth() + 1, 0, 23, 59, 59, 999);
+      start.setUTCDate(1);
+      const end = new Date(Date.UTC(
+        start.getUTCFullYear(),
+        start.getUTCMonth() + 1,
+        0,
+        23, 59, 59, 999
+      ));
       return { start, end };
     }
 
     if (viewMode === "week") {
-      const daysOfWeek = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+      const daysOfWeek = ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"];
       const firstDayIndex = daysOfWeek.indexOf(state.settings.firstDayOfWeek);
-      const currentDayIndex = start.getDay();
+      const currentDayIndex = start.getUTCDay();
       const diff = (currentDayIndex - firstDayIndex + 7) % 7;
-      start.setDate(start.getDate() - diff);
+      start.setUTCDate(start.getUTCDate() - diff);
+
       const end = new Date(start);
-      end.setDate(start.getDate() + 6);
-      end.setHours(23, 59, 59, 999);
+      end.setUTCDate(start.getUTCDate() + 6);
+      end.setUTCHours(23, 59, 59, 999);
       return { start, end };
     }
 
-    // Agenda: 30-day rolling window
     const endAgenda = new Date(start);
-    endAgenda.setDate(start.getDate() + 29);
-    endAgenda.setHours(23, 59, 59, 999);
+    endAgenda.setUTCDate(start.getUTCDate() + 29);
+    endAgenda.setUTCHours(23, 59, 59, 999);
     return { start, end: endAgenda };
   }
 


### PR DESCRIPTION
## Summary
This PR fixes missing events on the last day of week/month views by:
- Sending `start` / `end` to Sonarr and Radarr as RFC3339 (`date-time`) instead of truncating to `yyyy-MM-dd`.
- Aligning frontend range computation to strict UTC.

## Why
Sonarr and Radarr calendar endpoints accept `start` / `end` as RFC3339 `date-time`.
Truncating to `yyyy-MM-dd` causes the end boundary to be interpreted as start-of-day or as an exclusive bound, resulting in missing events on the last day (e.g. Sunday).

## Testing
- [x] Weekly view – all days have items.
- [x] Monthly view – all days have items.