### PR TITLE
feat: trigger Seerr recently-added scan on Jellyfin item added

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
@@ -125,6 +125,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             JellyseerrDisableCache = false;
             JellyseerrResponseCacheTtlMinutes = 10;
             JellyseerrUserIdCacheTtlMinutes = 30;
+            TriggerSeerrScanOnItemAdded = false;
+            SeerrScanDebounceSeconds = 60;
 
             // Arr Links Settings
             ArrLinksEnabled = false;
@@ -345,6 +347,11 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public string JellyseerrUrls { get; set; }
         public string JellyseerrApiKey { get; set; }
         public string JellyseerrUrlMappings { get; set; }
+
+        // On-demand library sync: POST {seerrUrl}/api/v1/settings/jobs/jellyfin-recently-added-scan/run
+        // when Jellyfin reports new items, debounced so a bulk import collapses to one call.
+        public bool TriggerSeerrScanOnItemAdded { get; set; }
+        public int SeerrScanDebounceSeconds { get; set; } = 60;
         public bool ShowCollectionsInSearch { get; set; }
         public bool JellyseerrDisableCache { get; set; }
         public int JellyseerrResponseCacheTtlMinutes { get; set; }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -1261,14 +1261,14 @@
                         </div>
                     </fieldset>
 
-<fieldset>
-                        <legend class="sectionTitle">Library Sync to Seerr</legend>
+                    <fieldset>
+                        <legend class="sectionTitle">Recently Added Sync to Seerr</legend>
                         <div class="configSection">
-                            <div class="checkboxContainer"><label><input id="triggerSeerrScanOnItemAdded" is="emby-checkbox" type="checkbox"/><span>Trigger Seerr recently-added scan on Jellyfin item added</span></label></div>
+                            <div class="checkboxContainer"><label><input id="triggerSeerrScanOnItemAdded" is="emby-checkbox" type="checkbox"/><span>Trigger Seerr recently-added scan when new Jellyfin items are added</span></label></div>
                             <div class="je-setting-description" data-desc-for="triggerSeerrScanOnItemAdded">
                                 <div class="fieldDescription je-field-desc-xl">
-                                    When Jellyfin reports new library items, POSTs to Seerr's <code>/api/v1/settings/jobs/jellyfin-recently-added-scan/run</code> endpoint so Seerr's "Available" status updates immediately instead of waiting for its 5-minute cron. Events are debounced, so a bulk import collapses into a single trigger.<br/><br/>
-                                    <strong>Tip:</strong> with this enabled, you can set Seerr's recently-added scan cron to a much longer interval (or disable it) to reduce noise.
+                                    When Jellyfin reports new library items added, enabling this triggers the "Jellyfin Recently Added Scan" job so that request statuses are immediately updated instead of waiting till next schedule run. Events are debounced, so a bulk import collapses into a single trigger.<br/><br/>
+                                    <strong>Tip:</strong> With this enabled, you can set Seerr's recently-added scan Frequency to a much longer interval (60 minutes) to reduce noise.
                                 </div>
                             </div>
 
@@ -1288,13 +1288,13 @@
                             </div>
                             <div class="je-setting-description" data-desc-for="triggerSeerrScanNowBtn">
                                 <div class="fieldDescription je-field-desc-md">
-                                    Uses the Seerr URL and API key entered in the Setup section above (does not require saving first). If multiple URLs are configured, the first reachable one is used.
+                                    Uses the Seerr URL and API key entered in the Setup section above. If multiple URLs are configured, the first reachable one is used.
                                 </div>
                             </div>
                         </div>
                     </fieldset>
 
-<fieldset>
+                    <fieldset>
                         <legend class="sectionTitle">Watchlist</legend>
                         <div class="configSection">
                             <div class="checkboxContainer"><label><input id="addRequestedMediaToWatchlist" is="emby-checkbox" type="checkbox"/><span>Add requested media to Watchlist</span></label></div>

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -1262,6 +1262,39 @@
                     </fieldset>
 
 <fieldset>
+                        <legend class="sectionTitle">Library Sync to Seerr</legend>
+                        <div class="configSection">
+                            <div class="checkboxContainer"><label><input id="triggerSeerrScanOnItemAdded" is="emby-checkbox" type="checkbox"/><span>Trigger Seerr recently-added scan on Jellyfin item added</span></label></div>
+                            <div class="je-setting-description" data-desc-for="triggerSeerrScanOnItemAdded">
+                                <div class="fieldDescription je-field-desc-xl">
+                                    When Jellyfin reports new library items, POSTs to Seerr's <code>/api/v1/settings/jobs/jellyfin-recently-added-scan/run</code> endpoint so Seerr's "Available" status updates immediately instead of waiting for its 5-minute cron. Events are debounced, so a bulk import collapses into a single trigger.<br/><br/>
+                                    <strong>Tip:</strong> with this enabled, you can set Seerr's recently-added scan cron to a much longer interval (or disable it) to reduce noise.
+                                </div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <label class="inputLabel" for="seerrScanDebounceSeconds">Debounce (seconds):</label>
+                                <input id="seerrScanDebounceSeconds" is="emby-input" type="number" min="5" max="3600" step="1"/>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="seerrScanDebounceSeconds">
+                                <div class="fieldDescription je-field-desc-mt-sm je-field-desc-md">
+                                    Wait this many seconds after the LAST item added before firing the scan. Default 60. Range 5 to 3600.
+                                </div>
+                            </div>
+
+                            <div class="inputContainer">
+                                <button id="triggerSeerrScanNowBtn" is="emby-button" type="button" class="raised"><span>Trigger scan now</span></button>
+                                <span id="triggerSeerrScanNowStatus" class="material-icons" aria-hidden="true"></span>
+                            </div>
+                            <div class="je-setting-description" data-desc-for="triggerSeerrScanNowBtn">
+                                <div class="fieldDescription je-field-desc-md">
+                                    Uses the Seerr URL and API key entered in the Setup section above (does not require saving first). If multiple URLs are configured, the first reachable one is used.
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+
+<fieldset>
                         <legend class="sectionTitle">Watchlist</legend>
                         <div class="configSection">
                             <div class="checkboxContainer"><label><input id="addRequestedMediaToWatchlist" is="emby-checkbox" type="checkbox"/><span>Add requested media to Watchlist</span></label></div>
@@ -3911,6 +3944,8 @@
                 loadBlockedUsersList(config.JellyseerrImportBlockedUsers || '');
                 document.querySelector('#preventWatchlistReAddition').checked = config.PreventWatchlistReAddition !== false;
                 document.querySelector('#watchlistMemoryRetentionDays').value = config.WatchlistMemoryRetentionDays || 365;
+                document.querySelector('#triggerSeerrScanOnItemAdded').checked = config.TriggerSeerrScanOnItemAdded === true;
+                document.querySelector('#seerrScanDebounceSeconds').value = config.SeerrScanDebounceSeconds || 60;
                 document.querySelector('#bookmarksEnabled').checked = config.BookmarksEnabled !== false;
                 document.querySelector('#bookmarksUsePluginPages').checked = config.BookmarksUsePluginPages === true;
                 document.querySelector('#bookmarksUseCustomTabs').checked = config.BookmarksUseCustomTabs === true;
@@ -4173,6 +4208,9 @@
 
             const retentionDays = parseInt(document.querySelector('#watchlistMemoryRetentionDays').value);
             config.WatchlistMemoryRetentionDays = isNaN(retentionDays) || retentionDays < 1 ? 365 : Math.min(retentionDays, 3650);
+            config.TriggerSeerrScanOnItemAdded = document.querySelector('#triggerSeerrScanOnItemAdded').checked;
+            const seerrScanDebounce = parseInt(document.querySelector('#seerrScanDebounceSeconds').value);
+            config.SeerrScanDebounceSeconds = isNaN(seerrScanDebounce) || seerrScanDebounce < 5 ? 60 : Math.min(seerrScanDebounce, 3600);
             config.BookmarksEnabled = document.querySelector('#bookmarksEnabled').checked;
             config.BookmarksUsePluginPages = document.querySelector('#bookmarksUsePluginPages').checked;
             config.BookmarksUseCustomTabs = document.querySelector('#bookmarksUseCustomTabs').checked;
@@ -5121,6 +5159,7 @@
             { parent: 'autoMovieRequestEnabled', label: 'Enable Automatic Movie Requests', children: ['autoMovieRequestTriggerOnStart', 'autoMovieRequestTriggerOnMinutesWatched', 'autoMovieRequestMinutesWatched', 'autoMovieRequestCheckReleaseDate', 'autoMovieRequestQualityMode', 'autoMovieRequestFallbackOn4k'] },
             { parent: 'autoSeasonRequestEnabled', label: 'Enable Automatic Season Requests', children: ['autoSeasonRequestRequireAllWatched', 'autoSeasonRequestThresholdValue'] },
             { parent: 'preventWatchlistReAddition', label: 'Prevent re-adding removed items', children: ['watchlistMemoryRetentionDays'] },
+            { parent: 'triggerSeerrScanOnItemAdded', label: 'Trigger Seerr scan on item added', children: ['seerrScanDebounceSeconds'] },
             { parent: 'bookmarksEnabled', label: 'Enable Bookmarks', children: ['bookmarksUsePluginPages', 'bookmarksUseCustomTabs'] },
             { parent: 'hiddenContentEnabled', label: 'Enable Hidden Content', children: ['hiddenContentUsePluginPages', 'hiddenContentUseCustomTabs'] }
         ];
@@ -6525,6 +6564,54 @@
             }
         });
         testJellyseerrBtn.addEventListener('click', testJellyseerrConnection);
+
+        async function triggerSeerrScanNow() {
+            const urls = (document.querySelector('#jellyseerrUrls').value || '').split('\n').map(u => u.trim()).filter(Boolean);
+            const apiKey = (document.querySelector('#JellyseerrApiKey').value || '').trim();
+            const btn = document.querySelector('#triggerSeerrScanNowBtn');
+            const status = document.querySelector('#triggerSeerrScanNowStatus');
+
+            if (!urls.length || !apiKey) {
+                Dashboard.alert({ title: 'Missing Information', message: 'Please provide at least one Seerr URL and an API key in the Setup section above.' });
+                return;
+            }
+
+            btn.disabled = true;
+            status.textContent = 'sync';
+            status.className = 'material-icons status-check';
+            status.style.color = '#00a4dc';
+
+            let triggered = false;
+            let lastError = '';
+            for (const url of urls) {
+                try {
+                    const triggerUrl = ApiClient.getUrl('/JellyfinEnhanced/jellyseerr/trigger-recently-added-scan', { url: url });
+                    const res = await ApiClient.ajax({ type: 'POST', url: triggerUrl, dataType: 'json', headers: { 'X-Arr-ApiKey': apiKey } });
+                    if (res && res.ok) {
+                        triggered = true;
+                        break;
+                    }
+                } catch (e) {
+                    console.error('Seerr scan trigger failed for ' + url + ':', e);
+                    lastError = connectionErrorMessage(e, 'Seerr', url);
+                }
+            }
+
+            btn.disabled = false;
+            status.classList.remove('status-check');
+
+            if (triggered) {
+                status.textContent = 'check_circle';
+                status.style.color = '#52b54b';
+                Dashboard.alert({ title: 'Scan Triggered', message: 'Seerr accepted the recently-added scan request.' });
+            } else {
+                status.textContent = 'error';
+                status.style.color = '#dc3545';
+                Dashboard.alert({ title: 'Trigger Failed', message: lastError || 'Could not trigger a scan against any provided URL.' });
+            }
+        }
+
+        document.querySelector('#triggerSeerrScanNowBtn').addEventListener('click', triggerSeerrScanNow);
 
         /**
          * Quick Action: re-test every external-service connection by proxying

--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -697,6 +697,56 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
             }
         }
 
+        // Manually trigger Seerr's recently-added library scan against a single URL.
+        // Used by the admin "Trigger scan now" button so the test runs against the
+        // values currently in the form (which may not be saved yet), exactly like
+        // the validate endpoint above.
+        [HttpPost("jellyseerr/trigger-recently-added-scan")]
+        [Authorize]
+        public async Task<IActionResult> TriggerJellyseerrRecentlyAddedScan([FromQuery] string url, [FromHeader(Name = "X-Arr-ApiKey")] string apiKey)
+        {
+            if (!IsAdminUser())
+            {
+                return Forbid();
+            }
+
+            if (string.IsNullOrWhiteSpace(url) || string.IsNullOrWhiteSpace(apiKey))
+                return BadRequest(new { ok = false, message = "Missing url or apiKey" });
+
+            if (!IsAllowedUrl(url))
+                return BadRequest(new { ok = false, message = "Invalid URL" });
+
+            var http = _httpClientFactory.CreateClient();
+            http.DefaultRequestHeaders.Clear();
+            http.Timeout = TimeSpan.FromSeconds(15);
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, $"{url.TrimEnd('/')}/api/v1/settings/jobs/jellyfin-recently-added-scan/run")
+                {
+                    Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                };
+                request.Headers.Add("X-Api-Key", apiKey);
+
+                using var resp = await http.SendAsync(request);
+                if (resp.IsSuccessStatusCode)
+                {
+                    _logger.Info($"[SeerrScan] Manually triggered Seerr recently-added scan via admin button — {url}");
+                    return Ok(new { ok = true });
+                }
+
+                var body = await resp.Content.ReadAsStringAsync();
+                var snippet = body.Length > 256 ? body.Substring(0, 256) + "…" : body;
+                _logger.Warning($"[SeerrScan] Manual trigger failed for {url}: HTTP {(int)resp.StatusCode} — {snippet}");
+                return StatusCode((int)resp.StatusCode, new { ok = false, message = $"Seerr returned {(int)resp.StatusCode}" });
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning($"[SeerrScan] Manual trigger threw for {url}: {ex.Message}");
+                return StatusCode(502, new { ok = false, message = "Unable to reach Seerr" });
+            }
+        }
+
         [HttpGet("jellyseerr/user-status")]
         [Authorize]
         public async Task<IActionResult> GetJellyseerrUserStatus()

--- a/Jellyfin.Plugin.JellyfinEnhanced/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/PluginServiceRegistrator.cs
@@ -24,6 +24,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced
             serviceCollection.AddSingleton<AutoMovieRequestService>();
             serviceCollection.AddSingleton<AutoMovieRequestMonitor>();
             serviceCollection.AddSingleton<WatchlistMonitor>();
+            serviceCollection.AddSingleton<SeerrScanTriggerService>();
             serviceCollection.AddSingleton<TagCacheService>();
             serviceCollection.AddSingleton<TagCacheMonitor>();
             serviceCollection.AddTransient<ArrTagsSyncTask>();

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/SeerrScanTriggerService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/SeerrScanTriggerService.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.JellyfinEnhanced.Configuration;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.JellyfinEnhanced.Services
+{
+    // Debounced bridge from Jellyfin's library ItemAdded event to Seerr's
+    // /api/v1/settings/jobs/jellyfin-recently-added-scan/run endpoint, so admins can
+    // disable Seerr's 5-minute cron and have the scan run only when Jellyfin actually
+    // ingests new content.
+    public class SeerrScanTriggerService : IDisposable
+    {
+        private const string ScanJobId = "jellyfin-recently-added-scan";
+        private const int MinDebounceSeconds = 5;
+        private const int MaxDebounceSeconds = 3600;
+
+        private readonly ILibraryManager _libraryManager;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly Logger _logger;
+
+        private readonly object _stateLock = new();
+        private readonly Timer _debounceTimer;
+        private int _pendingCount;
+        private bool _subscribed;
+        private bool _disposed;
+
+        public SeerrScanTriggerService(
+            ILibraryManager libraryManager,
+            IHttpClientFactory httpClientFactory,
+            Logger logger)
+        {
+            _libraryManager = libraryManager;
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+            _debounceTimer = new Timer(OnDebounceElapsed, null, Timeout.Infinite, Timeout.Infinite);
+        }
+
+        public void Initialize()
+        {
+            // Always subscribe; the per-event handler re-checks config at fire time so
+            // an admin toggling the feature on doesn't require a Jellyfin restart.
+            // Mirrors the WatchlistMonitor pattern.
+            lock (_stateLock)
+            {
+                if (_subscribed) return;
+                _libraryManager.ItemAdded += OnItemAdded;
+                _subscribed = true;
+            }
+            _logger.Info("[SeerrScan] Subscribed to library ItemAdded events");
+        }
+
+        private void OnItemAdded(object? sender, ItemChangeEventArgs e)
+        {
+            try
+            {
+                if (JellyfinEnhanced.Instance?.Configuration is not PluginConfiguration config) return;
+                if (!config.TriggerSeerrScanOnItemAdded) return;
+                if (!config.JellyseerrEnabled) return;
+
+                // Seerr's recently-added scan only inspects movies and series (and crawls
+                // their seasons/episodes itself). Filtering on the parent kinds avoids
+                // triggering on metadata noise (BoxSet, Folder, Audio, Photo, etc).
+                var kind = e.Item?.GetBaseItemKind();
+                if (kind != BaseItemKind.Movie
+                    && kind != BaseItemKind.Series
+                    && kind != BaseItemKind.Season
+                    && kind != BaseItemKind.Episode)
+                {
+                    return;
+                }
+
+                var debounce = ClampDebounceSeconds(config.SeerrScanDebounceSeconds);
+                lock (_stateLock)
+                {
+                    if (_disposed) return;
+                    _pendingCount++;
+                    // Reset the timer on every event — the actual POST runs `debounce`
+                    // seconds after the LAST event in the burst.
+                    _debounceTimer.Change(TimeSpan.FromSeconds(debounce), Timeout.InfiniteTimeSpan);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning($"[SeerrScan] OnItemAdded handler threw: {ex.Message}");
+            }
+        }
+
+        private void OnDebounceElapsed(object? state)
+        {
+            int batchSize;
+            lock (_stateLock)
+            {
+                if (_disposed) return;
+                batchSize = Interlocked.Exchange(ref _pendingCount, 0);
+            }
+            if (batchSize <= 0) return;
+
+            // Fire-and-forget; the timer thread should not block on HTTP.
+            _ = DispatchAsync(batchSize);
+        }
+
+        // Public so the admin "Trigger scan now" button (controller endpoint) can
+        // bypass the debounce and force a scan immediately.
+        public Task<IReadOnlyList<DispatchResult>> TriggerNowAsync()
+        {
+            return DispatchAsync(0);
+        }
+
+        private async Task<IReadOnlyList<DispatchResult>> DispatchAsync(int batchSize)
+        {
+            var results = new List<DispatchResult>();
+            try
+            {
+                if (JellyfinEnhanced.Instance?.Configuration is not PluginConfiguration config)
+                {
+                    _logger.Warning("[SeerrScan] Cannot dispatch: plugin configuration is null");
+                    return results;
+                }
+
+                var apiKey = config.JellyseerrApiKey;
+                var urls = ParseUrls(config.JellyseerrUrls);
+                if (urls.Count == 0 || string.IsNullOrEmpty(apiKey))
+                {
+                    _logger.Warning("[SeerrScan] Cannot dispatch: Seerr URL(s) or API key not configured");
+                    return results;
+                }
+
+                foreach (var url in urls)
+                {
+                    var result = await PostScanTrigger(url, apiKey).ConfigureAwait(false);
+                    results.Add(result);
+                    if (result.Success)
+                    {
+                        if (batchSize > 0)
+                            _logger.Info($"[SeerrScan] Triggered Seerr recently-added scan after {batchSize} library item(s) — {url}");
+                        else
+                            _logger.Info($"[SeerrScan] Triggered Seerr recently-added scan (manual) — {url}");
+                    }
+                    else
+                    {
+                        _logger.Warning($"[SeerrScan] Trigger failed for {url}: HTTP {result.StatusCode} — {result.Body}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error($"[SeerrScan] Dispatch threw: {ex.Message}");
+            }
+            return results;
+        }
+
+        private async Task<DispatchResult> PostScanTrigger(string url, string apiKey)
+        {
+            var endpoint = $"{url.TrimEnd('/')}/api/v1/settings/jobs/{ScanJobId}/run";
+            try
+            {
+                var http = _httpClientFactory.CreateClient();
+                http.Timeout = TimeSpan.FromSeconds(15);
+                using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+                {
+                    Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                };
+                request.Headers.Add("X-Api-Key", apiKey);
+
+                using var response = await http.SendAsync(request).ConfigureAwait(false);
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                return new DispatchResult
+                {
+                    Url = url,
+                    Success = response.IsSuccessStatusCode,
+                    StatusCode = (int)response.StatusCode,
+                    Body = Truncate(body, 256)
+                };
+            }
+            catch (Exception ex)
+            {
+                return new DispatchResult
+                {
+                    Url = url,
+                    Success = false,
+                    StatusCode = 0,
+                    Body = ex.Message
+                };
+            }
+        }
+
+        private static List<string> ParseUrls(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw)) return new List<string>();
+            return raw
+                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(u => u.Trim())
+                .Where(u => !string.IsNullOrEmpty(u))
+                .ToList();
+        }
+
+        private static int ClampDebounceSeconds(int requested)
+        {
+            if (requested < MinDebounceSeconds) return MinDebounceSeconds;
+            if (requested > MaxDebounceSeconds) return MaxDebounceSeconds;
+            return requested;
+        }
+
+        private static string Truncate(string s, int max)
+        {
+            if (string.IsNullOrEmpty(s)) return string.Empty;
+            return s.Length <= max ? s : s.Substring(0, max) + "…";
+        }
+
+        public void Dispose()
+        {
+            lock (_stateLock)
+            {
+                if (_disposed) return;
+                _disposed = true;
+                if (_subscribed)
+                {
+                    _libraryManager.ItemAdded -= OnItemAdded;
+                    _subscribed = false;
+                }
+                _debounceTimer.Dispose();
+            }
+            GC.SuppressFinalize(this);
+        }
+
+        public class DispatchResult
+        {
+            public string Url { get; set; } = string.Empty;
+            public bool Success { get; set; }
+            public int StatusCode { get; set; }
+            public string Body { get; set; } = string.Empty;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/StartupService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/StartupService.cs
@@ -24,13 +24,14 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         private readonly WatchlistMonitor _watchlistMonitor;
         private readonly TagCacheService _tagCacheService;
         private readonly TagCacheMonitor _tagCacheMonitor;
+        private readonly SeerrScanTriggerService _seerrScanTriggerService;
 
         public string Name => "Jellyfin Enhanced Startup";
         public string Key => "JellyfinEnhancedStartup";
         public string Description => "Injects the Jellyfin Enhanced script using the File Transformation plugin and performs necessary cleanups.";
         public string Category => "Jellyfin Enhanced";
 
-        public StartupService(Logger logger, IApplicationPaths applicationPaths, AutoSeasonRequestMonitor autoSeasonRequestMonitor, AutoMovieRequestMonitor autoMovieRequestMonitor, WatchlistMonitor watchlistMonitor, TagCacheService tagCacheService, TagCacheMonitor tagCacheMonitor)
+        public StartupService(Logger logger, IApplicationPaths applicationPaths, AutoSeasonRequestMonitor autoSeasonRequestMonitor, AutoMovieRequestMonitor autoMovieRequestMonitor, WatchlistMonitor watchlistMonitor, TagCacheService tagCacheService, TagCacheMonitor tagCacheMonitor, SeerrScanTriggerService seerrScanTriggerService)
         {
             _logger = logger;
             _applicationPaths = applicationPaths;
@@ -39,6 +40,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             _watchlistMonitor = watchlistMonitor;
             _tagCacheService = tagCacheService;
             _tagCacheMonitor = tagCacheMonitor;
+            _seerrScanTriggerService = seerrScanTriggerService;
         }
 
         public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
@@ -56,6 +58,9 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
 
                 // Initialize watchlist monitoring
                 _watchlistMonitor.Initialize();
+
+                // Initialize on-demand Seerr recently-added scan trigger
+                _seerrScanTriggerService.Initialize();
 
                 // Load tag cache from disk. New/changed items are picked up by the
                 // monitor via Jellyfin's library scan events (ItemAdded/ItemUpdated).


### PR DESCRIPTION
## What

Adds an opt-in admin setting that POSTs to Seerr's `/api/v1/settings/jobs/jellyfin-recently-added-scan/run` endpoint when Jellyfin reports new library items, debounced so a bulk import collapses into a single trigger.

This lets admins disable Seerr's 5-minute cron for that job and have it run only when Jellyfin actually ingests new content, while keeping Seerr's "Available" status fresh in near-real-time.

## How

- New `SeerrScanTriggerService` subscribes to `ILibraryManager.ItemAdded`, filters to Movie/Series/Season/Episode, and resets a single `Timer` on every event so all events in a burst collapse into one POST.
- Config is re-checked at fire time so toggling the feature on/off doesn't require a Jellyfin restart (mirrors the existing `WatchlistMonitor` pattern).
- Reuses existing `JellyseerrUrls` / `JellyseerrApiKey` from the Setup section. Fans out to every configured URL since each Seerr instance maintains its own library mirror.
- New `POST /JellyfinEnhanced/jellyseerr/trigger-recently-added-scan` endpoint backs the admin "Trigger scan now" button. Same auth + SSRF guard pattern as the existing `/jellyseerr/validate` endpoint.
- New "Library Sync to Seerr" fieldset on the admin config page with toggle, debounce input (5 to 3600s, default 60), and trigger button. `PARENT_DEPS` auto-greys the debounce when the toggle is off.

## Files

- `Configuration/PluginConfiguration.cs` (+7) — `TriggerSeerrScanOnItemAdded`, `SeerrScanDebounceSeconds`
- `Services/SeerrScanTriggerService.cs` (new, ~240 lines)
- `PluginServiceRegistrator.cs` (+1) — register singleton
- `Services/StartupService.cs` (+5) — initialize alongside other monitors
- `Controllers/JellyfinEnhancedController.cs` (+50) — trigger-now endpoint
- `Configuration/configPage.html` (+87) — fieldset, load/save, PARENT_DEPS, button handler

## Localization

Admin config page is English-only by convention (zero `JE.t` calls in `configPage.html`), so no locale files were touched.

## Disclosure

This PR was developed with AI assistance (Claude). All changes have been reviewed, tested, and understood.

## Testing

- [x] Built with `dotnet build` against current upstream main (584f442) — 0 warnings, 0 errors
- [x] Deployed and tested on jellyfin-dev (Jellyfin 10.11.x)
- [x] Plugin loads cleanly; `[SeerrScan] Subscribed to library ItemAdded events` on startup
- [x] Config UI: new fieldset renders; PARENT_DEPS greys/restores the debounce input correctly
- [x] Save + real reload roundtrip persists both settings
- [x] Save-clamping: debounce values below 5 clamp to 60 (default), values above 3600 clamp to 3600
- [x] "Trigger scan now" against bogus URL returns clean 502 + red status icon + alert
- [x] "Trigger scan now" with empty fields shows "Missing Information" alert without hitting backend
- [x] No browser-native dialogs (regression check)
- [x] **Real end-to-end:** triggered Sonarr to download Bluey S02E01, file landed in Jellyfin, `ItemAdded` fired 218 times across the import, debounce collapsed them into a single POST, Seerr accepted it (`Starting scheduled job: Jellyfin Recently Added Scan`) and completed the scan ~12s later