### PR TITLE
Keep last calendar view in user settings

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfiguration.cs
@@ -38,6 +38,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public string LastOpenedTab { get; set; } = string.Empty;
         public bool ReviewsExpandedByDefault { get; set; }
         public string DisplayLanguage { get; set; } = string.Empty;
+        public string CalendarDefaultViewMode { get; set; } = "auto";
     }
 
     public class UserShortcuts

--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -1518,6 +1518,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                         ShowRatingInPlayer = defaultConfig.ShowRatingInPlayer,
                         RemoveContinueWatchingEnabled = defaultConfig.RemoveContinueWatchingEnabled,
                         ReviewsExpandedByDefault = defaultConfig.ReviewsExpandedByDefault,
+                        CalendarDefaultViewMode = "auto",
                         LastOpenedTab = "shortcuts"
                     };
 
@@ -1669,6 +1670,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                 ShowRatingInPlayer = defaultConfig.ShowRatingInPlayer,
                 RemoveContinueWatchingEnabled = defaultConfig.RemoveContinueWatchingEnabled,
                 ReviewsExpandedByDefault = defaultConfig.ReviewsExpandedByDefault,
+                CalendarDefaultViewMode = "auto",
                 LastOpenedTab = "shortcuts"
             };
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar-page.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar-page.js
@@ -571,7 +571,13 @@
       return viewMatch[1];
     }
 
-    // Default to agenda on mobile, month on desktop
+    JE.currentSettings = JE.currentSettings || JE.loadSettings?.() || {};
+    const configuredDefault = (JE.currentSettings.calendarDefaultViewMode || "auto").toLowerCase();
+    if (configuredDefault === "month" || configuredDefault === "week" || configuredDefault === "agenda") {
+      return configuredDefault;
+    }
+
+    // Auto: default to agenda on mobile, month on desktop
     const isMobile = window.innerWidth <= 768;
     return isMobile ? "agenda" : "month";
   }
@@ -1016,6 +1022,13 @@
   function setViewMode(mode) {
     if (state.viewMode === mode) return;
     state.viewMode = mode;
+
+    JE.currentSettings = JE.currentSettings || JE.loadSettings?.() || {};
+    JE.currentSettings.calendarDefaultViewMode = mode;
+    if (typeof JE.saveUserSettings === 'function') {
+      JE.saveUserSettings('settings.json', JE.currentSettings);
+    }
+
     const config = JE.pluginConfig || {};
     // Update URL hash to reflect view mode
     const newHash = `#/calendar/${mode}`;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/config.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/config.js
@@ -80,6 +80,7 @@
             qualityTagsPosition: 'top-left', genreTagsPosition: 'top-right', languageTagsPosition: 'bottom-left', ratingTagsPosition: 'bottom-right',
             showRatingInPlayer: true,
             reviewsExpandedByDefault: false,
+            calendarDefaultViewMode: 'auto',
             disableAllShortcuts: false, longPress2xEnabled: false, lastOpenedTab: 'shortcuts'
         };
 


### PR DESCRIPTION
## Summary
This PR allows to keep the user's last selected calendar view.
The selected value is persisted in user `settings.json` configuration and applied consistently on the calendar page.

### Changes
- Added support for `CalendarDefaultViewMode`
  - If value is `week`, `month`, or `agenda` → use directly
  - If value is `auto` or missing → agenda on mobile, month on desktop

### Tests
- [x] Going to another view updates the configuration
- [x] Configuration is kept after refresh
- [x] Default view is selected according to the current configuration