### PR TITLE
fix: prevent plugin from overwriting user's language on every page load

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -554,20 +554,20 @@
 
             if (userId) {
                 const languageKey = `${userId}-language`;
-                const storedLanguage = localStorage.getItem(languageKey) || '';
-                const desiredLanguage = (JE.currentSettings?.displayLanguage || '').trim();
-                const normalizeLangCode = (code) => {
-                    if (!code) return '';
-                    const parts = code.split('-');
-                    if (parts.length === 1) return parts[0].toLowerCase();
-                    if (parts.length === 2) return `${parts[0].toLowerCase()}-${parts[1].toUpperCase()}`;
-                    return code;
-                };
-                // Use the language code as-is, no special mapping
-                const desiredStorageLanguage = desiredLanguage ? normalizeLangCode(desiredLanguage) : '';
-
-                if (storedLanguage !== desiredStorageLanguage) {
-                    localStorage.setItem(languageKey, desiredStorageLanguage);
+                // Only seed the admin's default language if the user has no language set yet.
+                // This prevents overwriting the user's own language choice on every page load.
+                if (localStorage.getItem(languageKey) === null) {
+                    const desiredLanguage = (JE.currentSettings?.displayLanguage || '').trim();
+                    if (desiredLanguage) {
+                        const normalizeLangCode = (code) => {
+                            if (!code) return '';
+                            const parts = code.split('-');
+                            if (parts.length === 1) return parts[0].toLowerCase();
+                            if (parts.length === 2) return `${parts[0].toLowerCase()}-${parts[1].toUpperCase()}`;
+                            return code;
+                        };
+                        localStorage.setItem(languageKey, normalizeLangCode(desiredLanguage));
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description

Fixes #441

The plugin was unconditionally writing to the `{userId}-language` localStorage key on every page load, comparing it against `JE.currentSettings.displayLanguage` and overwriting if different. When `displayLanguage` is empty (the default "Auto"), this wrote `''` to localStorage, erasing whatever language the user had set via Jellyfin's native settings UI. The user's language would revert to "Auto" after 2 refreshes.

## Implementation

Instead of syncing localStorage on every page load, the plugin now only seeds the admin's default language when the user has no language set yet (`localStorage.getItem(languageKey) === null`). Once any language is set by the plugin on first visit, by the user via Jellyfin's native settings, or via the JE panel the plugin never overwrites it.

No additional localStorage keys are introduced. The fix is a single-file change in `plugin.js`.

## Implementation Notes

This PR was developed with AI assistance (Claude). The change has been reviewed, tested, and verified on a live Jellyfin 10.11 instance.

## Testing

- [x] Tested on Jellyfin 10.11
- [x] Verified no console errors
- [x] Reproduced the bug with unmodified main branch (language reverts after 2 refreshes)
- [x] Confirmed fix resolves the issue (language persists across multiple refreshes)
- [x] Tested with admin and non-admin users
- [x] Doesn't break existing functionality (JE panel language dropdown still works)
- [x] Build passes with 0 warnings, 0 errors