### PR TITLE
fix: hidden users could not see their own reviews

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -2472,6 +2472,24 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
             var hideHiddenAuthors = config?.HideReviewsFromHiddenUsers ?? true;
             var hideDisabledAuthors = config?.HideReviewsFromDisabledUsers ?? true;
 
+            // Resolve the current viewer's "N"-format user id so we can
+            // always show their OWN review back to them, even when the
+            // viewer themselves is hidden/disabled in Jellyfin and the
+            // hide filters would otherwise drop their author record.
+            // Without this, a hidden non-admin user posting a review would
+            // immediately lose visibility of their own content (issue 546).
+            var viewerUserId = UserHelper.GetCurrentUserId(User);
+            var viewerUserIdN = viewerUserId?.ToString("N");
+            if (string.IsNullOrEmpty(viewerUserIdN))
+            {
+                // Anomalous: [Authorize] passed but the Jellyfin-UserId
+                // claim is missing or unparseable. The self-review bypass
+                // below will silently no-op, so warn here to give a
+                // diagnostic trail if a hidden user reports the symptom
+                // again with no obvious cause.
+                _logger.Warning($"GetItemReviews: could not resolve viewer user id from claims on {mediaType}:{tmdbId}; self-review bypass disabled.");
+            }
+
             var suffix = $":{mediaType}:{tmdbId}";
             var store = _userConfigurationManager.GetAllReviews();
             var results = new List<object>();
@@ -2497,8 +2515,26 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                         if (jellyfinUser != null) displayName = jellyfinUser.Username;
                     }
 
+                    // The viewer's own review is ALWAYS visible to themselves,
+                    // regardless of admin status or hide filters. The hide
+                    // filters exist to let admins moderate OTHER users'
+                    // content, not to make a user's own writing invisible to
+                    // them. Skipping the filter for self also prevents the
+                    // confusing "I just posted, where did it go?" symptom
+                    // when the viewer's own account has IsHidden set.
+                    //
+                    // Require jellyfinUser != null on the self-bypass so an
+                    // orphaned-self record (auth token still resolves to a
+                    // deleted user — Jellyfin doesn't universally invalidate
+                    // tokens on user delete) still falls into the orphan
+                    // hide path below instead of being served back with a
+                    // raw-Guid display name.
+                    var isOwnReview = jellyfinUser != null
+                        && !string.IsNullOrEmpty(viewerUserIdN)
+                        && string.Equals(review.UserId, viewerUserIdN, StringComparison.OrdinalIgnoreCase);
+
                     // Admin viewers always see every review so they can moderate.
-                    if (!viewerIsAdmin)
+                    if (!viewerIsAdmin && !isOwnReview)
                     {
                         // Orphaned authors (Jellyfin user was deleted) are
                         // hidden from non-admin viewers IF either hide toggle


### PR DESCRIPTION
## Description

Fixes the issue of a hidden user not being able to see their own comment. #546. A non-admin Jellyfin user with `IsHidden=true` (a common setting for accounts hidden from the login screen) could write a review and then immediately lose visibility of it. The same applied to `IsDisabled`. The original report:

> A regular user account can write a review, but they can't see their own review after posting it. They also can't see other users' reviews.

## Root cause

Me oops but here:
The `HideReviewsFromHiddenUsers` / `HideReviewsFromDisabledUsers` filters added in #545 (default ON) were applied indiscriminately in `GetItemReviews`, including to the viewer's own author record. Those filters exist so admins can moderate OTHER users' content, not to make a user's own writing invisible to themselves.

If the viewer themselves was hidden, every one of their own reviews would silently vanish from their own view. Other hidden users' reviews would also disappear, which is the intended behavior, so the user saw an empty section with no obvious cause.

## Fix

Single file, +37/-1 in `JellyfinEnhancedController.cs:GetItemReviews`. The actual logic change is one condition: `if (!viewerIsAdmin)` becomes `if (!viewerIsAdmin && !isOwnReview)`. The rest is the supporting `viewerUserIdN` resolution + the `isOwnReview` computation + comments + a diagnostic warning.

- Resolves the viewer's `N`-format user id once at the top of the method from the auth-derived `ClaimsPrincipal` (no URL/body input, cannot be spoofed).
- Computes `isOwnReview` per loop iteration as a strict equality check against the stored `review.UserId`.
- Bypasses the hide-hidden / hide-disabled filter for self only. Non-self filtering, admin moderation, and orphan fail-closed behavior are unchanged.
- Requires `jellyfinUser != null` on the self-bypass so an orphaned-self record (auth token still resolves to a deleted user, since Jellyfin does not universally invalidate tokens on user delete) still falls into the orphan hide path instead of being served back with a raw-Guid display name.
- Logs a warning if the `Jellyfin-UserId` claim is missing or unparseable when the endpoint is reached. The self-bypass silently no-ops in that case, which would otherwise reproduce the exact symptom from #546 with no diagnostic trail.

## Implementation Notes

This PR was developed with AI assistance (Claude/GPT). All changes have been reviewed, tested, and understood.

## Testing

- [x] Built with `dotnet build`, 0 warnings, 0 errors
- [x] Deployed and tested on Jellyfin 10.11.x dev instance
- [x] No console errors
- [x] Doesn't break existing functionality
- [x] **Empirical before/after on the SAME data and SAME hidden user, only the deployed DLL differs**:
  - `origin/main` (unfixed): hidden Test user sees 2 of 3 reviews, own review missing
  - `issues/bugs/546` (fixed): hidden Test user sees all 3 reviews, including own
- [x] Regression matrix on jellyfin-dev:
  - Hidden non-admin viewer sees: own review (self bypass) + non-hidden other-author reviews
  - Hidden non-admin viewer does NOT see: another hidden user's review (filter still applies for non-self)
  - Admin viewer sees all reviews regardless (admin exemption unchanged)
- [x] Orphaned-self regression check: an injected `reviews.json` record with a fake `UserId` is correctly hidden from non-admins (the new `jellyfinUser != null` guard) and still visible to admins for moderation, with a warning logged
- [x] Playwright E2E covering all 5 scenarios end-to-end including a fresh post-and-see-own roundtrip, all PASS
- [x] Reviewed by 3 independent reviewers (code-reviewer, silent-failure-hunter, codex). The orphaned-self guard and the missing-claim warning came from silent-failure-hunter findings on the first pass

## Breaking changes

None. Non-self filtering behavior is byte-identical to `origin/main` for every code path that does not match the viewer's own auth-derived user id.