### PR TITLE
fix: scope global .material-icons CSS to prevent volume OSD shrinking

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/bookmarks-library.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/bookmarks-library.js
@@ -877,7 +877,7 @@
       color: #ff9800;
     }
 
-    .material-icons {
+    .je-bookmarks-wrapper .material-icons {
       font-size: 18px;
     }
   `;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/extras/colored-activity-icons.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/extras/colored-activity-icons.js
@@ -15,7 +15,7 @@
         a[href^="#/dashboard/activity"] .MuiAvatar-root > svg {
           display: none !important;
         }
-        .material-icons {
+        a[href^="#/dashboard/activity"] .MuiAvatar-root .material-icons {
           font-family: 'Material Icons';
           font-size: 18px;
           line-height: 1;


### PR DESCRIPTION
## Summary

Fixes #476 — the volume OSD popup (speaker icon + slider that appears when changing volume during video playback) was rendering at ~30% of its intended size when the plugin was installed.

**Root cause:** Two stylesheets injected **global** `.material-icons { font-size: 18px }` rules that overrode Jellyfin's `.iconOsdIcon { font-size: 320% }` due to CSS cascade ordering — both selectors have single-class specificity, so whichever loads last wins.

**Fix:** Scoped both rules to their intended containers:
- `bookmarks-library.js` — `.material-icons` → `.je-bookmarks-wrapper .material-icons`
- `colored-activity-icons.js` — `.material-icons` → `a[href^="#/dashboard/activity"] .MuiAvatar-root .material-icons`

## Changes

| File | Change |
|------|--------|
| `js/enhanced/bookmarks-library.js` | Scope `.material-icons` rule to `.je-bookmarks-wrapper` |
| `js/extras/colored-activity-icons.js` | Scope `.material-icons` rule to activity page avatars |

## Test plan

- [x] Volume OSD popup renders at correct size (icon at 320%, not 18px)
- [x] Bookmarks library icons still render at 18px inside `.je-bookmarks-wrapper`
- [x] Activity page colored icons still render at 18px inside avatar elements
- [x] Standalone `.material-icons` elements are no longer overridden (back to Jellyfin's default 24px)
- [x] Plugin builds with 0 warnings, 0 errors
- [x] Tested on jellyfin-dev with admin user