### PR TITLE
Add HSS discovery handler for Jellyseerr modal

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/hss-discovery-handler.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/hss-discovery-handler.js
@@ -1,0 +1,47 @@
+/**
+ * Home Screen Sections (HSS) Discovery Handler
+ * Intercepts discover card clicks and opens the Jellyseerr more-info modal
+ * instead of navigating to the Jellyseerr website
+ */
+
+(function(JE) {
+    'use strict';
+
+    const logPrefix = '🪼 Jellyfin Enhanced: HSS Discovery Handler:';
+
+    function initDiscoveryHandler() {
+
+        document.addEventListener('click', function(e) {
+            // Don't intercept if clicking the request button
+            if (e.target.closest('.discover-requestbutton')) {
+                return;
+            }
+
+            // Target any click on the discover card (except the request button)
+            const discoverCard = e.target.closest('.discover-card');
+
+            if (!discoverCard) {
+                return;
+            }
+
+            const tmdbId = discoverCard.dataset.tmdbId;
+            const mediaType = discoverCard.dataset.mediaType;
+
+            // Check if JE.jellyseerrMoreInfo is available
+            if (!tmdbId || !mediaType || !JE?.jellyseerrMoreInfo?.open) {
+                return;
+            }
+
+            console.log(`${logPrefix} Opening more-info modal for TMDB ID: ${tmdbId}, Type: ${mediaType}`);
+
+            e.preventDefault();
+            e.stopPropagation();
+
+            // Open the more-info modal
+            JE.jellyseerrMoreInfo.open(tmdbId, mediaType);
+        }, true);
+    }
+
+    initDiscoveryHandler();
+
+})(window.JellyfinEnhanced || {});

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -633,6 +633,7 @@
                 'jellyseerr/ui.js',
                 'jellyseerr/modal.js',
                 'jellyseerr/more-info-modal.js',
+                'jellyseerr/hss-discovery-handler.js',
                 'jellyseerr/item-details.js',
                 'jellyseerr/issue-reporter.js',
                 'jellyseerr/seamless-scroll.js',


### PR DESCRIPTION
Introduce a new hss-discovery-handler.js that intercepts clicks on Home Screen Sections (discover-card) and opens the Jellyseerr more-info modal (unless the request button is clicked).

For #360 