### PR TITLE
fix: Calendar card click navigates to episode instead of series

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar-page.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar-page.js
@@ -2705,7 +2705,7 @@
 
     e.preventDefault();
     e.stopPropagation();
-    navigateToJellyfinItem(event, { preferSeries: true });
+    navigateToJellyfinItem(event, { preferSeries: false });
   }
 
   /**


### PR DESCRIPTION
## Summary

Clicking a calendar episode card currently navigates to the **series** detail page instead of the **specific episode**. This is because `handleEventClick` passes `{ preferSeries: true }` to `navigateToJellyfinItem`.

This changes it to `{ preferSeries: false }` so the click resolves to `event.itemEpisodeId` (the episode) first, falling back to series providers only if no episode match is found. Movies are unaffected.

**Question:** Was the original `preferSeries: true` behavior intentional — i.e., card click = series page, play button = episode? Or should clicking an episode entry in the calendar take you directly to that episode?

### How it broke

| Commit | What happened |
|--------|--------------|
| `e3f662c` (PR #332) | Added provider-based navigation — no `preferSeries` concept, worked fine |
| `9863ec9` (PR #338) | Rework Calendar UI — introduced `preferSeries`, set card click to `true` |
| `c6433ca` | Added `itemEpisodeId` support — play button (`preferSeries: false`) navigates to episode correctly, but general card click stayed `preferSeries: true` |

### One-line change

```diff
- navigateToJellyfinItem(event, { preferSeries: true });
+ navigateToJellyfinItem(event, { preferSeries: false });
```

## Test plan
- [x] Click an episode card in calendar → should navigate to episode detail page
- [x] Click play button on episode → should navigate to episode detail page  
- [x] Click a movie card in calendar → should navigate to movie detail page (unchanged)
- [x] Verify series-level navigation still works via other UI paths