### PR TITLE
Reduce size of quality tags or show only inside details poster

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/qualitytags.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/qualitytags.js
@@ -75,7 +75,7 @@
             'ATMOS': { bg: 'rgba(0, 100, 255, 0.9)', text: '#ffffff' },
             'DTS-X': { bg: 'rgba(255, 100, 0, 0.9)', text: '#ffffff' },
             'DTS': { bg: 'rgba(255, 140, 0, 0.85)', text: '#ffffff' },
-            'Dolby Digital+': { bg: 'rgba(0, 150, 136, 0.9)', text: '#ffffff' },
+            'DD+': { bg: 'rgba(0, 150, 136, 0.9)', text: '#ffffff' },
             'TRUEHD': { bg: 'rgba(76, 175, 80, 0.9)', text: '#ffffff' },
             '7.1': { bg: 'rgba(156, 39, 176, 0.9)', text: '#ffffff' },
             '5.1': { bg: 'rgba(103, 58, 183, 0.9)', text: '#ffffff' },
@@ -952,7 +952,7 @@
          */
         function renderVisibleTags() {
             const elements = Array.from(document.querySelectorAll(
-                '.cardImageContainer, div.listItemImage'
+                '#itemDetailPage .detailImageContainer .cardImageContainer'
             ));
 
             elements.forEach(el => {


### PR DESCRIPTION
*This is just an example, I'll open the coresponding enhancement issue*

The quality tags occupy to much space on the outside poster, and dolby digital+ 2.0 is the worst case of it.

I proposed 2 changes: changing dolby digital to DD, or another change, that I've no idea at all if it works, it was made with AI, and maybe someone wants it like this so should add an additional checkbox on the config to select both or only inside details page. I like the tags, but the top of the poster is where normally goes the faces or title of series, so I find some change would be nice, maybe not what i proposed.. but just to give some ideas.