### PR TITLE
Calendar UI polish: mobile sidebar toggle, grid tweaks, simplified css

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar-page.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar-page.js
@@ -978,15 +978,15 @@
         justify-content: space-around;
       }
 
-      .je-calendar-page.je-view-month .je-calendar-weekdays {
+      .je-calendar-month .je-calendar-weekdays {
         display: none;
       }
 
-      .je-calendar-page.je-view-month .je-calendar-month-day-name {
+      .je-calendar-month .je-calendar-month-day-name {
         display: block;
       }
 
-      .je-calendar-page.je-view-month .je-calendar-day-placeholder {
+      .je-calendar-month .je-calendar-day-placeholder {
         display: none;
       }
     }
@@ -1037,6 +1037,10 @@
 
       .je-calendar-hour-label {
         text-align: left;
+      }
+
+      .je-calendar-month .je-calendar-weekdays {
+        display: none;
       }
 
       .je-calendar-agenda-row {


### PR DESCRIPTION
# Calendar UI polish: mobile legend toggle, grid tweaks, and simplified grays

## Summary
- Add a collapsible toggle for the calendar sidebar for very small screens.
- Standardize neutral grays to two variables (base + hover) across the calendar UI.
- Align day/week/month grid behavior at small widths.
- Remove dead CSS related to unused and/or unreachable styles.

## Testing
- [x] All mods look good in small screens
- [x] All mods still look the same at >1450px