### PR TITLE
Update Discord link in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ When reporting bugs:
 
 If you have questions or need help:
 
-- **Discord**: Reach out on the [Jellyfin Community Discord](https://discord.gg/8wk3q74s)
+- **Discord**: Reach out on the [Jellyfin Community Discord](https://discord.gg/EYNFf7y4CG)
 - **Discussions**: Start a discussion on GitHub
 - **Issues**: For bug-related questions
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Translations are available immediately after merge!
 
 - [Report Issues](https://github.com/n00bcodr/Jellyfin-Enhanced/issues)
 - [Feature Requests](https://github.com/n00bcodr/Jellyfin-Enhanced/discussions)
-- [Discord Community](https://discord.gg/8wk3q74s)
+- [Discord Community](https://discord.gg/EYNFf7y4CG)
 
 <br>
 
@@ -181,7 +181,7 @@ Need help? Check these resources:
 - [FAQ](https://n00bcodr.github.io/Jellyfin-Enhanced/faq-support/faq/)
 - [Troubleshooting Guide](https://n00bcodr.github.io/Jellyfin-Enhanced/installation/troubleshooting/)
 - [GitHub Discussions](https://github.com/n00bcodr/Jellyfin-Enhanced/discussions)
-- [Discord Community](https://discord.gg/8wk3q74s)
+- [Discord Community](https://discord.gg/EYNFf7y4CG)
 
 <br>
 
@@ -227,7 +227,7 @@ This project is licensed under the [GNU General Public License v3.0](LICENSE).
 ### Enjoying Jellyfin Enhanced?
 
 If this plugin has enhanced your Jellyfin experience, consider:
-⭐ Starring the repository ⦁ 🐛 Reporting bugs or suggesting features ⦁ 🌍 Contributing translations ⦁ 💬 Joining <a href="https://discord.gg/8wk3q74s">Discord community</a> ⦁ ☕ Supporting me on <a href="https://ko-fi.com/n00bcodr">Ko-Fi</a>
+⭐ Starring the repository ⦁ 🐛 Reporting bugs or suggesting features ⦁ 🌍 Contributing translations ⦁ 💬 Joining <a href="https://discord.gg/EYNFf7y4CG">Discord community</a> ⦁ ☕ Supporting me on <a href="https://ko-fi.com/n00bcodr">Ko-Fi</a>
 
 Made with 💜 for Jellyfin and the community
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -87,7 +87,7 @@ We welcome contributions from the community!
 - [Discussions](https://github.com/n00bcodr/Jellyfin-Enhanced/discussions)
 - [Contributing Translations](faq-support/contributing-translations.md)
 - [Troubleshooting Guide](installation/troubleshooting.md)
-- [Discord Community](https://discord.gg/8wk3q74s)
+- [Discord Community](https://discord.gg/EYNFf7y4CG)
 
 ## Support Me
 

--- a/docs/faq-support/faq.md
+++ b/docs/faq-support/faq.md
@@ -557,7 +557,7 @@ Yes, via Enhanced panel settings:
 
 - [GitHub Issues](https://github.com/n00bcodr/Jellyfin-Enhanced/issues) - Bug reports and feature requests
 - [GitHub Discussions](https://github.com/n00bcodr/Jellyfin-Enhanced/discussions) - General questions and discussion
-- [Discord Community](https://discord.gg/8wk3q74s) - Real-time chat and support
+- [Discord Community](https://discord.gg/EYNFf7y4CG) - Real-time chat and support
 
 **Before Asking:**
 
@@ -600,5 +600,5 @@ Yes, via Enhanced panel settings:
 If your question isn't answered here:
 
 1. Search [GitHub Discussions](https://github.com/n00bcodr/Jellyfin-Enhanced/discussions)
-2. Ask in [Discord Community](https://discord.gg/8wk3q74s)
+2. Ask in [Discord Community](https://discord.gg/EYNFf7y4CG)
 3. Create a [GitHub Issue](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/new)

--- a/docs/faq-support/support.md
+++ b/docs/faq-support/support.md
@@ -3,4 +3,4 @@
 - [GitHub Repository](https://github.com/n00bcodr/Jellyfin-Enhanced)
     - [Report Issues](https://github.com/n00bcodr/Jellyfin-Enhanced/issues)
     - [Discussions](https://github.com/n00bcodr/Jellyfin-Enhanced/discussions)
-- [Discord Community](https://discord.gg/8wk3q74s)
+- [Discord Community](https://discord.gg/EYNFf7y4CG)

--- a/docs/installation/troubleshooting.md
+++ b/docs/installation/troubleshooting.md
@@ -15,12 +15,12 @@
 
 **Clear Browser Cache:**
 
-1. Open menu: 
-  
+1. Open menu:
+
   Windows/Linux: ++ctrl+shift+delete++
-  
+
   MacOS: ++command+shift+delete++
-  
+
 1. Select "Cached images and files" *(or similar)*
 
 2. Clear cache
@@ -90,7 +90,7 @@ Example of a common error:
 System.UnauthorizedAccessException: Access to the path '/jellyfin/jellyfin-web/index.html' is denied.
 ```
 
-If you are **^^not^^ using the [file-transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) plugin**, you'll need to manually map the `index.html` file 
+If you are **^^not^^ using the [file-transformation](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) plugin**, you'll need to manually map the `index.html` file
 
 1. Copy the `index.html` file from your container:
   ```bash title="Bash"
@@ -121,7 +121,7 @@ If you are **^^not^^ using the [file-transformation](https://github.com/IAmParad
 
 #### Windows
 
-Known solution: 
+Known solution:
 
 1. Navigate to your Jellyfin installation folder (usually `C:\Program Files\Jellyfin\Server`)
 2. Right-click the folder → `Properties` → `Security`
@@ -147,4 +147,4 @@ If you encounter issues:
 2. [GitHub Issues](https://github.com/n00bcodr/Jellyfin-Enhanced/issues)
     - Search existing issues
     - Create a new issue *(please include log and details)*
-3. Join the [Discord Community](https://discord.gg/8wk3q74s)
+3. Join the [Discord Community](https://discord.gg/EYNFf7y4CG)

--- a/docs/other-projects/other-projects.md
+++ b/docs/other-projects/other-projects.md
@@ -169,16 +169,16 @@ A beautiful, modern theme for Jellyfin with multiple color variants.
 
 **For Jellyfin Enhanced:**
 - [GitHub Issues](https://github.com/n00bcodr/Jellyfin-Enhanced/issues)
-- [Discord Community](https://discord.gg/8wk3q74s)
+- [Discord Community](https://discord.gg/EYNFf7y4CG)
 - [Discussions](https://github.com/n00bcodr/Jellyfin-Enhanced/discussions)
 
 **For Jellyfin Tweaks:**
 - [GitHub Issues](https://github.com/n00bcodr/JellyfinTweaks/issues)
-- [Discord Community](https://discord.gg/8wk3q74s)
+- [Discord Community](https://discord.gg/EYNFf7y4CG)
 
 **For JavaScript Injector:**
 - [GitHub Issues](https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/issues)
-- [Discord Community](https://discord.gg/8wk3q74s)
+- [Discord Community](https://discord.gg/EYNFf7y4CG)
 
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,7 @@ extra:
       link: https://github.com/n00bcodr/Jellyfin-Enhanced
       name: GitHub Repository
     - icon: fontawesome/brands/discord
-      link: https://discord.gg/8wk3q74s
+      link: https://discord.gg/EYNFf7y4CG
       name: Jellyfin Community Discord - Jellyfin Enhanced Channel
 
 plugins:


### PR DESCRIPTION
This change replaces the old discord link that was expired with a new one which should never expire;
https://discord.gg/EYNFf7y4CG