### PR TITLE
fix: prevent hide icon from appearing on image editor cards

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hidden-content.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hidden-content.js
@@ -1401,6 +1401,8 @@
         const cards = document.querySelectorAll(CARD_SEL_NEW);
         for (let i = 0; i < cards.length; i++) {
             const card = cards[i];
+            // Skip image editor cards (they have data-imagetype attribute)
+            if (card.hasAttribute('data-imagetype')) continue;
             const itemId = getCardItemId(card);
             card.setAttribute(PROCESSED_ATTR, '1');
             card.removeAttribute(HIDDEN_PARENT_ATTR);
@@ -1680,6 +1682,10 @@
 
             const card = cardBox.closest('.card');
             if (!card) continue;
+
+            // Skip image editor cards and cards inside dialogs/admin pages
+            if (card.hasAttribute('data-imagetype') || card.closest('.formDialog, .editPageInnerContent')) continue;
+
             const itemId = getCardItemId(card);
             if (!itemId) continue;
 


### PR DESCRIPTION
## Summary
- Prevents hide toggle buttons from appearing on Jellyfin's image editor cards
- Prevents hidden content filtering from affecting image editor cards

## Problem
The `addLibraryHideButtons()` and `filterNativeCards()` functions use `.card[data-id]` selectors to find media cards. Jellyfin's image editor also uses `.card[data-id]` with `.cardBox` for image thumbnails, causing hide icons to incorrectly appear on the edit images page.

## Changes
- **`filterNativeCards()`**: Skip cards with `data-imagetype` attribute to prevent hidden content filtering from hiding image editor thumbnails
- **`addLibraryHideButtons()`**: Skip cards with `data-imagetype` attribute or inside `.formDialog` / `.editPageInnerContent` to prevent hide buttons from being injected on non-media cards

## How it works
Jellyfin's image editor cards have a `data-imagetype` attribute (e.g., `Primary`, `Backdrop`) that regular media cards do not. This attribute is used as the distinguishing check. Additionally, cards inside `.formDialog` (dialogs) and `.editPageInnerContent` (metadata editor) are excluded.

## Testing
- [x] Hide buttons no longer appear on image editor cards
- [x] Hide buttons still work correctly on library cards, detail pages, and Jellyseerr results
- [x] Hidden content filtering does not affect image editor thumbnails
- [x] Tested on Jellyfin 10.11.x
- [x] No console errors

> 🤖 AI-assisted: This PR was developed with AI assistance (Claude). The implementation has been reviewed and understood.