### PR TITLE
fix: gate TMDB reviews on Elsewhere toggle, boxify reviews ui and blocks

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -493,14 +493,18 @@
                                 </label>
                             </div>
                             <div class="fieldDescription" style="margin-bottom: 1.5em; font-size: 0.9em;">When enabled, the reviews section opens expanded by default for all users (unless they override in their session).</div>
-                            <h3 style="margin-top: 2.5em;">User Reviews</h3>
-                            <h5>These settings do not require TMDB API key to be populated</h5>
+                        </div>
+                    </fieldset>
+                    <fieldset class="verticalSection-extrabottompadding">
+                        <legend class="sectionTitle"><h3>User Reviews</h3></legend>
+                        <div class="configSection">
+                            <div class="fieldDescription" style="margin-bottom: 1em; font-size: 0.9em;">Independent of Elsewhere. Does not require a TMDB API key.</div>
                             <div class="checkboxContainer" style="margin-bottom: 0.5em;">
                                 <label style="line-height: 1.2em; align-self: flex-start;"><input id="showUserReviews" is="emby-checkbox" type="checkbox"/>
                                     <span>Enable User Reviews in Item Details Page</span>
                                 </label>
                             </div>
-                            <div class="fieldDescription" style="margin-bottom: 1.5em; font-size: 0.9em;">Allows users to write reviews and rate items in the library.<br/><strong>Completely independent of Elsewhere being enabled and TMDB Reviews being enabled</strong></div>
+                            <div class="fieldDescription" style="margin-bottom: 1.5em; font-size: 0.9em;">Allows users to write reviews and rate items in the library.</div>
                             <div class="checkboxContainer" style="margin-bottom: 0.5em;">
                                 <label style="line-height: 1.2em; align-self: flex-start;"><input id="hideReviewsFromHiddenUsers" is="emby-checkbox" type="checkbox"/>
                                     <span>Hide reviews written by hidden users</span>
@@ -3610,6 +3614,17 @@
                 var container = child.closest('.checkboxContainer, .inputContainer, .selectContainer')
                              || child.closest('label');
 
+                // Collect any immediately-following sibling .fieldDescription blocks so help text
+                // greys with its checkbox (layout places descriptions outside the container).
+                var siblingDescs = [];
+                if (container) {
+                    var sib = container.nextElementSibling;
+                    while (sib && sib.classList && sib.classList.contains('fieldDescription')) {
+                        siblingDescs.push(sib);
+                        sib = sib.nextElementSibling;
+                    }
+                }
+
                 if (!isEnabled) {
                     child.disabled = true;
                     addDepTag(child, tag);
@@ -3625,6 +3640,10 @@
                             container.appendChild(hint);
                         }
                     }
+                    siblingDescs.forEach(function(d) {
+                        d.style.opacity = '0.5';
+                        addDepTag(d, tag);
+                    });
                 } else {
                     var allClear = removeDepTag(child, tag);
                     if (allClear) child.disabled = false;
@@ -3635,6 +3654,9 @@
                         var hint = container.querySelector('.' + hintClass);
                         if (hint) hint.remove();
                     }
+                    siblingDescs.forEach(function(d) {
+                        if (removeDepTag(d, tag)) d.style.opacity = '';
+                    });
                 }
             });
         }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
@@ -3,9 +3,20 @@
     'use strict';
 
     JE.initializeReviewsScript = function () {
-        const tmdbReviewsEnabled = JE.pluginConfig.ShowReviews && JE.pluginConfig.TmdbEnabled;
-        const userReviewsEnabled = JE.pluginConfig.ShowUserReviews;
-        if (!tmdbReviewsEnabled && !userReviewsEnabled) {
+        // TMDB reviews are a sub-feature of Elsewhere so they inherit its master toggle.
+        // User Reviews are intentionally independent of Elsewhere and TMDB.
+        // Read fresh from pluginConfig on every check — admin may toggle at runtime
+        // via the reactive config system, and a captured constant would stay stale.
+        const reviewsGates = () => ({
+            tmdb: !!(JE.pluginConfig?.ElsewhereEnabled && JE.pluginConfig?.ShowReviews && JE.pluginConfig?.TmdbEnabled),
+            user: !!JE.pluginConfig?.ShowUserReviews,
+        });
+        // Register the onViewPage handler whenever either feature COULD become enabled
+        // (ShowReviews or ShowUserReviews is persisted on). The runtime gate inside the
+        // handler decides per-navigation whether to actually fetch. Bailing based on
+        // ElsewhereEnabled at init would orphan reviews when admin re-enables Elsewhere
+        // mid-session, because no handler would be registered to pick up the change.
+        if (!JE.pluginConfig?.ShowReviews && !JE.pluginConfig?.ShowUserReviews) {
             console.log('🪼 Jellyfin Enhanced: Reviews feature disabled.');
             return;
         }
@@ -539,10 +550,14 @@
             const viewerIsAdmin = currentUser?.Policy?.IsAdministrator === true;
             const ownReview = userReviews.find(r => r.userId.replace(/-/g, '') === currentUserId.replace(/-/g, ''));
             const hasReviews = (reviews && reviews.length > 0) || userReviews.length > 0;
+            // Force-show the empty accordion only when user reviews are enabled — users need the
+            // "Write Review" button to appear even when no one has reviewed yet. If user reviews
+            // are off and TMDB has nothing to show, don't render a hollow "Reviews (0)" block.
+            const userReviewsEnabledNow = !!JE.pluginConfig?.ShowUserReviews;
 
             let reviewsSection;
 
-            if (hasReviews || true /* always show so users can add their own */) {
+            if (hasReviews || userReviewsEnabledNow) {
                 reviewsSection = document.createElement('details');
                 reviewsSection.className = 'detailSection tmdb-reviews-section';
                 if (JE.currentSettings?.reviewsExpandedByDefault) {
@@ -560,7 +575,7 @@
                 actionBar.className = 'je-review-action-bar';
                 let writeBtn = null;
 
-                if (userReviewsEnabled && !ownReview) {
+                if (reviewsGates().user && !ownReview) {
                     writeBtn = document.createElement('button');
                     writeBtn.className = 'je-review-btn je-review-write-btn';
                     writeBtn.textContent = JE.t('reviews_add');
@@ -709,6 +724,10 @@
                 });
             }
 
+            // When the if-block above was skipped (no content and user reviews disabled),
+            // reviewsSection is undefined — nothing to insert.
+            if (!reviewsSection) return;
+
             const insertionAnchor =
                 contextPage.querySelector('.streaming-lookup-container') ||
                 contextPage.querySelector('.itemExternalLinks') ||
@@ -741,13 +760,23 @@
                 // Fetch the current user fresh alongside the review data so
                 // admin status reflects the actual live session, not a
                 // potentially-stale JE.currentUser captured at plugin init.
+                const gates = reviewsGates();
+                const page = document.querySelector('#itemDetailPage:not(.hide)') || contextPage;
+
+                // Admin may have disabled the feature between the initial render and this refresh.
+                // Tear down any existing accordion rather than rebuilding an empty "Reviews (0)" block.
+                if (!gates.tmdb && !gates.user) {
+                    const existing = page?.querySelector('.tmdb-reviews-section');
+                    if (existing) existing.remove();
+                    return;
+                }
+
                 const [tmdbReviews, userReviews, currentUser] = await Promise.all([
-                    tmdbReviewsEnabled ? fetchReviews(tmdbId, mediaType) : Promise.resolve(null),
-                    userReviewsEnabled ? fetchUserReviews(tmdbId, mediaType) : Promise.resolve([]),
+                    gates.tmdb ? fetchReviews(tmdbId, mediaType) : Promise.resolve(null),
+                    gates.user ? fetchUserReviews(tmdbId, mediaType) : Promise.resolve([]),
                     ApiClient.getCurrentUser().catch(() => null),
                 ]);
 
-                const page = document.querySelector('#itemDetailPage:not(.hide)') || contextPage;
                 addReviewsToPage(tmdbReviews, userReviews, page, tmdbId, apiMediaType, currentUser);
             } catch (err) {
                 console.error(`${logPrefix} Failed to refresh reviews:`, err);
@@ -944,9 +973,12 @@
                         // See refreshReviews for why we resolve currentUser here
                         // instead of reading JE.currentUser — same race/staleness
                         // reasoning.
+                        const gates = reviewsGates();
+                        if (!gates.tmdb && !gates.user) return;
+
                         const [tmdbReviews, userReviews, currentUser] = await Promise.all([
-                            tmdbReviewsEnabled ? fetchReviews(tmdbId, mediaType) : Promise.resolve(null),
-                            userReviewsEnabled ? fetchUserReviews(tmdbId, mediaType) : Promise.resolve([]),
+                            gates.tmdb ? fetchReviews(tmdbId, mediaType) : Promise.resolve(null),
+                            gates.user ? fetchUserReviews(tmdbId, mediaType) : Promise.resolve([]),
                             ApiClient.getCurrentUser().catch(() => null),
                         ]);
                         addReviewsToPage(tmdbReviews, userReviews, visiblePage, tmdbId, apiMediaType, currentUser);
@@ -959,11 +991,30 @@
 
         injectCss();
 
+        // Tear down any lingering reviews section on the currently-visible page
+        // (e.g. a cached detail page from a prior render when features were on).
+        // Scoped to the visible detail page so we don't nuke sections on cached-
+        // but-not-visible prior pages kept in DOM by Jellyfin's SPA router.
+        function teardownExistingSection() {
+            const visiblePage = document.querySelector('#itemDetailPage:not(.hide)');
+            if (!visiblePage) return;
+            visiblePage.querySelectorAll('.tmdb-reviews-section').forEach(el => el.remove());
+        }
+
         // Use Emby.Page.onViewShow hook for reliable page navigation detection
         const unregister = JE.helpers.onViewPage(async (view, element, hash, itemPromise) => {
-            // Check if feature is still enabled
-            if (!JE?.pluginConfig?.ShowReviews && !JE?.pluginConfig?.ShowUserReviews) {
+            // Only unregister when the persisted toggles say the feature is off — that's the only
+            // state transition that cannot be recovered without a reload. When gates are false purely
+            // because of runtime-derived values (ElsewhereEnabled, TmdbEnabled), skip this navigation
+            // but stay registered so a live admin toggle can re-enable reviews on the next nav.
+            if (!JE.pluginConfig?.ShowReviews && !JE.pluginConfig?.ShowUserReviews) {
+                teardownExistingSection();
                 unregister();
+                return;
+            }
+            const gates = reviewsGates();
+            if (!gates.tmdb && !gates.user) {
+                teardownExistingSection();
                 return;
             }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -622,6 +622,9 @@
             if (typeof JE.initializeArrLinksScript === 'function' && JE.pluginConfig?.ArrLinksEnabled) JE.initializeArrLinksScript();
             if (typeof JE.initializeArrTagLinksScript === 'function' && JE.pluginConfig?.ArrTagsShowAsLinks) JE.initializeArrTagLinksScript();
             if (typeof JE.initializeLetterboxdLinksScript === 'function' && JE.pluginConfig?.LetterboxdEnabled) JE.initializeLetterboxdLinksScript();
+            // Deliberately loose: register the module if either feature MIGHT become enabled.
+            // Runtime gating in reviewsGates() inside reviews.js enforces correctness per-fetch
+            // so admin can toggle ElsewhereEnabled/ShowReviews/ShowUserReviews live without a reload.
             if (typeof JE.initializeReviewsScript === 'function' && (JE.pluginConfig?.ShowReviews || JE.pluginConfig?.ShowUserReviews)) JE.initializeReviewsScript();
             if (typeof JE.initializeLanguageTags === 'function' && JE.currentSettings?.languageTagsEnabled) JE.initializeLanguageTags();
             if (typeof JE.initializePeopleTags === 'function' && JE.currentSettings?.peopleTagsEnabled) JE.initializePeopleTags();


### PR DESCRIPTION
## Description

Tightens the gating and layout of the Reviews feature in the Elsewhere tab.

### Fixes

- **TMDB reviews now respect the Elsewhere toggle.** Previously the runtime only checked `ShowReviews && TmdbEnabled`, so disabling Elsewhere still rendered TMDB reviews on item detail pages. The gate is now `ElsewhereEnabled && ShowReviews && TmdbEnabled`, matching the parent-child relationship already shown in the config UI.
- **No more stale "Reviews (0)" accordion.** When all review features are effectively off, any lingering `.tmdb-reviews-section` on the visible detail page is torn down on the next navigation, and `addReviewsToPage` no longer force-renders an empty section unless User Reviews is enabled (keeping the Write Review affordance where it belongs).
- **Config page help text greys out with its checkbox.** `updateParentDep` now walks immediately-following sibling `.fieldDescription` blocks and applies the same opacity and dep-tag treatment, so descriptions under locked-out controls fade consistently with their parent.

### Improvements

- **User Reviews moved into its own `<fieldset>`** under the Elsewhere tab, with a clear "Independent of Elsewhere. Does not require a TMDB API key." note. User Reviews is deliberately not gated on Elsewhere or TMDB, and the separated box makes that contract visually explicit.
- Extras (TMDB reviews + expand-by-default) stays inside the Elsewhere Configuration fieldset since it correctly inherits Elsewhere's master toggle.
- Plugin still registers the reviews module whenever either `ShowReviews` or `ShowUserReviews` is persisted on, so live-enabling Elsewhere in an existing session immediately brings TMDB reviews back on the next nav without needing a browser reload.

## Implementation Notes

This PR was developed with AI assistance (Claude/GPT). I have reviewed and tested all changes and understand the implementation.

## Testing

- [x] Built with \`dotnet build\` on net9.0 with 0 warnings, 0 errors
- [x] Tested on Jellyfin 10.11.x dev instance
- [x] No console errors on item detail pages across the Elsewhere / ShowReviews / ShowUserReviews config matrix
- [x] Verified TMDB reviews hide when Elsewhere is disabled, and appear when it is re-enabled (both at init and live mid-session)
- [x] Verified User Reviews continue working independently of Elsewhere
- [x] Verified the empty "Reviews (0)" accordion does not appear when User Reviews is off and an item has no TMDB reviews
- [x] Verified grey-out behavior across the parent-dep chain in the Elsewhere tab (checkbox + sibling help text fade together, restore correctly)
- [x] Verified live toggling via direct pluginConfig mutation (admin changes propagate on next SPA navigation without page reload)
- [x] Compatible with Jellyfin 10.11.x, no breaking changes