### PR TITLE
fix: Clear stale UseCustomTabs/UsePluginPages flags when plugins not installed

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -379,6 +379,31 @@
             JE.t = window.JellyfinEnhanced.t; // Ensure the real function is assigned
             await loadPrivateConfig();
 
+            // Clear stale UseCustomTabs / UsePluginPages config flags when those
+            // plugins are not installed.  Settings persist after uninstall, which
+            // causes sidebar injection to be skipped even though the delivery
+            // plugin is no longer present.
+            try {
+                const installedPlugins = await ApiClient.ajax({
+                    type: 'GET', url: ApiClient.getUrl('/Plugins'), dataType: 'json'
+                });
+                if (!Array.isArray(installedPlugins)) throw new Error('Unexpected /Plugins response');
+                const hasCustomTabs = installedPlugins.some(p => p.Name === 'Custom Tabs');
+                const hasPluginPages = installedPlugins.some(p => p.Name === 'Plugin Pages');
+                if (!hasCustomTabs) {
+                    JE.pluginConfig.CalendarUseCustomTabs = false;
+                    JE.pluginConfig.HiddenContentUseCustomTabs = false;
+                    JE.pluginConfig.DownloadsUseCustomTabs = false;
+                }
+                if (!hasPluginPages) {
+                    JE.pluginConfig.HiddenContentUsePluginPages = false;
+                    JE.pluginConfig.DownloadsUsePluginPages = false;
+                    JE.pluginConfig.CalendarUsePluginPages = false;
+                }
+            } catch (e) {
+                console.warn('🪼 Jellyfin Enhanced: Could not verify installed plugins:', e);
+            }
+
             // Check if server has triggered a translation cache clear
             const serverTranslationClearTs = JE.pluginConfig.ClearTranslationCacheTimestamp || 0;
             const localTranslationClearTs = parseInt(localStorage.getItem('JE_translation_clear_ts') || '0', 10);


### PR DESCRIPTION
## Summary

- When Custom Tabs or Plugin Pages is uninstalled, the `UseCustomTabs`/`UsePluginPages` config flags persist on the server
- All modules' `injectNavigation()` functions check these flags and skip sidebar injection, leaving features (Calendar, Hidden Content, Downloads) with no navigation path
- Queries the `/Plugins` API at startup and clears stale flags in memory when the delivery plugin is not installed
- Server-side settings are preserved so reinstalling the plugin restores the original configuration

## Files changed (1)

| File | Change |
|------|--------|
| `js/plugin.js` | Add runtime installed-plugin check after `pluginConfig` loads |

## Test plan

- [x] Built with `dotnet build` -- 0 warnings, 0 errors
- [x] Deployed and tested on Jellyfin 10.11.x dev instance
- [x] Verified sidebar items appear when Custom Tabs/Plugin Pages uninstalled but flags still true
- [x] Verified flags are NOT cleared when plugins ARE installed
- [x] Verified server-side config unchanged (settings preserved for reinstall)
- [x] No console errors
- [x] Doesn't break existing functionality

This PR was developed with AI assistance (Claude). All changes have been reviewed, tested, and understood.