### PR TITLE
fix: stability fixes (CheckPluginPages + search grid alignment)

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
@@ -899,13 +899,7 @@
 
         const itemsContainer = document.createElement('div');
         itemsContainer.setAttribute('is', 'emby-itemscontainer');
-        itemsContainer.className = 'focuscontainer-x itemsContainer scrollSlider';
-
-        const isTvMode = document.querySelector('.alphaPicker-tv') !== null;
-        if (isTvMode) {
-            itemsContainer.classList.add('itemsContainer-tv');
-            itemsContainer.classList.add('animatedScrollX');
-        }
+        itemsContainer.className = 'vertical-wrap itemsContainer padded-left padded-right';
 
         results.forEach(item => {
             const card = createJellyseerrCard(item, isJellyseerrActive, jellyseerrUserFound);


### PR DESCRIPTION
## Summary
- Wrap `CheckPluginPages` in try/catch to prevent plugin malfunction when custom pages fail to load (#424)
- Left-align search results grid to match Jellyfin's native layout instead of centered horizontal scroll

## Changes
- `JellyfinEnhanced.cs`: Added try/catch around CheckPluginPages initialization
- `ui.js`: Changed search results container from horizontal scroll to vertical-wrap grid

## Test plan
- [x] Verify plugin loads correctly even when custom plugin pages fail
- [x] Verify Seerr search results display in a left-aligned grid matching Jellyfin's native layout
- [x] Verify no regressions on discovery pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)