### PR TITLE
fix: prevent watchlist sync from re-adding user-removed items

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfiguration.cs
@@ -82,4 +82,25 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
     {
         public List<PendingWatchlistItem> Items { get; set; } = new List<PendingWatchlistItem>();
     }
+
+    // Tracks items that have already been synced to a user's Jellyfin watchlist.
+    // Once an item key (e.g. "movie:12345") is in this set, it will never be
+    // re-added by the sync task, even if the user later removes it from their watchlist.
+    // Keys are always stored lowercase to avoid case-sensitivity issues after JSON deserialization.
+    public class SyncedWatchlistItems
+    {
+        public const string FileName = "watchlist-synced.json";
+
+        public HashSet<string> SyncedKeys { get; set; } = new HashSet<string>();
+
+        // Build a normalized key for consistent lookup (lowercase to survive JSON round-trip).
+        public static string MakeKey(string mediaType, int tmdbId)
+            => $"{mediaType.ToLowerInvariant()}:{tmdbId}";
+
+        public bool HasBeenSynced(string mediaType, int tmdbId)
+            => SyncedKeys.Contains(MakeKey(mediaType, tmdbId));
+
+        public void MarkSynced(string mediaType, int tmdbId)
+            => SyncedKeys.Add(MakeKey(mediaType, tmdbId));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #329

The watchlist sync (scheduled task, real-time library monitor, and manual sync endpoint) would re-add items to a user's Jellyfin watchlist on every run, even if the user had intentionally removed them. This happened because the sync only checked `userData.Likes` and would set it back to `true` whenever the item was still in the Jellyseerr watchlist/requests.

This PR adds persistent per-user tracking of synced items via a `watchlist-synced.json` file. Once an item has been synced to a user's watchlist, it is recorded and never re-added — respecting the user's choice to remove it.

## Changes

- **`UserConfiguration.cs`** — Added `SyncedWatchlistItems` class with `HashSet<string>` for tracking synced keys, a `MakeKey()` helper that normalizes to lowercase (survives JSON round-trip), and `HasBeenSynced()` / `MarkSynced()` methods. Includes a `FileName` constant to avoid magic strings.
- **`JellyseerrWatchlistSyncTask.cs`** — Loads synced data before the per-user item loop; skips previously-synced items; records newly synced items; persists changes once per user via dirty flag.
- **`WatchlistMonitor.cs`** — Added `UserConfigurationManager` dependency; checks synced data per user before adding; batches disk writes per user after the loop instead of per iteration.
- **`JellyfinEnhancedController.cs`** — Manual sync endpoint now loads/checks/records synced data with the same pattern as the scheduled task.

## Implementation Notes

- AI tools (Claude Code) were used to assist with this implementation. The approach and all code have been reviewed and understood.
- Keys are normalized to lowercase via `MakeKey()` to avoid case-sensitivity issues after Newtonsoft.Json deserialization (which loses custom `HashSet` comparers).
- Items not yet in the Jellyfin library are intentionally **not** recorded as synced, so `WatchlistMonitor` can still pick them up when they arrive.

## Testing Checklist

- [x] Feature functions as intended
- [x] No console errors present
- [ ] Compatible with Jellyfin 10.10 and 10.11
- [ ] Works across browsers (Chrome, Firefox, Edge)
- [x] Existing functionality remains intact
- [x] Build succeeds with 0 warnings, 0 errors