### PR TITLE
feat: tag-based request matching fallback for calendar filter

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
@@ -185,6 +185,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             CalendarHighlightFavorites = false;
             CalendarHighlightWatchedSeries = false;
             CalendarShowOnlyRequested = false;
+            CalendarTagBasedRequestMatching = false;
 
             // Hidden Content Settings
             HiddenContentEnabled = false;
@@ -348,6 +349,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public bool CalendarHighlightFavorites { get; set; }
         public bool CalendarHighlightWatchedSeries { get; set; }
         public bool CalendarShowOnlyRequested { get; set; }
+        public bool CalendarTagBasedRequestMatching { get; set; }
 
         // Hidden Content Settings
         public bool HiddenContentEnabled { get; set; }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -1153,6 +1153,13 @@
                                 </label>
                             </div>
                             <div class="fieldDescription">When enabled, the calendar will load showing only Requested items by default, but users can still change filters.</div>
+                            <div class="checkboxContainer" style="margin-bottom: 0.5em !important;">
+                                <label>
+                                    <input id="calendarTagBasedRequestMatching" is="emby-checkbox" type="checkbox"/>
+                                    <span>Tag-Based Request Matching</span>
+                                </label>
+                            </div>
+                            <div class="fieldDescription">When enabled, also uses Sonarr/Radarr tags to identify your requested items. Useful if Jellyseerr request data is incomplete.</div>
                         </div>
                         <div style="background-color: rgba(255, 255, 255, 0.05); border-left: 4px solid #00a4dc; border-radius: 4px; padding: 1em 1.5em; margin: 1.5em 0; display: flex; align-items: center; gap: 1em;">
                             <div style="display: flex; align-items: flex-start; gap: 1em;">
@@ -2058,6 +2065,7 @@
                 document.querySelector('#calendarHighlightFavorites').checked = config.CalendarHighlightFavorites || false;
                 document.querySelector('#calendarHighlightWatchedSeries').checked = config.CalendarHighlightWatchedSeries || false;
                 document.querySelector('#calendarShowOnlyRequested').checked = config.CalendarShowOnlyRequested || false;
+                document.querySelector('#calendarTagBasedRequestMatching').checked = config.CalendarTagBasedRequestMatching || false;
 
                 // Hidden Content settings
                 document.querySelector('#hiddenContentEnabled').checked = config.HiddenContentEnabled || false;
@@ -2240,6 +2248,7 @@
             config.CalendarHighlightFavorites = document.querySelector('#calendarHighlightFavorites').checked;
             config.CalendarHighlightWatchedSeries = document.querySelector('#calendarHighlightWatchedSeries').checked;
             config.CalendarShowOnlyRequested = document.querySelector('#calendarShowOnlyRequested').checked;
+            config.CalendarTagBasedRequestMatching = document.querySelector('#calendarTagBasedRequestMatching').checked;
 
             // Hidden Content settings
             config.HiddenContentEnabled = document.querySelector('#hiddenContentEnabled').checked;


### PR DESCRIPTION
## Summary

Possible fix for #347 and #396.

When Jellyseerr loses user→request mappings, the calendar "Requests" filter stops showing those items. However, Seerr adds tags to Sonarr/Radarr in the format `{seerrUserId} - {username}` that still identify the requesting user.

This adds an opt-in fallback that checks arr tags by the user's Seerr **numeric ID prefix** (e.g. `"8 - "`), merging matches into the existing Requests filter. The matching chain uses stable identifiers only (Jellyfin GUID → Seerr numeric ID → tag prefix), so it's **resilient to username changes** in either Jellyfin or Jellyseerr.

## Changes

- **New config option**: `CalendarTagBasedRequestMatching` (default: off) with admin checkbox
- **New endpoint**: `GET /arr/tag-requested-items` — returns `{ items: [{ type, tmdbId }] }` for arr items tagged with the current user's Seerr ID
- **New service methods**: `GetTmdbIdsMatchingTagPrefix()` on `SonarrService` / `RadarrService`
- **Frontend**: merges tag results into existing `requestedItems` Set in `fetchUserRequests()`
- Existing request flow is completely untouched — tag matching is additive only

## Files Changed

| File | Change |
|------|--------|
| `PluginConfiguration.cs` | New `CalendarTagBasedRequestMatching` property |
| `configPage.html` | New checkbox + load/save logic |
| `SonarrService.cs` | `TmdbId` on `SonarrSeries`, new `GetTmdbIdsMatchingTagPrefix()` |
| `RadarrService.cs` | New `GetTmdbIdsMatchingTagPrefix()` |
| `JellyfinEnhancedController.cs` | Exposed in public config, new `GET arr/tag-requested-items` endpoint |
| `calendar-page.js` | Tag fallback fetch in `fetchUserRequests()` |

## How It Works

1. User enables "Tag-Based Request Matching" in admin Calendar settings
2. When calendar loads with Requests filter, after fetching Seerr requests it also calls the new endpoint
3. Endpoint resolves: Jellyfin user GUID → Jellyseerr user (via existing `GetJellyseerrUser()`) → Seerr numeric ID
4. Queries Sonarr/Radarr tags for labels starting with `"{seerrId} - "` → returns matching TMDB IDs
5. Frontend merges these into the same `requestedItems` Set — `isRequestedEvent()` works unchanged

## Test Plan

- [x] Build passes with no errors/warnings
- [x] With setting disabled (default), no tag fetch occurs and behavior is identical to before
- [x] With setting enabled, items with matching arr tags appear in Requests filter
- [x] Items from Seerr's own request data still appear (no regression)
- [x] Renaming Jellyfin username does not break matching
- [x] Renaming Jellyseerr display name does not break matching
- [x] If Sonarr/Radarr is unreachable, Seerr requests still work (graceful degradation)

More testing to follow.

🤖 Generated with [Claude Code](https://claude.ai/code)