### PR TITLE
fix: include primary language in translation fallback chain

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/translations.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/translations.js
@@ -17,6 +17,10 @@
         const normalizedLang = normalizeLangCode(primaryLang);
         const langCodes = [];
 
+        if (normalizedLang) {
+            langCodes.push(normalizedLang);
+        }
+
         if (normalizedLang && normalizedLang.includes('-')) {
             const baseLang = normalizedLang.split('-')[0];
             if (!langCodes.includes(baseLang)) {
@@ -189,6 +193,15 @@
                 const storedLang = localStorage.getItem(storageKey);
                 if (storedLang) {
                     lang = normalizeLangCode(storedLang);
+                } else {
+                    // Fall back to the HTML lang attribute set by Jellyfin's web client.
+                    // This covers the Android app and other clients where the localStorage
+                    // key may not exist but Jellyfin has already resolved the user's
+                    // preferred language from server-side settings.
+                    const docLang = document.documentElement.lang;
+                    if (docLang) {
+                        lang = normalizeLangCode(docLang);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description

Fixes a regression in `buildLanguageChain()` where the primary language code was not included in the fallback chain for simple (non-hyphenated) codes like `de`, `fr`, `es`, `it`, etc. This caused all non-English simple language codes to resolve to `["en"]` only, so translations were never loaded for those languages.

The bug was introduced in PR # 466 (zh-CN support). That PR correctly removed the special-case `zh` handling, but also removed the general-purpose line that added the primary language to the chain:

```js
if (normalizedLang) {
    langCodes.push(normalizedLang);
}
```

This line was originally present when the translations module was first created and was essential for all simple language codes to work.

### Before (broken)
| Input | Chain |
|-------|-------|
| `de` | `["en"]` |
| `fr` | `["en"]` |
| `de-DE` | `["de", "en"]` |

### After (fixed)
| Input | Chain |
|-------|-------|
| `de` | `["de", "en"]` |
| `fr` | `["fr", "en"]` |
| `de-DE` | `["de-DE", "de", "en"]` |

Also adds a fallback to `document.documentElement.lang` when the `{userId}-language` localStorage key does not exist. This covers the Android app and other clients where Jellyfin has already resolved the user's preferred language from server-side settings but the per-client localStorage key has not been written yet.

This PR was developed with AI assistance (Claude). All changes have been reviewed, tested, and understood.

## Testing
- [x] Built with `dotnet build` -- 0 warnings, 0 errors
- [x] Deployed and tested on Jellyfin 10.11.x dev instance
- [x] Verified `JE.t("calendar_title")` returns `"Kalender"` (German) after setting language to `de`
- [x] Verified `buildLanguageChain` produces correct chains for `de`, `fr`, `en`, `de-DE`, `en-GB`, `pt-BR`, `zh-CN`
- [x] No console errors
- [x] Doesn't break existing functionality

Closes #513