### PR TITLE
fix: warn admin when jellyfin-web version is behind server

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -2494,14 +2494,16 @@
 
                 var webParts = webVersion.split('.').map(Number);
                 var serverParts = serverVersion.split('.').map(Number);
+                var validSemver = !isNaN(webParts[0]) && !isNaN(webParts[1]) && !isNaN(serverParts[0]) && !isNaN(serverParts[1]);
 
-                // Compare major.minor (e.g. 10.8 vs 10.11)
-                var webMajorMinor = webParts[0] * 1000 + (webParts[1] || 0);
-                var serverMajorMinor = serverParts[0] * 1000 + (serverParts[1] || 0);
+                if (validSemver) {
+                    // Compare major.minor (e.g. 10.8 vs 10.11)
+                    var webMajorMinor = webParts[0] * 1000 + webParts[1];
+                    var serverMajorMinor = serverParts[0] * 1000 + serverParts[1];
+                    if (webMajorMinor >= serverMajorMinor) return;
+                }
 
-                if (webMajorMinor >= serverMajorMinor) return;
-
-                var minorDiff = (serverParts[1] || 0) - (webParts[1] || 0);
+                // Non-semver web version (e.g. "20220818.18-unstable") or web is behind server
                 var container = document.getElementById('webVersionMessage');
                 container.textContent = '';
 
@@ -2510,12 +2512,19 @@
                     { text: webVersion, bold: true },
                     { text: ') does not match your server version (' },
                     { text: serverVersion, bold: true },
-                    { text: '). The web client is ' },
-                    { text: minorDiff + ' minor version' + (minorDiff > 1 ? 's' : ''), bold: true },
-                    { text: ' behind. Some Jellyfin Enhanced features (such as Seerr search) may not work correctly. Please update your ' },
-                    { text: 'jellyfin-web', code: true },
-                    { text: ' package to match your server version.' }
+                    { text: '). ' }
                 ];
+
+                if (validSemver) {
+                    var minorDiff = serverParts[1] - webParts[1];
+                    parts.push({ text: 'The web client is ' });
+                    parts.push({ text: minorDiff + ' version' + (minorDiff > 1 ? 's' : ''), bold: true });
+                    parts.push({ text: ' behind. ' });
+                }
+
+                parts.push({ text: 'Some Jellyfin Enhanced features (such as Seerr search) may not work correctly. Please update your ' });
+                parts.push({ text: 'jellyfin-web', code: true });
+                parts.push({ text: ' package to match your server version.' });
 
                 parts.forEach(function(p) {
                     var el;


### PR DESCRIPTION
## Summary

Adds a version mismatch warning banner on the admin config page when the `jellyfin-web` version is behind the server version. This was the root cause of #528 -- the user had `jellyfin-web` stuck on `20220818.18-unstable` (a 2022 build) while `jellyfin-server` was on `10.11.7`.

Rather than patching individual selectors that break on older web clients, this surfaces the real problem to the admin so they can fix it at the source.

Would you want something like this in the plugin?
<img width="1721" height="111" alt="Screenshot_20260404_133331" src="https://github.com/user-attachments/assets/2e518710-5ded-4ee3-862b-c479254a7625" />


### How it works
- Compares `ApiClient._appVersion` (web) vs `ApiClient._serverVersion` (server) on config page load
- Only warns when web client major.minor is **behind** the server (web ahead of server does not trigger)
- Same minor with different patch (e.g. 10.11.3 vs 10.11.7) does not trigger
- Handles non-semver version strings (e.g. date-based unstable builds) gracefully

### AI Assistance Disclosure
This PR was developed with AI assistance (Claude). All changes have been reviewed, tested, and understood.

### Testing
- [x] Built with `dotnet build` -- 0 warnings, 0 errors
- [x] Deployed and tested on Jellyfin 10.11.7 dev instance
- [x] Tested: matching versions (no warning)
- [x] Tested: web behind server, e.g. 10.8.13 vs 10.11.7 (warning shown)
- [x] Tested: web ahead of server (no warning)
- [x] Tested: same minor, different patch (no warning)
- [x] Tested: non-semver version string `20220818.18-unstable` (warning shown)
- [x] Tested on Chromium and Firefox
- [x] No console errors
- [x] Does not break existing functionality

Closes #528