### PR TITLE
fix: fall back to show poster for seasons missing artwork

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/more-info-modal.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/more-info-modal.js
@@ -73,14 +73,26 @@ async function backfillSeasonMetadata(tmdbId, data) {
             const tmdbSeason = tmdbMap[sNum];
 
             // Backfill posterPath (validate format to prevent loading from unexpected URLs)
-            if (!season.posterPath && tmdbSeason?.poster_path && isValidPosterPath(tmdbSeason.poster_path)) {
-                season.posterPath = tmdbSeason.poster_path;
-                const posterEl = card.querySelector('.season-poster');
-                if (posterEl && !posterEl.querySelector('img')) {
-                    const img = document.createElement('img');
-                    img.src = `https://image.tmdb.org/t/p/w185${season.posterPath}`;
-                    img.alt = card.querySelector('.season-name')?.textContent || '';
-                    posterEl.appendChild(img);
+            // Try TMDB season poster first, then fall back to the show poster
+            if (!season.posterPath) {
+                const tmdbPoster = tmdbSeason?.poster_path;
+                const fallbackPoster = (tmdbPoster && isValidPosterPath(tmdbPoster)) ? tmdbPoster : data.posterPath;
+                if (fallbackPoster && isValidPosterPath(fallbackPoster)) {
+                    season.posterPath = fallbackPoster;
+                    const posterEl = card.querySelector('.season-poster');
+                    if (posterEl) {
+                        const newSrc = `https://image.tmdb.org/t/p/w185${season.posterPath}`;
+                        const existingImg = posterEl.querySelector('img');
+                        if (existingImg) {
+                            // Update src if it changed (e.g., replacing show poster with season poster)
+                            if (existingImg.src !== newSrc) existingImg.src = newSrc;
+                        } else {
+                            const img = document.createElement('img');
+                            img.src = newSrc;
+                            img.alt = card.querySelector('.season-name')?.textContent || '';
+                            posterEl.appendChild(img);
+                        }
+                    }
                 }
             }
 
@@ -1818,8 +1830,10 @@ function buildSeasonsSection(data) {
                     const seasonInfo = getSeasonStatusInfo(data, season.seasonNumber);
                     const seasonJellyfinId = getSeasonJellyfinId(seasonInfo, false);
                     const seasonJellyfinId4k = getSeasonJellyfinId(seasonInfo, true);
-                    const posterUrl = season.posterPath
-                        ? `https://image.tmdb.org/t/p/w185${season.posterPath}`
+                    const seasonPosterPath = season.posterPath
+                        || (data.posterPath && isValidPosterPath(data.posterPath) ? data.posterPath : null);
+                    const posterUrl = seasonPosterPath
+                        ? `https://image.tmdb.org/t/p/w185${seasonPosterPath}`
                         : '';
 
                     // Derive a display name: if the API returns just the number (TheTVDB), generate a proper label.


### PR DESCRIPTION
## Description

When a TV show's seasons lack individual poster images in both Seerr and TMDB (common for older/long-running shows like *The Tonight Show with Jay Leno*), the season cards in the more info modal displayed empty placeholders. This change falls back to the show-level poster when no season-specific poster is available.

**How it works:**
- **Initial render** (`buildSeasonsSection`): Uses the show's own poster (`data.posterPath`) as fallback when `season.posterPath` is empty, with `isValidPosterPath()` validation
- **Async TMDB backfill** (`backfillSeasonMetadata`): After checking TMDB for a season-specific poster, falls back to the show poster. Updates existing fallback images when a real season poster is found later

The browser only downloads the show poster once — all season cards reference the same URL and the browser HTTP cache deduplicates it.

This PR was developed with AI assistance (Claude). All changes have been reviewed, tested, and understood.

## Testing

- [x] Built with `dotnet build` — 0 warnings, 0 errors
- [x] Deployed and tested on Jellyfin 10.11.x dev instance
- [x] Verified with "The Tonight Show with Jay Leno (1992)" — all 22 seasons now display the show poster
- [x] Verified with "Breaking Bad" — show poster displays initially, real TMDB season posters replace them after backfill
- [x] No console errors
- [x] Doesn't break existing functionality

Fixes the missing season artwork issue for shows where Seerr (TheTVDB) and TMDB lack per-season poster images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)