### PR TITLE
fix(ratings): update South Korea rating selector to KR-19

### DIFF
--- a/css/ratings.css
+++ b/css/ratings.css
@@ -320,7 +320,7 @@
 .mediaInfoOfficialRating[rating='IL-18'],                  /* 🇮🇱 Israel */
 .mediaInfoOfficialRating[rating='IT-VM18'],                /* 🇮🇹 Italy */
 .mediaInfoOfficialRating[rating='JP-R18+'],                /* 🇯🇵 Japan */
-.mediaInfoOfficialRating[rating='KR-18'],                  /* 🇰🇷 South Korea */
+.mediaInfoOfficialRating[rating='KR-19'],                  /* 🇰🇷 South Korea */
 .mediaInfoOfficialRating[rating='KR-R'],                   /* 🇰🇷 South Korea */
 .mediaInfoOfficialRating[rating='MY-18'],                  /* 🇲🇾 Malaysia */
 .mediaInfoOfficialRating[rating='MX-C'],                   /* 🇲🇽 Mexico */


### PR DESCRIPTION
Change CSS selector in css/ratings.css from rating='KR-18' to rating='KR-19' for the South Korea entry to align with the updated rating system.

The Korea Media Rating Board replaced the former 18+ rating in 2024 with a 19+ classification ("청소년관람불가"), restricting content to viewers aged 19 and above.

Reference:
https://allbom.kmrb.or.kr/main/page.jsp?pid=intro.greeting
https://rating-system.fandom.com/wiki/Korea_Media_Rating_Board