### PR TITLE
feat: add Simplified Chinese (zh-CN) support

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/translations.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/translations.js
@@ -17,13 +17,6 @@
         const normalizedLang = normalizeLangCode(primaryLang);
         const langCodes = [];
 
-        // Treat generic zh as simplified Chinese (zh-CN) unless a region-specific variant is requested.
-        const preferredZh = normalizedLang === 'zh' ? 'zh-CN' : normalizedLang;
-
-        if (preferredZh) {
-            langCodes.push(preferredZh);
-        }
-
         if (normalizedLang && normalizedLang.includes('-')) {
             const baseLang = normalizedLang.split('-')[0];
             if (!langCodes.includes(baseLang)) {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/ui.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/ui.js
@@ -1587,7 +1587,6 @@
                 // Custom languages not in Jellyfin's official culture list
                 const CUSTOM_LANGUAGES = {
                     'pr': { Name: 'Pirate', DisplayName: "Pirate", TwoLetterISOLanguageName: 'pr' },
-                    'zh-CN': { Name: '简体中文', DisplayName: "简体中文", TwoLetterISOLanguageName: 'zh-CN' },
                     'en-GB': { Name: 'English (United Kingdom)', DisplayName: "English (United Kingdom)", TwoLetterISOLanguageName: 'en-GB' },
                     'en-US': { Name: 'English (United States)', DisplayName: "English (United States)", TwoLetterISOLanguageName: 'en-US' }
                 };


### PR DESCRIPTION
Adds a zh-CN translation file and ensures that generic "zh" language settings fall back to zh-CN for correct Simplified Chinese loading. Includes UI language selector support for zh-CN.