### PR TITLE
Jellyfin Helper favicon.ico

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/extras/plugin-icons.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/extras/plugin-icons.js
@@ -227,6 +227,12 @@
                     selector: 'a[href*="File%20Transformation"]',
                     type: 'material',
                     icon: 'file_open'
+                },
+                {
+                    selector: 'a[href*="Jellyfin%20Helper"]',
+                    type: 'image',
+                    src: 'https://cdn.jsdelivr.net/gh/JellyPlugins/jellyfin-helper@2.0.0.2/media/favicon.ico',
+                    alt: 'Jellyfin Helper'
                 }
             ];
 


### PR DESCRIPTION
Add custom ico for Jellyfin Helper Plugin

Changed:
[plugin-icons.js](https://github.com/n00bcodr/Jellyfin-Enhanced/pull/584/changes#diff-ee1be9852c4c59ce650ecb8fb59a14c845311e9e3cc10c43fde50f42aa40fd3b)

Build: successfull

Tested: locally

<img width="455" height="223" alt="image" src="https://github.com/user-attachments/assets/c53218e0-a1b3-4d1f-bc18-f50af1dd0ea6" />
