### PR TITLE
fix: wait for access token before Seerr initialization

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/jellyseerr.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/jellyseerr.js
@@ -418,7 +418,7 @@
             const timeout = 20000;
 
             const checkForUser = async () => {
-                if (ApiClient.getCurrentUserId()) {
+                if (ApiClient.getCurrentUserId() && ApiClient.accessToken()) {
                     console.log(`${logPrefix} User session found. Initializing...`);
                     const status = await checkUserStatus();
                     isJellyseerrActive = status.active;


### PR DESCRIPTION
## Description

Fixes a race condition where Seerr integration fails to connect on Jellyfin 10.11.6.

On Jellyfin 10.11.6, the React SPA sets `ApiClient.getCurrentUserId()` before `ApiClient.accessToken()` is available during startup. `waitForUserAndInitialize()` in `jellyseerr.js` only checked for the user ID, so `checkUserStatus()` would fire a request to `/JellyfinEnhanced/jellyseerr/user-status` without a valid auth token. The server returns 401, and the catch block permanently caches `{ active: false, userFound: false }`, disabling Seerr for the entire session with no way to recover short of a full page reload.

The fix adds `ApiClient.accessToken()` to the readiness check so the existing polling loop (300ms intervals, 20s timeout) continues until both the user ID and auth token are available.

## Implementation Notes

This PR was developed with AI assistance (Claude). All changes have been reviewed, tested, and understood.

One-line change in `waitForUserAndInitialize()`:
```diff
- if (ApiClient.getCurrentUserId()) {
+ if (ApiClient.getCurrentUserId() && ApiClient.accessToken()) {
```

## Testing

- [x] Built with `dotnet build` - 0 warnings, 0 errors
- [x] Deployed and tested on Jellyfin 10.11.x dev instance
- [x] Verified `/jellyseerr/user-status` returns `{ active: true, userFound: true }` with valid token
- [x] Verified 401 response without token (confirms the race condition scenario)
- [x] No console errors
- [x] Doesn't break existing functionality

Closes #516