### PR TITLE
feat: add IMAX quality tag

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/qualitytags.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/qualitytags.js
@@ -82,7 +82,7 @@
             'HDR10': { bg: 'rgba(255, 215, 0, 0.95)', text: '#000000' },
             'HDR10+': { bg: 'rgba(255, 215, 0, 0.95)', text: '#000000' },
             'Dolby Vision': { bg: 'rgba(139, 69, 19, 0.95)', text: '#ffffff' },
-            'IMAX': { bg: '#0072CE', text: '#ffffff' },
+            'IMAX': { bg: 'rgba(0, 114, 206, 0.9)', text: '#ffffff' },
             'ATMOS': { bg: 'rgba(0, 100, 255, 0.9)', text: '#ffffff' },
             'DTS-X': { bg: 'rgba(255, 100, 0, 0.9)', text: '#ffffff' },
             'DTS': { bg: 'rgba(255, 140, 0, 0.85)', text: '#ffffff' },


### PR DESCRIPTION
## Summary
- add a new `IMAX` quality tag in quality tags with color `rgba(0, 114, 206, 0.9)`
- detect IMAX using release/title/path stream signals with support for both `IMAX` and `IMAX Enhanced`
- exclude false positives for `NON-IMAX`
- include IMAX in the feature ordering so it renders consistently with other quality tags

## Detection Rules
- based on TRaSH Guides IMAX and IMAX Enhanced patterns
- aligned with Dictionarry-Hub `IMAX.yml` and `IMAX Enhanced.yml` regex patterns
- adds extra Jellyfin-specific signal coverage from `MediaSources.Path`, `MediaSources.Name`, and stream `DisplayTitle`/`Title`

## Testing
- `node --check Jellyfin.Plugin.JellyfinEnhanced/js/tags/qualitytags.js`
- local regex sample checks for:
  - IMAX match
  - IMAX Enhanced match
  - NON-IMAX exclusion
- verified served `qualitytags.js` contains IMAX tag color and regex logic
- manual validation in `jellyfin-dev`: IMAX and IMAX Enhanced file-name cases were detected successfully

Fixes #325
