### PR TITLE
feat: user reviews for seasons/episodes + average rating on posters and item details

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
@@ -55,6 +55,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             ReviewsExpandedByDefault = false;
             HideReviewsFromHiddenUsers = true;
             HideReviewsFromDisabledUsers = true;
+            ShowUserRatingDash = true;
             PauseScreenEnabled = true;
             QualityTagsEnabled = false;
             ShowResolutionTag = true;
@@ -311,6 +312,11 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public bool ReviewsExpandedByDefault { get; set; }
         public bool HideReviewsFromHiddenUsers { get; set; } = true;
         public bool HideReviewsFromDisabledUsers { get; set; } = true;
+        /// <summary>
+        /// When true (default), shows a "—" on poster cards for items the user hasn't rated yet.
+        /// When false, the person_heart chip is hidden entirely for unrated items.
+        /// </summary>
+        public bool ShowUserRatingDash { get; set; } = true;
         public List<Shortcut> Shortcuts { get; set; }
         public bool PauseScreenEnabled { get; set; }
         public int PauseScreenDelaySeconds { get; set; } = 5;

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
@@ -55,6 +55,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             ReviewsExpandedByDefault = false;
             HideReviewsFromHiddenUsers = true;
             HideReviewsFromDisabledUsers = true;
+            ShowUserRatingOnPosters = false;
             ShowUserRatingDash = true;
             PauseScreenEnabled = true;
             QualityTagsEnabled = false;
@@ -312,6 +313,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public bool ReviewsExpandedByDefault { get; set; }
         public bool HideReviewsFromHiddenUsers { get; set; } = true;
         public bool HideReviewsFromDisabledUsers { get; set; } = true;
+        public bool ShowUserRatingOnPosters { get; set; } = false;
         /// <summary>
         /// When true (default), shows a "—" on poster cards for items the user hasn't rated yet.
         /// When false, the person_heart chip is hidden entirely for unrated items.

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -1707,6 +1707,10 @@
                             <div class="je-setting-description" data-desc-for="hideReviewsFromDisabledUsers">
                                 <div class="fieldDescription je-field-desc-sm-font-lg">When enabled, reviews written by Jellyfin users marked as "Disable this user" are hidden from non-admin viewers. Admins always see all reviews.</div>
                             </div>
+                            <div class="checkboxContainer"><label><input id="showUserRatingDash" is="emby-checkbox" type="checkbox"/><span>Show "—" on posters for unrated items</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showUserRatingDash">
+                                <div class="fieldDescription je-field-desc-sm-font-lg">When Rating Tags are enabled, a <span class="material-icons" style="font-size:14px;vertical-align:middle;color:#e91e8c;">person_heart</span> chip appears on every poster. Enable this to show "—" for items the user hasn't rated yet. Disable to hide the chip entirely for unrated items.</div>
+                            </div>
                         </div>
                     </fieldset>
                 </div>
@@ -4014,6 +4018,7 @@
                 document.querySelector('#reviewsExpandedByDefault').checked = config.ReviewsExpandedByDefault;
                 document.querySelector('#hideReviewsFromHiddenUsers').checked = config.HideReviewsFromHiddenUsers !== false;
                 document.querySelector('#hideReviewsFromDisabledUsers').checked = config.HideReviewsFromDisabledUsers !== false;
+                document.querySelector('#showUserRatingDash').checked = config.ShowUserRatingDash !== false;
                 document.querySelector('#jellyseerrEnabled').checked = config.JellyseerrEnabled;
                 document.querySelector('#showCollectionsInSearch').checked = config.ShowCollectionsInSearch !== false;
                 document.querySelector('#jellyseerrShowSearchResults').checked = config.JellyseerrShowSearchResults !== false;
@@ -4283,6 +4288,7 @@
             config.ReviewsExpandedByDefault = document.querySelector('#reviewsExpandedByDefault').checked;
             config.HideReviewsFromHiddenUsers = document.querySelector('#hideReviewsFromHiddenUsers').checked;
             config.HideReviewsFromDisabledUsers = document.querySelector('#hideReviewsFromDisabledUsers').checked;
+            config.ShowUserRatingDash = document.querySelector('#showUserRatingDash').checked;
             config.JellyseerrEnabled = document.querySelector('#jellyseerrEnabled').checked;
             config.JellyseerrShowSearchResults = document.querySelector('#jellyseerrShowSearchResults').checked;
             config.ShowCollectionsInSearch = document.querySelector('#showCollectionsInSearch').checked;
@@ -5274,7 +5280,7 @@
         var PARENT_DEPS = [
             { parent: 'elsewhereEnabled', label: 'Enable Elsewhere', children: ['DEFAULT_REGION', 'DEFAULT_PROVIDERS', 'IGNORE_PROVIDERS', 'ElsewhereCustomBrandingText', 'ElsewhereCustomBrandingImageUrl', 'showReviews', 'reviewsExpandedByDefault'] },
             { parent: 'showReviews', label: 'Show Reviews', children: ['reviewsExpandedByDefault'] },
-            { parent: 'showUserReviews', label: 'Enable User Reviews', children: ['hideReviewsFromHiddenUsers', 'hideReviewsFromDisabledUsers'] },
+            { parent: 'showUserReviews', label: 'Enable User Reviews', children: ['hideReviewsFromHiddenUsers', 'hideReviewsFromDisabledUsers', 'showUserRatingDash'] },
             { parent: 'randomButtonEnabled', label: 'Enable Random Button', children: ['randomUnwatchedOnly', 'randomIncludeMovies', 'randomIncludeShows'] },
             { parent: 'showWatchProgress', label: 'Show watch progress', children: ['watchProgressDefaultMode', 'watchProgressTimeFormat'] },
             { parent: 'qualityTagsEnabled', label: 'Enable Quality Tags', children: ['qualityTagsPosition', 'showResolutionTag', 'showSourceTag', 'showDynamicRangeTag', 'showSpecialFormatTag', 'showVideoCodecTag', 'showAudioInfoTag'], noHint: true },

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -1707,6 +1707,10 @@
                             <div class="je-setting-description" data-desc-for="hideReviewsFromDisabledUsers">
                                 <div class="fieldDescription je-field-desc-sm-font-lg">When enabled, reviews written by Jellyfin users marked as "Disable this user" are hidden from non-admin viewers. Admins always see all reviews.</div>
                             </div>
+                            <div class="checkboxContainer"><label><input id="showUserRatingOnPosters" is="emby-checkbox" type="checkbox"/><span>Show average user rating on poster cards</span></label></div>
+                            <div class="je-setting-description" data-desc-for="showUserRatingOnPosters">
+                                <div class="fieldDescription je-field-desc-sm-font-lg">When Rating Tags are enabled, overlay a <span class="material-icons" style="font-size:14px;vertical-align:middle;color:#e91e8c;">person_heart</span> chip on poster cards showing the average rating from all user reviews.</div>
+                            </div>
                             <div class="checkboxContainer"><label><input id="showUserRatingDash" is="emby-checkbox" type="checkbox"/><span>Show "—" on posters for unrated items</span></label></div>
                             <div class="je-setting-description" data-desc-for="showUserRatingDash">
                                 <div class="fieldDescription je-field-desc-sm-font-lg">When Rating Tags are enabled, a <span class="material-icons" style="font-size:14px;vertical-align:middle;color:#e91e8c;">person_heart</span> chip appears on every poster. Enable this to show "—" for items the user hasn't rated yet. Disable to hide the chip entirely for unrated items.</div>
@@ -4019,6 +4023,7 @@
                 document.querySelector('#hideReviewsFromHiddenUsers').checked = config.HideReviewsFromHiddenUsers !== false;
                 document.querySelector('#hideReviewsFromDisabledUsers').checked = config.HideReviewsFromDisabledUsers !== false;
                 document.querySelector('#showUserRatingDash').checked = config.ShowUserRatingDash !== false;
+                document.querySelector('#showUserRatingOnPosters').checked = config.ShowUserRatingOnPosters === true;
                 document.querySelector('#jellyseerrEnabled').checked = config.JellyseerrEnabled;
                 document.querySelector('#showCollectionsInSearch').checked = config.ShowCollectionsInSearch !== false;
                 document.querySelector('#jellyseerrShowSearchResults').checked = config.JellyseerrShowSearchResults !== false;
@@ -4289,6 +4294,7 @@
             config.HideReviewsFromHiddenUsers = document.querySelector('#hideReviewsFromHiddenUsers').checked;
             config.HideReviewsFromDisabledUsers = document.querySelector('#hideReviewsFromDisabledUsers').checked;
             config.ShowUserRatingDash = document.querySelector('#showUserRatingDash').checked;
+            config.ShowUserRatingOnPosters = document.querySelector('#showUserRatingOnPosters').checked;
             config.JellyseerrEnabled = document.querySelector('#jellyseerrEnabled').checked;
             config.JellyseerrShowSearchResults = document.querySelector('#jellyseerrShowSearchResults').checked;
             config.ShowCollectionsInSearch = document.querySelector('#showCollectionsInSearch').checked;
@@ -5280,7 +5286,7 @@
         var PARENT_DEPS = [
             { parent: 'elsewhereEnabled', label: 'Enable Elsewhere', children: ['DEFAULT_REGION', 'DEFAULT_PROVIDERS', 'IGNORE_PROVIDERS', 'ElsewhereCustomBrandingText', 'ElsewhereCustomBrandingImageUrl', 'showReviews', 'reviewsExpandedByDefault'] },
             { parent: 'showReviews', label: 'Show Reviews', children: ['reviewsExpandedByDefault'] },
-            { parent: 'showUserReviews', label: 'Enable User Reviews', children: ['hideReviewsFromHiddenUsers', 'hideReviewsFromDisabledUsers', 'showUserRatingDash'] },
+            { parent: 'showUserReviews', label: 'Enable User Reviews', children: ['hideReviewsFromHiddenUsers', 'hideReviewsFromDisabledUsers', 'showUserRatingDash', 'showUserRatingOnPosters'] },
             { parent: 'randomButtonEnabled', label: 'Enable Random Button', children: ['randomUnwatchedOnly', 'randomIncludeMovies', 'randomIncludeShows'] },
             { parent: 'showWatchProgress', label: 'Show watch progress', children: ['watchProgressDefaultMode', 'watchProgressTimeFormat'] },
             { parent: 'qualityTagsEnabled', label: 'Enable Quality Tags', children: ['qualityTagsPosition', 'showResolutionTag', 'showSourceTag', 'showDynamicRangeTag', 'showSpecialFormatTag', 'showVideoCodecTag', 'showAudioInfoTag'], noHint: true },

--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -2226,6 +2226,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                 config.ReviewsExpandedByDefault,
                 config.HideReviewsFromHiddenUsers,
                 config.HideReviewsFromDisabledUsers,
+                config.ShowUserRatingOnPosters,
                 config.ShowUserRatingDash,
                 config.PauseScreenEnabled,
                 config.QualityTagsEnabled,

--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -2226,6 +2226,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                 config.ReviewsExpandedByDefault,
                 config.HideReviewsFromHiddenUsers,
                 config.HideReviewsFromDisabledUsers,
+                config.ShowUserRatingDash,
                 config.PauseScreenEnabled,
                 config.QualityTagsEnabled,
                 config.ShowResolutionTag,
@@ -3179,6 +3180,13 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
         private static readonly System.Text.RegularExpressions.Regex _tmdbIdRegex =
             new System.Text.RegularExpressions.Regex(@"^\d+$", System.Text.RegularExpressions.RegexOptions.Compiled);
 
+        // Extended key for season/episode reviews: {tmdbId}:s{n} or {tmdbId}:s{n}e{n}
+        private static readonly System.Text.RegularExpressions.Regex _tmdbIdExtendedRegex =
+            new System.Text.RegularExpressions.Regex(@"^\d+(:s\d+(:e\d+)?)?$", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        private static bool IsValidTmdbKey(string tmdbId) =>
+            !string.IsNullOrWhiteSpace(tmdbId) && _tmdbIdExtendedRegex.IsMatch(tmdbId);
+
         /// <summary>
         /// Returns all user-written reviews for a specific TMDB item,
         /// enriched with each reviewer's display name.
@@ -3191,7 +3199,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
             if (mediaType != "movie" && mediaType != "tv")
                 return BadRequest(new { message = "MediaType must be 'movie' or 'tv'." });
 
-            if (string.IsNullOrWhiteSpace(tmdbId) || !_tmdbIdRegex.IsMatch(tmdbId))
+            if (!IsValidTmdbKey(tmdbId))
                 return BadRequest(new { message = "Invalid TmdbId." });
 
             var config = JellyfinEnhanced.Instance?.Configuration;
@@ -3318,7 +3326,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
             if (mediaType != "movie" && mediaType != "tv")
                 return BadRequest(new { success = false, message = "MediaType must be 'movie' or 'tv'." });
 
-            if (string.IsNullOrWhiteSpace(tmdbId) || !_tmdbIdRegex.IsMatch(tmdbId))
+            if (!IsValidTmdbKey(tmdbId))
                 return BadRequest(new { success = false, message = "Invalid TmdbId." });
 
             if (payload == null)
@@ -3365,7 +3373,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
             if (mediaType != "movie" && mediaType != "tv")
                 return BadRequest(new { success = false, message = "MediaType must be 'movie' or 'tv'." });
 
-            if (string.IsNullOrWhiteSpace(tmdbId) || !_tmdbIdRegex.IsMatch(tmdbId))
+            if (!IsValidTmdbKey(tmdbId))
                 return BadRequest(new { success = false, message = "Invalid TmdbId." });
 
             var currentUserId = UserHelper.GetCurrentUserId(User);
@@ -3400,7 +3408,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
             if (mediaType != "movie" && mediaType != "tv")
                 return BadRequest(new { success = false, message = "MediaType must be 'movie' or 'tv'." });
 
-            if (string.IsNullOrWhiteSpace(tmdbId) || !_tmdbIdRegex.IsMatch(tmdbId))
+            if (!IsValidTmdbKey(tmdbId))
                 return BadRequest(new { success = false, message = "Invalid TmdbId." });
 
             if (string.IsNullOrWhiteSpace(userIdN) || !Guid.TryParseExact(userIdN, "N", out _))

--- a/Jellyfin.Plugin.JellyfinEnhanced/Model/TagCacheEntry.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Model/TagCacheEntry.cs
@@ -9,6 +9,13 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Model
     public class TagCacheEntry
     {
         public string? Type { get; set; }
+        public string? TmdbId { get; set; }
+        /// <summary>For Season/Episode: the parent Series TMDB ID.</summary>
+        public string? SeriesTmdbId { get; set; }
+        /// <summary>For Season/Episode: season number for building the review key.</summary>
+        public int? SeasonNumber { get; set; }
+        /// <summary>For Episode: episode number for building the review key.</summary>
+        public int? EpisodeNumber { get; set; }
         public string[]? Genres { get; set; }
         public float? CommunityRating { get; set; }
         public float? CriticRating { get; set; }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
@@ -295,6 +295,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                 var entry = new TagCacheEntry
                 {
                     Type = kind.ToString(),
+                    TmdbId = item.ProviderIds?.TryGetValue("Tmdb", out var tmdbId) == true ? tmdbId : null,
                     Genres = item.Genres,
                     CommunityRating = item.CommunityRating,
                     CriticRating = item.CriticRating,
@@ -335,6 +336,15 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                             }
                         }
                     }
+
+                    // For Season: store parent series TMDB ID + season number for user review key
+                    if (kind == BaseItemKind.Season && item is MediaBrowser.Controller.Entities.TV.Season season)
+                    {
+                        var series = GetParentSeries(item);
+                        if (series?.ProviderIds?.TryGetValue("Tmdb", out var seriesTmdb) == true)
+                            entry.SeriesTmdbId = seriesTmdb;
+                        entry.SeasonNumber = season.IndexNumber;
+                    }
                 }
                 else
                 {
@@ -356,6 +366,16 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                             entry.CommunityRating = series.CommunityRating;
                             entry.CriticRating = series.CriticRating;
                         }
+                    }
+
+                    // For Episode: store parent series TMDB ID + season/episode numbers for user review key
+                    if (kind == BaseItemKind.Episode && item is MediaBrowser.Controller.Entities.TV.Episode ep)
+                    {
+                        var series = GetParentSeries(item);
+                        if (series?.ProviderIds?.TryGetValue("Tmdb", out var seriesTmdb) == true)
+                            entry.SeriesTmdbId = seriesTmdb;
+                        entry.SeasonNumber = ep.ParentIndexNumber;
+                        entry.EpisodeNumber = ep.IndexNumber;
                     }
                 }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
@@ -1018,7 +1018,7 @@
 
                     // Resolve tmdbKey and apiMediaType based on item type
                     let tmdbKey = null;
-                    let apiMediaType = 'movie';
+                    let apiMediaType;
 
                     if (mediaType === 'Movie') {
                         const tmdbId = item?.ProviderIds?.Tmdb;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
@@ -32,8 +32,8 @@
          * Fetches all user-written reviews for a TMDB item (aggregated across all users).
          */
         function fetchUserReviews(tmdbId, mediaType) {
-            const apiMediaType = mediaType === 'Series' ? 'tv' : 'movie';
-            const url = ApiClient.getUrl(`/JellyfinEnhanced/reviews/${apiMediaType}/${tmdbId}`);
+            // mediaType is already in API format ('movie' or 'tv') — no conversion needed
+            const url = ApiClient.getUrl(`/JellyfinEnhanced/reviews/${mediaType}/${tmdbId}`);
             return fetch(url, {
                 headers: { "X-Emby-Token": ApiClient.accessToken() }
             })
@@ -311,7 +311,7 @@
             }) : '';
 
             const rating = review.author_details?.rating;
-            const ratingDisplay = rating ? `<span class="tmdb-review-rating">${JE.icon(JE.IconName.STAR)} ${rating}/10</span>` : '';
+            const ratingDisplay = rating ? `<span class="tmdb-review-rating">${JE.icon(JE.IconName.STAR)} ${rating}</span>` : '';
 
             reviewCard.innerHTML = `
                 <div class="tmdb-review-header">
@@ -528,21 +528,29 @@
                 const ratingsWithValue = userReviews.filter(r => r.rating);
                 if (ratingsWithValue.length > 0) {
                     const avg = ratingsWithValue.reduce((sum, r) => sum + r.rating, 0) / ratingsWithValue.length;
-                    const avgDisplay = (avg * 2).toFixed(1); // convert 1-5 → /10
+                    const raw = avg * 2; // convert 1-5 → raw out of 10
+                    const avgDisplay = Number.isInteger(raw) ? `${raw}` : `${raw.toFixed(1)}`;
 
                     // Remove any existing chip first
                     contextPage.querySelector('.je-avg-user-rating-chip')?.remove();
 
                     const chip = document.createElement('div');
-                    chip.className = 'mediaInfoItem je-avg-user-rating-chip';
+                    chip.className = 'mediaInfoCriticRating mediaInfoItem je-avg-user-rating-chip';
                     chip.title = tWithFallback('reviews_avg_rating_tooltip',
                         '{count} user rating(s)', { count: ratingsWithValue.length });
-                    chip.innerHTML = `<span class="material-icons" style="font-size:16px;vertical-align:middle;color:#e91e8c;margin-right:3px;">person_heart</span><span>${avgDisplay}/10</span>`;
+                    chip.innerHTML = `<span class="material-icons starIcon" aria-hidden="true" style="color:#e91e8c;">person_heart</span>${avgDisplay}`;
 
-                    // Insert into starRatingContainer if present, else mediaInfoItems
-                    const ratingContainer = contextPage.querySelector('.starRatingContainer') ||
-                        contextPage.querySelector('.mediaInfoItems');
-                    if (ratingContainer) ratingContainer.appendChild(chip);
+                    // Insert after starRatingContainer, or after mediaInfoCriticRating if present,
+                    // falling back to appending to the mediaInfoItems container
+                    const criticRating = contextPage.querySelector('.mediaInfoCriticRating');
+                    const starRating = contextPage.querySelector('.starRatingContainer');
+                    const anchor = criticRating || starRating;
+                    if (anchor && anchor.parentNode) {
+                        anchor.parentNode.insertBefore(chip, anchor.nextSibling);
+                    } else {
+                        const container = contextPage.querySelector('.mediaInfoItems');
+                        if (container) container.appendChild(chip);
+                    }
                 }
             }
 
@@ -772,14 +780,26 @@
                     tmdbKey = String(tmdbId);
                     apiMediaType = 'tv';
                 } else if (mediaType === 'Season') {
-                    const seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
-                    if (!seriesTmdbId || item?.IndexNumber == null) return;
-                    tmdbKey = `${seriesTmdbId}:s${item.IndexNumber}`;
-                    apiMediaType = 'tv';
-                } else if (mediaType === 'Episode') {
-                    const seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
-                    if (!seriesTmdbId || item?.ParentIndexNumber == null || item?.IndexNumber == null) return;
-                    tmdbKey = `${seriesTmdbId}:s${item.ParentIndexNumber}:e${item.IndexNumber}`;
+                        let seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
+                        if (!seriesTmdbId && item?.SeriesId) {
+                            try {
+                                const series = await ApiClient.getItem(userId, item.SeriesId);
+                                seriesTmdbId = series?.ProviderIds?.Tmdb;
+                            } catch (_) {}
+                        }
+                        if (!seriesTmdbId || item?.IndexNumber == null) return;
+                        tmdbKey = `${seriesTmdbId}:s${item.IndexNumber}`;
+                        apiMediaType = 'tv';
+                    } else if (mediaType === 'Episode') {
+                        let seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
+                        if (!seriesTmdbId && item?.SeriesId) {
+                            try {
+                                const series = await ApiClient.getItem(userId, item.SeriesId);
+                                seriesTmdbId = series?.ProviderIds?.Tmdb;
+                            } catch (_) {}
+                        }
+                        if (!seriesTmdbId || item?.ParentIndexNumber == null || item?.IndexNumber == null) return;
+                        tmdbKey = `${seriesTmdbId}:s${item.ParentIndexNumber}:e${item.IndexNumber}`;
                     apiMediaType = 'tv';
                 } else {
                     return;
@@ -974,15 +994,9 @@
                 .je-review-form-error { color: rgb(244, 67, 54); font-size: 0.85em; min-height: 1em; }
 
                 /* Average user rating chip in item details */
-                .je-avg-user-rating-chip {
-                    display: inline-flex;
-                    align-items: center;
-                    gap: 2px;
-                    color: #e91e8c;
-                    font-size: 0.9em;
-                    font-weight: 600;
-                    cursor: default;
-                }
+                .je-avg-user-rating-chip .starIcon { color: #e91e8c !important; }
+                /* Remove the padding coming from using critic rating container */
+                .je-avg-user-rating-chip { padding-left: 0 !important; }
             `;
             document.head.appendChild(style);
         }
@@ -1017,12 +1031,24 @@
                         tmdbKey = String(tmdbId);
                         apiMediaType = 'tv';
                     } else if (mediaType === 'Season') {
-                        const seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
+                        let seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
+                        if (!seriesTmdbId && item?.SeriesId) {
+                            try {
+                                const series = await ApiClient.getItem(userId, item.SeriesId);
+                                seriesTmdbId = series?.ProviderIds?.Tmdb;
+                            } catch (_) {}
+                        }
                         if (!seriesTmdbId || item?.IndexNumber == null) return;
                         tmdbKey = `${seriesTmdbId}:s${item.IndexNumber}`;
                         apiMediaType = 'tv';
                     } else if (mediaType === 'Episode') {
-                        const seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
+                        let seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
+                        if (!seriesTmdbId && item?.SeriesId) {
+                            try {
+                                const series = await ApiClient.getItem(userId, item.SeriesId);
+                                seriesTmdbId = series?.ProviderIds?.Tmdb;
+                            } catch (_) {}
+                        }
                         if (!seriesTmdbId || item?.ParentIndexNumber == null || item?.IndexNumber == null) return;
                         tmdbKey = `${seriesTmdbId}:s${item.ParentIndexNumber}:e${item.IndexNumber}`;
                         apiMediaType = 'tv';

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
@@ -537,7 +537,7 @@
                     const chip = document.createElement('div');
                     chip.className = 'mediaInfoCriticRating mediaInfoItem je-avg-user-rating-chip';
                     chip.title = tWithFallback('reviews_avg_rating_tooltip',
-                        '{count} user rating(s)', { count: ratingsWithValue.length });
+                        'Average rating from {count} user(s)', { count: ratingsWithValue.length });
                     chip.innerHTML = `<span class="material-icons starIcon" aria-hidden="true" style="color:#e91e8c;">person_heart</span>${avgDisplay}`;
 
                     // Insert after starRatingContainer, or after mediaInfoCriticRating if present,

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
@@ -767,7 +767,7 @@
                 const mediaType = item?.Type;
 
                 let tmdbKey = null;
-                let apiMediaType = 'movie';
+                let apiMediaType;
 
                 if (mediaType === 'Movie') {
                     const tmdbId = item?.ProviderIds?.Tmdb;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/reviews.js
@@ -523,6 +523,29 @@
                 existingSection.remove();
             }
 
+            // Inject average user rating chip next to the TMDB/RT rating chips
+            if (userReviewsEnabled && userReviews.length > 0) {
+                const ratingsWithValue = userReviews.filter(r => r.rating);
+                if (ratingsWithValue.length > 0) {
+                    const avg = ratingsWithValue.reduce((sum, r) => sum + r.rating, 0) / ratingsWithValue.length;
+                    const avgDisplay = (avg * 2).toFixed(1); // convert 1-5 → /10
+
+                    // Remove any existing chip first
+                    contextPage.querySelector('.je-avg-user-rating-chip')?.remove();
+
+                    const chip = document.createElement('div');
+                    chip.className = 'mediaInfoItem je-avg-user-rating-chip';
+                    chip.title = tWithFallback('reviews_avg_rating_tooltip',
+                        '{count} user rating(s)', { count: ratingsWithValue.length });
+                    chip.innerHTML = `<span class="material-icons" style="font-size:16px;vertical-align:middle;color:#e91e8c;margin-right:3px;">person_heart</span><span>${avgDisplay}/10</span>`;
+
+                    // Insert into starRatingContainer if present, else mediaInfoItems
+                    const ratingContainer = contextPage.querySelector('.starRatingContainer') ||
+                        contextPage.querySelector('.mediaInfoItems');
+                    if (ratingContainer) ratingContainer.appendChild(chip);
+                }
+            }
+
             // `currentUser` is resolved fresh by the caller (processPage /
             // refreshReviews) instead of read from the cached `JE.currentUser`
             // set once at plugin init. This matters for:
@@ -733,22 +756,52 @@
                 const item = JE.helpers?.getItemCached
                     ? await JE.helpers.getItemCached(itemId, { userId })
                     : await ApiClient.getItem(userId, itemId);
-                const tmdbId = item?.ProviderIds?.Tmdb;
                 const mediaType = item?.Type;
-                if (!tmdbId || !(mediaType === 'Movie' || mediaType === 'Series')) return;
 
-                const apiMediaType = mediaType === 'Series' ? 'tv' : 'movie';
-                // Fetch the current user fresh alongside the review data so
-                // admin status reflects the actual live session, not a
-                // potentially-stale JE.currentUser captured at plugin init.
+                let tmdbKey = null;
+                let apiMediaType = 'movie';
+
+                if (mediaType === 'Movie') {
+                    const tmdbId = item?.ProviderIds?.Tmdb;
+                    if (!tmdbId) return;
+                    tmdbKey = String(tmdbId);
+                    apiMediaType = 'movie';
+                } else if (mediaType === 'Series') {
+                    const tmdbId = item?.ProviderIds?.Tmdb;
+                    if (!tmdbId) return;
+                    tmdbKey = String(tmdbId);
+                    apiMediaType = 'tv';
+                } else if (mediaType === 'Season') {
+                    const seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
+                    if (!seriesTmdbId || item?.IndexNumber == null) return;
+                    tmdbKey = `${seriesTmdbId}:s${item.IndexNumber}`;
+                    apiMediaType = 'tv';
+                } else if (mediaType === 'Episode') {
+                    const seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
+                    if (!seriesTmdbId || item?.ParentIndexNumber == null || item?.IndexNumber == null) return;
+                    tmdbKey = `${seriesTmdbId}:s${item.ParentIndexNumber}:e${item.IndexNumber}`;
+                    apiMediaType = 'tv';
+                } else {
+                    return;
+                }
+
+                if (!tmdbKey) return;
+
                 const [tmdbReviews, userReviews, currentUser] = await Promise.all([
-                    tmdbReviewsEnabled ? fetchReviews(tmdbId, mediaType) : Promise.resolve(null),
-                    userReviewsEnabled ? fetchUserReviews(tmdbId, mediaType) : Promise.resolve([]),
+                    (tmdbReviewsEnabled && (mediaType === 'Movie' || mediaType === 'Series'))
+                        ? fetchReviews(tmdbKey.split(':')[0], mediaType)
+                        : Promise.resolve(null),
+                    userReviewsEnabled ? fetchUserReviews(tmdbKey, apiMediaType) : Promise.resolve([]),
                     ApiClient.getCurrentUser().catch(() => null),
                 ]);
 
                 const page = document.querySelector('#itemDetailPage:not(.hide)') || contextPage;
-                addReviewsToPage(tmdbReviews, userReviews, page, tmdbId, apiMediaType, currentUser);
+                addReviewsToPage(tmdbReviews, userReviews, page, tmdbKey, apiMediaType, currentUser);
+
+                // Bust the poster tag cache for this item so the overlay updates
+                if (typeof JE.invalidateUserReviewTagCache === 'function') {
+                    JE.invalidateUserReviewTagCache(tmdbKey);
+                }
             } catch (err) {
                 console.error(`${logPrefix} Failed to refresh reviews:`, err);
             }
@@ -919,6 +972,17 @@
                 .je-review-submit-btn:hover { background: rgba(94, 213, 95, 0.15); }
                 .je-review-submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
                 .je-review-form-error { color: rgb(244, 67, 54); font-size: 0.85em; min-height: 1em; }
+
+                /* Average user rating chip in item details */
+                .je-avg-user-rating-chip {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 2px;
+                    color: #e91e8c;
+                    font-size: 0.9em;
+                    font-weight: 600;
+                    cursor: default;
+                }
             `;
             document.head.appendChild(style);
         }
@@ -936,20 +1000,46 @@
                     const item = JE.helpers?.getItemCached
                         ? await JE.helpers.getItemCached(itemId, { userId })
                         : await ApiClient.getItem(userId, itemId);
-                    const tmdbId = item?.ProviderIds?.Tmdb;
                     const mediaType = item?.Type;
 
-                    if (tmdbId && mediaType && (mediaType === 'Movie' || mediaType === 'Series')) {
-                        const apiMediaType = mediaType === 'Series' ? 'tv' : 'movie';
-                        // See refreshReviews for why we resolve currentUser here
-                        // instead of reading JE.currentUser — same race/staleness
-                        // reasoning.
+                    // Resolve tmdbKey and apiMediaType based on item type
+                    let tmdbKey = null;
+                    let apiMediaType = 'movie';
+
+                    if (mediaType === 'Movie') {
+                        const tmdbId = item?.ProviderIds?.Tmdb;
+                        if (!tmdbId) return;
+                        tmdbKey = String(tmdbId);
+                        apiMediaType = 'movie';
+                    } else if (mediaType === 'Series') {
+                        const tmdbId = item?.ProviderIds?.Tmdb;
+                        if (!tmdbId) return;
+                        tmdbKey = String(tmdbId);
+                        apiMediaType = 'tv';
+                    } else if (mediaType === 'Season') {
+                        const seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
+                        if (!seriesTmdbId || item?.IndexNumber == null) return;
+                        tmdbKey = `${seriesTmdbId}:s${item.IndexNumber}`;
+                        apiMediaType = 'tv';
+                    } else if (mediaType === 'Episode') {
+                        const seriesTmdbId = item?.SeriesProviderIds?.Tmdb;
+                        if (!seriesTmdbId || item?.ParentIndexNumber == null || item?.IndexNumber == null) return;
+                        tmdbKey = `${seriesTmdbId}:s${item.ParentIndexNumber}:e${item.IndexNumber}`;
+                        apiMediaType = 'tv';
+                    } else {
+                        return;
+                    }
+
+                    if (tmdbKey) {
                         const [tmdbReviews, userReviews, currentUser] = await Promise.all([
-                            tmdbReviewsEnabled ? fetchReviews(tmdbId, mediaType) : Promise.resolve(null),
-                            userReviewsEnabled ? fetchUserReviews(tmdbId, mediaType) : Promise.resolve([]),
+                            // TMDB reviews only available for top-level movie/tv, not seasons/episodes
+                            (tmdbReviewsEnabled && (mediaType === 'Movie' || mediaType === 'Series'))
+                                ? fetchReviews(tmdbKey.split(':')[0], mediaType)
+                                : Promise.resolve(null),
+                            userReviewsEnabled ? fetchUserReviews(tmdbKey, apiMediaType) : Promise.resolve([]),
                             ApiClient.getCurrentUser().catch(() => null),
                         ]);
-                        addReviewsToPage(tmdbReviews, userReviews, visiblePage, tmdbId, apiMediaType, currentUser);
+                        addReviewsToPage(tmdbReviews, userReviews, visiblePage, tmdbKey, apiMediaType, currentUser);
                     }
                 }
             } catch (error) {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en.json
@@ -322,6 +322,7 @@
     "reviews_delete_error_body": "Could not delete the review: {err}",
     "reviews_form_error_empty": "Please add a rating or write a review before saving.",
     "reviews_form_error_save": "Failed to save review. Please try again.",
+    "reviews_avg_rating_tooltip": "Average rating from {count} user(s)",
     "panel_settings_language": "Language Settings",
     "panel_settings_language_display": "Display Language",
     "panel_settings_language_display_desc": "Select the language for Jellyfin Enhanced interface. Changes take effect after page refresh.",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -547,6 +547,7 @@
                 'tags/peopletags.js',
                 'tags/qualitytags.js',
                 'tags/ratingtags.js',
+                'tags/userreviewtags.js',
 
                 // arr
                 'arr/arr-links.js',
@@ -619,6 +620,7 @@
             if (typeof JE.initializeQualityTags === 'function' && JE.currentSettings?.qualityTagsEnabled) JE.initializeQualityTags();
             if (typeof JE.initializeGenreTags === 'function' && JE.currentSettings?.genreTagsEnabled) JE.initializeGenreTags();
             if (typeof JE.initializeRatingTags === 'function' && JE.currentSettings?.ratingTagsEnabled) JE.initializeRatingTags();
+            if (typeof JE.initializeUserReviewTags === 'function' && JE.pluginConfig?.ShowUserReviews && JE.currentSettings?.ratingTagsEnabled) JE.initializeUserReviewTags();
             if (typeof JE.initializeArrLinksScript === 'function' && JE.pluginConfig?.ArrLinksEnabled) JE.initializeArrLinksScript();
             if (typeof JE.initializeArrTagLinksScript === 'function' && JE.pluginConfig?.ArrTagsShowAsLinks) JE.initializeArrTagLinksScript();
             if (typeof JE.initializeLetterboxdLinksScript === 'function' && JE.pluginConfig?.LetterboxdEnabled) JE.initializeLetterboxdLinksScript();

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -620,7 +620,7 @@
             if (typeof JE.initializeQualityTags === 'function' && JE.currentSettings?.qualityTagsEnabled) JE.initializeQualityTags();
             if (typeof JE.initializeGenreTags === 'function' && JE.currentSettings?.genreTagsEnabled) JE.initializeGenreTags();
             if (typeof JE.initializeRatingTags === 'function' && JE.currentSettings?.ratingTagsEnabled) JE.initializeRatingTags();
-            if (typeof JE.initializeUserReviewTags === 'function' && JE.pluginConfig?.ShowUserReviews && JE.currentSettings?.ratingTagsEnabled) JE.initializeUserReviewTags();
+            if (typeof JE.initializeUserReviewTags === 'function' && JE.pluginConfig?.ShowUserReviews && JE.pluginConfig?.ShowUserRatingOnPosters && JE.currentSettings?.ratingTagsEnabled) JE.initializeUserReviewTags();
             if (typeof JE.initializeArrLinksScript === 'function' && JE.pluginConfig?.ArrLinksEnabled) JE.initializeArrLinksScript();
             if (typeof JE.initializeArrTagLinksScript === 'function' && JE.pluginConfig?.ArrTagsShowAsLinks) JE.initializeArrTagLinksScript();
             if (typeof JE.initializeLetterboxdLinksScript === 'function' && JE.pluginConfig?.LetterboxdEnabled) JE.initializeLetterboxdLinksScript();

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/ratingtags.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/ratingtags.js
@@ -355,6 +355,10 @@
 
                     if (tmdb || critic !== null) {
                         applyRatingTag(el, rating);
+                        if (typeof JE.appendUserRatingToContainer === 'function') {
+                            const container = el.querySelector('.rating-overlay-container');
+                            if (container) JE.appendUserRatingToContainer(container, item);
+                        }
                     }
                 },
                 renderFromCache: function(el, itemId) {
@@ -364,6 +368,7 @@
                     const cached = getCachedEntry(itemId);
                     if (cached && (cached.tmdb || cached.critic !== null)) {
                         applyRatingTag(el, cached);
+                        // User rating needs the full item — skip here, pipeline will call render() with item
                         return true;
                     }
                     return false;
@@ -379,6 +384,7 @@
                         : null;
                     if (tmdb || critic !== null) {
                         applyRatingTag(el, { tmdb, critic });
+                        // User rating needs item provider IDs — not available in server cache entry
                     }
                 },
                 isEnabled: function() { return !!JE.currentSettings?.ratingTagsEnabled; },

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/ratingtags.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/ratingtags.js
@@ -334,6 +334,10 @@
                         if (cached.tmdb || cached.critic !== null) {
                             applyRatingTag(el, cached);
                         }
+                        // Still need to append user rating even on cache hit
+                        if (typeof JE.appendUserRatingToContainer === 'function') {
+                            JE.appendUserRatingToContainer(el, item, extras);
+                        }
                         return;
                     }
 
@@ -351,14 +355,22 @@
                         : null;
 
                     const rating = { tmdb, critic };
-                    setCachedEntry(itemId, rating);
+                    // Store tmdbId in cache entry so renderFromCache can call appendUserRatingToContainer
+                    const tmdbId = item.ProviderIds?.Tmdb || item.ProviderIds?.tmdb || null;
+                    const seriesTmdbId = extras?.parentSeries?.ProviderIds?.Tmdb || extras?.parentSeries?.ProviderIds?.tmdb || null;
+                    const tmdbMediaType = item.Type === 'Series' ? 'tv' : 'movie';
+                    setCachedEntry(itemId, { ...rating, tmdbId, seriesTmdbId, tmdbMediaType,
+                        seasonNumber: item.IndexNumber ?? null,
+                        episodeNumber: item.Type === 'Episode' ? item.IndexNumber : null,
+                        parentSeasonNumber: item.Type === 'Episode' ? item.ParentIndexNumber : null });
 
                     if (tmdb || critic !== null) {
                         applyRatingTag(el, rating);
                         if (typeof JE.appendUserRatingToContainer === 'function') {
-                            const container = el.querySelector('.rating-overlay-container');
-                            if (container) JE.appendUserRatingToContainer(container, item);
+                            JE.appendUserRatingToContainer(el, item, extras);
                         }
+                    } else if (typeof JE.appendUserRatingToContainer === 'function') {
+                        JE.appendUserRatingToContainer(el, item, extras);
                     }
                 },
                 renderFromCache: function(el, itemId) {
@@ -366,12 +378,30 @@
                     if (shouldIgnoreElement(el)) return true;
                     if (el.closest('.je-hidden')) return true;
                     const cached = getCachedEntry(itemId);
-                    if (cached && (cached.tmdb || cached.critic !== null)) {
+                    if (!cached) return false;
+                    if (cached.tmdb || cached.critic !== null) {
                         applyRatingTag(el, cached);
-                        // User rating needs the full item — skip here, pipeline will call render() with item
-                        return true;
                     }
-                    return false;
+                    if (typeof JE.appendUserRatingToContainer === 'function' && (cached.tmdbId || cached.seriesTmdbId)) {
+                        const syntheticItem = {
+                            Type: cached.tmdbMediaType === 'tv' ? 'Series' : 'Movie',
+                            ProviderIds: cached.tmdbId ? { Tmdb: cached.tmdbId } : {},
+                            SeriesProviderIds: cached.seriesTmdbId ? { Tmdb: cached.seriesTmdbId } : {},
+                            IndexNumber: cached.seasonNumber,
+                            ParentIndexNumber: cached.parentSeasonNumber,
+                        };
+                        // Refine Type for Season/Episode based on available data
+                        if (cached.seriesTmdbId && cached.episodeNumber != null) {
+                            syntheticItem.Type = 'Episode';
+                            syntheticItem.IndexNumber = cached.episodeNumber;
+                            syntheticItem.ParentIndexNumber = cached.parentSeasonNumber;
+                        } else if (cached.seriesTmdbId && cached.seasonNumber != null) {
+                            syntheticItem.Type = 'Season';
+                            syntheticItem.IndexNumber = cached.seasonNumber;
+                        }
+                        JE.appendUserRatingToContainer(el, syntheticItem);
+                    }
+                    return !!(cached.tmdb || cached.critic !== null);
                 },
                 renderFromServerCache: function(el, entry) {
                     if (isCardAlreadyTagged(el)) return;
@@ -384,9 +414,23 @@
                         : null;
                     if (tmdb || critic !== null) {
                         applyRatingTag(el, { tmdb, critic });
-                        // User rating needs item provider IDs — not available in server cache entry
                     }
-                },
+                    if (typeof JE.appendUserRatingToContainer === 'function') {
+                        // Build a synthetic item so resolveTmdbKey can derive the correct key
+                        // for Movie/Series (TmdbId) and Season/Episode (SeriesTmdbId + numbers)
+                        const syntheticItem = {
+                            Type: entry.Type,
+                            ProviderIds: entry.TmdbId ? { Tmdb: entry.TmdbId } : {},
+                            SeriesProviderIds: entry.SeriesTmdbId ? { Tmdb: entry.SeriesTmdbId } : {},
+                            IndexNumber: entry.SeasonNumber,
+                            ParentIndexNumber: entry.SeasonNumber,
+                            // For Episode, SeasonNumber is ParentIndexNumber and EpisodeNumber is IndexNumber
+                            ...(entry.Type === 'Episode' ? { ParentIndexNumber: entry.SeasonNumber, IndexNumber: entry.EpisodeNumber } : {})
+                        };
+                        if (entry.TmdbId || entry.SeriesTmdbId) {
+                            JE.appendUserRatingToContainer(el, syntheticItem, null);
+                        }
+                    }                },
                 isEnabled: function() { return !!JE.currentSettings?.ratingTagsEnabled; },
                 needsFirstEpisode: false,
                 needsParentSeries: false,

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/userreviewtags.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/userreviewtags.js
@@ -1,7 +1,7 @@
 // /js/tags/userreviewtags.js
 // Adds the current user's personal rating (person_heart icon) to the rating
 // tag overlay on poster cards. Piggybacks on the ratingTagsEnabled setting —
-// no separate toggle needed. Shows X/10 when rated, "—" when not (unless
+// no separate toggle needed. Shows X when rated, "—" when not (unless
 // ShowUserRatingDash is false in admin config).
 (function(JE) {
     'use strict';
@@ -14,8 +14,8 @@
     const _inFlight = new Map();
 
     /**
-     * Fetch the current user's rating for a given tmdbKey.
-     * Returns null if no review exists or reviews are disabled.
+     * Fetch the average rating across all users for a given tmdbKey.
+     * Returns null if no reviews with ratings exist.
      */
     async function fetchUserRating(tmdbKey, mediaType) {
         if (!JE.pluginConfig?.ShowUserReviews) return null;
@@ -33,13 +33,15 @@
                     return null;
                 }
                 const data = await response.json();
-                const currentUserId = (ApiClient.getCurrentUserId() || '').replace(/-/g, '');
-                const ownReview = (data.reviews || []).find(r =>
-                    (r.userId || '').replace(/-/g, '') === currentUserId
-                );
-                const rating = ownReview?.rating ?? null;
-                _reviewCache.set(tmdbKey, rating);
-                return rating;
+                const rated = (data.reviews || []).filter(r => r.rating);
+                if (rated.length === 0) {
+                    _reviewCache.set(tmdbKey, null);
+                    return null;
+                }
+                // Average across all users, stored as a 1-5 float
+                const avg = rated.reduce((sum, r) => sum + r.rating, 0) / rated.length;
+                _reviewCache.set(tmdbKey, avg);
+                return avg;
             } catch (e) {
                 _reviewCache.set(tmdbKey, null);
                 return null;
@@ -53,21 +55,24 @@
     }
 
     /**
-     * Append a person_heart chip to an existing rating overlay container.
-     * @param {HTMLElement} container - The .rating-overlay-container element.
-     * @param {number|null} rating - 1-5 star rating, or null if unrated.
+     * Append a person_heart chip to a rating overlay container.
+     * Uses the same .rating-tag + .rating-tag-critic structure as the tomato chip,
+     * with a material icon instead of the SVG background.
      */
     function appendUserRatingChip(container, rating) {
-        // Remove any existing chip first
         container.querySelector('.je-userreview-tag')?.remove();
 
-        const showDash = JE.pluginConfig?.ShowUserRatingDash !== false; // default true
+        const showDash = JE.pluginConfig?.ShowUserRatingDash !== false;
         if (rating === null && !showDash) return;
 
-        const displayText = rating !== null ? `${rating * 2}/10` : '—';
+        // rating is a 1-5 float average — convert to /10, drop trailing .0
+        const raw = rating !== null ? rating * 2 : null;
+        const displayText = raw !== null
+            ? (Number.isInteger(raw) ? `${raw}` : `${raw.toFixed(1)}`)
+            : '—';
 
         const tag = document.createElement('div');
-        tag.className = 'rating-tag je-userreview-tag';
+        tag.className = 'rating-tag rating-tag-critic je-userreview-tag';
 
         const icon = document.createElement('span');
         icon.className = 'material-icons je-userreview-icon';
@@ -85,8 +90,10 @@
     /**
      * Resolve the tmdbKey and mediaType for a Jellyfin item.
      * Returns null if the item type is unsupported or TMDB ID is missing.
+     * @param {object} item - Jellyfin item from tag pipeline batch response.
+     * @param {object} [extras] - Pipeline extras containing parentSeries.
      */
-    function resolveTmdbKey(item) {
+    function resolveTmdbKey(item, extras) {
         const type = item.Type || '';
         if (type === 'Movie') {
             const id = item.ProviderIds?.Tmdb || item.ProviderIds?.tmdb;
@@ -96,17 +103,19 @@
             const id = item.ProviderIds?.Tmdb || item.ProviderIds?.tmdb;
             return id ? { tmdbKey: String(id), mediaType: 'tv' } : null;
         }
-        if (type === 'Season') {
-            const id = item.SeriesProviderIds?.Tmdb || item.SeriesProviderIds?.tmdb;
-            return (id && item.IndexNumber != null)
-                ? { tmdbKey: `${id}:s${item.IndexNumber}`, mediaType: 'tv' }
-                : null;
-        }
-        if (type === 'Episode') {
-            const id = item.SeriesProviderIds?.Tmdb || item.SeriesProviderIds?.tmdb;
-            return (id && item.ParentIndexNumber != null && item.IndexNumber != null)
-                ? { tmdbKey: `${id}:s${item.ParentIndexNumber}:e${item.IndexNumber}`, mediaType: 'tv' }
-                : null;
+        if (type === 'Season' || type === 'Episode') {
+            // SeriesProviderIds is not in the tag-data response — use parentSeries from extras
+            const series = extras?.parentSeries;
+            const seriesTmdbId = series?.ProviderIds?.Tmdb || series?.ProviderIds?.tmdb;
+            if (!seriesTmdbId) return null;
+
+            if (type === 'Season') {
+                if (item.IndexNumber == null) return null;
+                return { tmdbKey: `${seriesTmdbId}:s${item.IndexNumber}`, mediaType: 'tv' };
+            } else {
+                if (item.ParentIndexNumber == null || item.IndexNumber == null) return null;
+                return { tmdbKey: `${seriesTmdbId}:s${item.ParentIndexNumber}:e${item.IndexNumber}`, mediaType: 'tv' };
+            }
         }
         return null;
     }
@@ -116,12 +125,15 @@
             console.log(`${logPrefix} User reviews disabled, skipping.`);
             return;
         }
+        if (!JE.pluginConfig?.ShowUserRatingOnPosters) {
+            console.log(`${logPrefix} User rating on posters disabled, skipping.`);
+            return;
+        }
         if (!JE.currentSettings?.ratingTagsEnabled) {
             console.log(`${logPrefix} Rating tags disabled, skipping.`);
             return;
         }
 
-        // Inject CSS for the person_heart chip (reuses .rating-tag base styles)
         const styleId = 'je-userreview-tags-css';
         if (!document.getElementById(styleId)) {
             const style = document.createElement('style');
@@ -132,6 +144,7 @@
                     font-size: 14px !important;
                     line-height: 1;
                     color: #e91e8c !important;
+                    vertical-align: middle;
                 }
             `;
             document.head.appendChild(style);
@@ -141,20 +154,36 @@
     };
 
     /**
-     * Called by ratingtags.js after it applies a rating overlay to a card.
-     * Appends the user rating chip to the existing container.
-     * @param {HTMLElement} container - The .rating-overlay-container element.
+     * Called by ratingtags.js after applying a rating overlay, OR directly
+     * for items with no TMDB/RT rating. Creates the overlay container if needed.
+     * @param {HTMLElement} containerOrEl - .rating-overlay-container or cardImageContainer.
      * @param {object} item - The Jellyfin item object.
+     * @param {object} [extras] - Pipeline extras (parentSeries, etc.).
      */
-    JE.appendUserRatingToContainer = async function(container, item) {
+    JE.appendUserRatingToContainer = async function(containerOrEl, item, extras) {
         if (!JE.pluginConfig?.ShowUserReviews) return;
+        if (!JE.pluginConfig?.ShowUserRatingOnPosters) return;
         if (!JE.currentSettings?.ratingTagsEnabled) return;
 
-        const resolved = resolveTmdbKey(item);
+        const resolved = resolveTmdbKey(item, extras);
         if (!resolved) return;
 
         const { tmdbKey, mediaType } = resolved;
         const rating = await fetchUserRating(tmdbKey, mediaType);
+
+        if (rating === null && JE.pluginConfig?.ShowUserRatingDash === false) return;
+
+        // Accept either the overlay container itself or the cardImageContainer
+        let container = containerOrEl;
+        if (!container.classList.contains('rating-overlay-container')) {
+            container = containerOrEl.querySelector('.rating-overlay-container');
+            if (!container) {
+                container = document.createElement('div');
+                container.className = 'rating-overlay-container';
+                containerOrEl.appendChild(container);
+            }
+        }
+
         appendUserRatingChip(container, rating);
     };
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/userreviewtags.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/userreviewtags.js
@@ -1,0 +1,169 @@
+// /js/tags/userreviewtags.js
+// Adds the current user's personal rating (person_heart icon) to the rating
+// tag overlay on poster cards. Piggybacks on the ratingTagsEnabled setting —
+// no separate toggle needed. Shows X/10 when rated, "—" when not (unless
+// ShowUserRatingDash is false in admin config).
+(function(JE) {
+    'use strict';
+
+    const logPrefix = '🪼 Jellyfin Enhanced: User Review Tags:';
+
+    // Per-session cache: tmdbKey → rating (1-5 or null)
+    const _reviewCache = new Map();
+    // In-flight deduplication
+    const _inFlight = new Map();
+
+    /**
+     * Fetch the current user's rating for a given tmdbKey.
+     * Returns null if no review exists or reviews are disabled.
+     */
+    async function fetchUserRating(tmdbKey, mediaType) {
+        if (!JE.pluginConfig?.ShowUserReviews) return null;
+        if (_reviewCache.has(tmdbKey)) return _reviewCache.get(tmdbKey);
+        if (_inFlight.has(tmdbKey)) return _inFlight.get(tmdbKey);
+
+        const promise = (async () => {
+            try {
+                const url = ApiClient.getUrl(`/JellyfinEnhanced/reviews/${mediaType}/${tmdbKey}`);
+                const response = await fetch(url, {
+                    headers: { 'X-Emby-Token': ApiClient.accessToken() }
+                });
+                if (!response.ok) {
+                    _reviewCache.set(tmdbKey, null);
+                    return null;
+                }
+                const data = await response.json();
+                const currentUserId = (ApiClient.getCurrentUserId() || '').replace(/-/g, '');
+                const ownReview = (data.reviews || []).find(r =>
+                    (r.userId || '').replace(/-/g, '') === currentUserId
+                );
+                const rating = ownReview?.rating ?? null;
+                _reviewCache.set(tmdbKey, rating);
+                return rating;
+            } catch (e) {
+                _reviewCache.set(tmdbKey, null);
+                return null;
+            } finally {
+                _inFlight.delete(tmdbKey);
+            }
+        })();
+
+        _inFlight.set(tmdbKey, promise);
+        return promise;
+    }
+
+    /**
+     * Append a person_heart chip to an existing rating overlay container.
+     * @param {HTMLElement} container - The .rating-overlay-container element.
+     * @param {number|null} rating - 1-5 star rating, or null if unrated.
+     */
+    function appendUserRatingChip(container, rating) {
+        // Remove any existing chip first
+        container.querySelector('.je-userreview-tag')?.remove();
+
+        const showDash = JE.pluginConfig?.ShowUserRatingDash !== false; // default true
+        if (rating === null && !showDash) return;
+
+        const displayText = rating !== null ? `${rating * 2}/10` : '—';
+
+        const tag = document.createElement('div');
+        tag.className = 'rating-tag je-userreview-tag';
+
+        const icon = document.createElement('span');
+        icon.className = 'material-icons je-userreview-icon';
+        icon.textContent = 'person_heart';
+
+        const text = document.createElement('span');
+        text.className = 'rating-text';
+        text.textContent = displayText;
+
+        tag.appendChild(icon);
+        tag.appendChild(text);
+        container.appendChild(tag);
+    }
+
+    /**
+     * Resolve the tmdbKey and mediaType for a Jellyfin item.
+     * Returns null if the item type is unsupported or TMDB ID is missing.
+     */
+    function resolveTmdbKey(item) {
+        const type = item.Type || '';
+        if (type === 'Movie') {
+            const id = item.ProviderIds?.Tmdb || item.ProviderIds?.tmdb;
+            return id ? { tmdbKey: String(id), mediaType: 'movie' } : null;
+        }
+        if (type === 'Series') {
+            const id = item.ProviderIds?.Tmdb || item.ProviderIds?.tmdb;
+            return id ? { tmdbKey: String(id), mediaType: 'tv' } : null;
+        }
+        if (type === 'Season') {
+            const id = item.SeriesProviderIds?.Tmdb || item.SeriesProviderIds?.tmdb;
+            return (id && item.IndexNumber != null)
+                ? { tmdbKey: `${id}:s${item.IndexNumber}`, mediaType: 'tv' }
+                : null;
+        }
+        if (type === 'Episode') {
+            const id = item.SeriesProviderIds?.Tmdb || item.SeriesProviderIds?.tmdb;
+            return (id && item.ParentIndexNumber != null && item.IndexNumber != null)
+                ? { tmdbKey: `${id}:s${item.ParentIndexNumber}:e${item.IndexNumber}`, mediaType: 'tv' }
+                : null;
+        }
+        return null;
+    }
+
+    JE.initializeUserReviewTags = function() {
+        if (!JE.pluginConfig?.ShowUserReviews) {
+            console.log(`${logPrefix} User reviews disabled, skipping.`);
+            return;
+        }
+        if (!JE.currentSettings?.ratingTagsEnabled) {
+            console.log(`${logPrefix} Rating tags disabled, skipping.`);
+            return;
+        }
+
+        // Inject CSS for the person_heart chip (reuses .rating-tag base styles)
+        const styleId = 'je-userreview-tags-css';
+        if (!document.getElementById(styleId)) {
+            const style = document.createElement('style');
+            style.id = styleId;
+            style.textContent = `
+                .je-userreview-tag { color: #e91e8c !important; }
+                .je-userreview-icon {
+                    font-size: 14px !important;
+                    line-height: 1;
+                    color: #e91e8c !important;
+                }
+            `;
+            document.head.appendChild(style);
+        }
+
+        console.log(`${logPrefix} Initialized.`);
+    };
+
+    /**
+     * Called by ratingtags.js after it applies a rating overlay to a card.
+     * Appends the user rating chip to the existing container.
+     * @param {HTMLElement} container - The .rating-overlay-container element.
+     * @param {object} item - The Jellyfin item object.
+     */
+    JE.appendUserRatingToContainer = async function(container, item) {
+        if (!JE.pluginConfig?.ShowUserReviews) return;
+        if (!JE.currentSettings?.ratingTagsEnabled) return;
+
+        const resolved = resolveTmdbKey(item);
+        if (!resolved) return;
+
+        const { tmdbKey, mediaType } = resolved;
+        const rating = await fetchUserRating(tmdbKey, mediaType);
+        appendUserRatingChip(container, rating);
+    };
+
+    /**
+     * Invalidate cache for a specific tmdbKey (called after review save/delete).
+     */
+    JE.invalidateUserReviewTagCache = function(tmdbKey) {
+        if (tmdbKey) _reviewCache.delete(tmdbKey);
+        else _reviewCache.clear();
+    };
+
+})(window.JellyfinEnhanced = window.JellyfinEnhanced || {});


### PR DESCRIPTION
Reviews
- Extend review key scheme to support seasons (tv:{id}:s{n}) and
  episodes (tv:{id}:s{n}:e{n}), stored under the same show TMDB ID
- Show review panel on Season and Episode item detail pages
- Fix fetchUserReviews mediaType conversion bug (was mapping 'tv' → 'movie')
- Fall back to fetching parent series via SeriesId when SeriesProviderIds
  is absent from the Jellyfin item response

Average rating chip
- Inject person_heart chip next to TMDB/RT chips on item detail pages
  showing average rating across all users (1-5 × 2, no /10 suffix)
- Bust poster tag cache after review save/delete so chip updates live

Poster overlay (admin opt-in: ShowUserRatingOnPosters)
- Add userreviewtags.js — appends person_heart average rating chip to
  rating tag overlay on poster cards, piggybacks on ratingTagsEnabled
- Add TmdbId, SeriesTmdbId, SeasonNumber, EpisodeNumber to TagCacheEntry
  so all three render paths (render, renderFromCache, renderFromServerCache)
  can resolve the correct review key without a Jellyfin→TMDB ID mapping
- Add ShowUserRatingOnPosters and ShowUserRatingDash admin config options
- Server tag cache rebuild required to populate new TmdbId fields


Fixes #547 