### PR TITLE
fix: admin config page UI bugs

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -1339,6 +1339,14 @@
     display: block;
     font-style: italic;
 }
+/* Parent-dep hints get appended as direct <div class="dep-hint-text"> children
+   of .checkboxContainer (which is display: flex; align-items: center). Without
+   these rules the hint becomes a flex sibling of the label, sharing the row
+   and crushing both pieces on narrow viewports (visible on phones: the label
+   "Use Plugin Pages for Hidden Content" and the hint "Enable X to configure"
+   end up squashed into half-width columns). Wrap the hint onto its own line. */
+#JellyfinEnhancedPage .checkboxContainer { flex-wrap: wrap; }
+#JellyfinEnhancedPage .checkboxContainer > .dep-hint-text { flex-basis: 100%; }
 .dep-required-icon { vertical-align: middle; margin-left: 6px; }
 
 /* ---------------------------------------------------------------------------
@@ -1779,14 +1787,18 @@ body.je-has-filetransformation .je-installed-badge[data-plugin="filetransformati
     }
     .je-save-dock .je-save-dock-btn { width: 100%; justify-content: center; }
     .je-tab-bar { padding: 10px 0; }
-    .jellyfin-tab-button { padding: 8px 14px; }
+    /* Prefix with #JellyfinEnhancedPage to match the base rule's specificity
+       (1,1,0). Class-only selectors (0,1,0) here lose the cascade to the
+       prefixed base, leaving desktop padding/grid values stuck on phones. */
+    #JellyfinEnhancedPage .jellyfin-tab-button { padding: 8px 14px; }
     .je-tab-icon { font-size: 18px !important; }
 
     /* The tab content grid uses minmax(480px, 1fr) for desktop multi-column.
        On viewports narrower than the 480px min, the grid forces horizontal
        overflow (descriptions get cut off, page scrolls sideways). Collapse
-       to single column under 768px so cards stack cleanly. */
-    .jellyfin-tab-content.active {
+       to single column under 768px so cards stack cleanly. The prefix is
+       required for specificity parity with the base rule at line ~654. */
+    #JellyfinEnhancedPage .jellyfin-tab-content.active {
         grid-template-columns: 1fr;
         gap: 12px;
     }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -979,7 +979,7 @@
                 </div>
 
                 <div id="seerr" class="jellyfin-tab-content">
-                    <fieldset>
+                    <fieldset data-dep-setup>
                         <legend class="sectionTitle">Seerr Connection Setup</legend>
                         <div class="configSection">
                             <div class="checkboxContainer je-main-feature">
@@ -1456,7 +1456,7 @@
                         </div>
                     </div>
 
-                    <fieldset>
+                    <fieldset data-dep-setup>
                         <legend class="sectionTitle"><img class="je-legend-icon-img" src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/sonarr.svg" alt="">Sonarr</legend>
                         <div class="configSection">
                             <div class="je-setting-description" data-desc-for="sonarrInstancesList">
@@ -1471,7 +1471,7 @@
                         </div>
                     </fieldset>
 
-                    <fieldset>
+                    <fieldset data-dep-setup>
                         <legend class="sectionTitle"><img class="je-legend-icon-img" src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/radarr-light-hybrid-light.svg" alt="">Radarr</legend>
                         <div class="configSection">
                             <div class="je-setting-description" data-desc-for="radarrInstancesList">
@@ -1486,7 +1486,7 @@
                         </div>
                     </fieldset>
 
-                    <fieldset>
+                    <fieldset data-dep-setup>
                         <legend class="sectionTitle"><img class="je-legend-icon-img" src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/bazarr.svg" alt="">Bazarr</legend>
                         <div class="configSection">
                             <div class="je-setting-description" data-desc-for="bazarrUrl">
@@ -4982,20 +4982,45 @@
         resetAllUserSettingsBtn.addEventListener('click', resetAllUserSettings);
         initAutoMovieQualityMode();
 
-        // Live-update the Requests Page requirements banner as the admin types
-        // into Seerr fields or adds/edits/removes *arr instances. Delegated on
-        // the form so it also covers dynamically-created instance cards.
+        // Live-update the Requests Page requirements banner AND the dependency
+        // gates as the admin types into Seerr fields or adds/edits/removes/
+        // toggles *arr instances. Without this, the *arr UI Links / Tags Sync
+        // gate banners would stay up until the next form save + reload even
+        // though hasAnyArrService() is already true.
         (function wireRequestsBannerReactive() {
             var formEl = document.getElementById('JellyfinEnhancedForm');
-            if (!formEl) return;
+            if (!formEl) {
+                console.error('[JE] #JellyfinEnhancedForm missing — reactive dep updates disabled');
+                return;
+            }
             function relevant(target) {
                 if (!target) return false;
                 if (target.id === 'jellyseerrUrls' || target.id === 'JellyseerrApiKey') return true;
-                if (target.classList && (target.classList.contains('arr-instance-url') || target.classList.contains('arr-instance-apikey'))) return true;
-                return false;
+                if (!target.classList) return false;
+                return target.classList.contains('arr-instance-url')
+                    || target.classList.contains('arr-instance-apikey')
+                    || target.classList.contains('arr-instance-enabled');
             }
+            function refresh() {
+                try {
+                    updateRequestsRequirementsBanner();
+                    debouncedUpdateDeps();
+                } catch (err) {
+                    // Observer + listener callbacks must never throw — a throw
+                    // here would leave gate banners frozen in their last state
+                    // and keep firing on every subsequent mutation.
+                    console.error('[JE] dep refresh failed', err);
+                }
+            }
+            // `input` covers all relevant cases: per-keystroke for text/api-key
+            // fields, and bubbled-from-checkbox for `.arr-instance-enabled`
+            // clicks/keyboard toggles. We deliberately skip a parallel `change`
+            // listener — native checkboxes fire BOTH events per toggle, which
+            // would double-fire refresh() (debouncedUpdateDeps collapses it,
+            // but the synchronous updateRequestsRequirementsBanner pass would
+            // run twice).
             formEl.addEventListener('input', function(e) {
-                if (relevant(e.target)) updateRequestsRequirementsBanner();
+                if (relevant(e.target)) refresh();
             });
             // Instance add/remove happens via button clicks that mutate
             // #sonarrInstancesList / #radarrInstancesList. Observe both so the
@@ -5003,8 +5028,7 @@
             ['sonarrInstancesList', 'radarrInstancesList'].forEach(function(id) {
                 var root = document.getElementById(id);
                 if (!root) return;
-                new MutationObserver(updateRequestsRequirementsBanner)
-                    .observe(root, { childList: true, subtree: true });
+                new MutationObserver(refresh).observe(root, { childList: true, subtree: true });
             });
         })();
 
@@ -5128,23 +5152,33 @@
         }
 
         /**
-         * Checks whether at least one arr service (Sonarr or Radarr) has a URL and API key.
-         * @returns {boolean} True if any arr service is configured
+         * Checks whether at least one ENABLED arr service (Sonarr or Radarr) has a URL and API key.
+         * Disabled instances are skipped — they're stored config but the fan-out callers
+         * (controller endpoints, scheduled tag sync) skip them, so gating dependent
+         * features behind a disabled-only set would be misleading.
+         * @returns {boolean} True if any enabled arr service is fully configured
          */
         function hasAnyArrService() {
             var cards = document.querySelectorAll('#sonarrInstancesList .arr-instance-card, #radarrInstancesList .arr-instance-card');
             for (var i = 0; i < cards.length; i++) {
                 var url = cards[i].querySelector('.arr-instance-url');
                 var key = cards[i].querySelector('.arr-instance-apikey');
+                var enabled = cards[i].querySelector('.arr-instance-enabled');
+                // Treat missing checkbox as enabled (defensive — every card should have one)
+                if (enabled && !enabled.checked) continue;
                 if (url && url.value.trim() && key && key.value.trim()) return true;
             }
             return false;
         }
 
+        // Setup fieldsets that hold the connection inputs are tagged with
+        // `data-dep-setup` directly in the HTML — `updateSectionDep` walks
+        // every fieldset and gates only the ones WITHOUT that marker, so
+        // admins can always edit Sonarr/Radarr/Bazarr/Seerr setup boxes
+        // regardless of what else is configured.
         var SECTION_DEPS = [
             {
                 tabSelector: '#seerr',
-                skipFirst: true,
                 checkFn: hasJellyseerrConfigured,
                 bannerIcon: 'link_off',
                 bannerTitle: 'Enable "Seerr integration" to configure',
@@ -5153,11 +5187,10 @@
             },
             {
                 tabSelector: '#arr',
-                skipFirst: true,
                 checkFn: hasAnyArrService,
                 bannerIcon: 'link_off',
                 bannerTitle: 'Enable a *arr service to configure',
-                bannerHint: 'Add a URL and API key for Sonarr or Radarr in the Configuration section above.',
+                bannerHint: 'Add a URL and API key for Sonarr or Radarr above to enable these features.',
                 bannerId: 'dep-banner-arr'
             }
         ];
@@ -5246,7 +5279,10 @@
             var fieldsets = tab.querySelectorAll(':scope > fieldset');
             var targets = [];
             for (var i = 0; i < fieldsets.length; i++) {
-                if (dep.skipFirst && i === 0) continue;
+                // Setup fieldsets (Sonarr/Radarr/Bazarr config, Seerr connection setup)
+                // are always editable so admins can add a connection without first
+                // having one — they carry `data-dep-setup` directly in the HTML.
+                if (fieldsets[i].hasAttribute('data-dep-setup')) continue;
                 targets.push(fieldsets[i]);
             }
 


### PR DESCRIPTION
## Summary

Bundles three small admin config page UI bugfixes:

1. **Radarr / Bazarr setup boxes can be configured independently of Sonarr.** The `*arr` tab was gating fieldsets[1] (Radarr) and fieldsets[2] (Bazarr) until a Sonarr URL+API key was configured, because `SECTION_DEPS` used `skipFirst: true` which only skipped fieldset[0]. Switched to a declarative `data-dep-setup` HTML attribute on setup fieldsets (Seerr Connection Setup, Sonarr, Radarr, Bazarr) so all four service-setup boxes are always editable. Dependent feature fieldsets (`*arr UI Links`, `Tags Sync`, Seerr feature fieldsets) still gate behind their `checkFn`s. **Note: I introduced this regression in my own PR #559 (multi-instance Sonarr/Radarr support).**

2. **Config page no longer overflows the viewport on portrait phones.** The mobile media query at `@media (max-width: 768px)` was setting `.jellyfin-tab-content.active { grid-template-columns: 1fr; }` without the `#JellyfinEnhancedPage` ID prefix, so its specificity (0,2,0) lost to the base rule's (1,1,0). On a Samsung S20 Ultra (412px) or iPhone (390px) the grid stayed pinned to a 480px minimum column, forcing every card 90-100px wider than the screen. Same specificity bug on `.jellyfin-tab-button` padding. Both rules now carry the prefix.

3. **Parent-dep hint text wraps below the label instead of beside it.** Parent-dep hints (e.g. `Enable "Enable Hidden Content" to configure`) are appended as direct `<div class="dep-hint-text">` children of `.checkboxContainer`. Since the container is `display: flex; align-items: center`, the hint became a flex sibling of the label, sharing the row. On narrow viewports both halves crushed into ~150px columns. Added `flex-wrap: wrap` to the container + `flex-basis: 100%` to direct-child hints so the hint falls onto its own line.

While in the `*arr` reactive code path for fix #1, also tightened a few things:

- Hook `debouncedUpdateDeps()` into the existing `wireRequestsBannerReactive` IIFE so the `*arr UI Links` / `Tags Sync` gate banners react in real-time as the admin types in a Sonarr/Radarr URL+key, instead of requiring save+reload.
- Tighten `hasAnyArrService()` to skip instances whose enabled-checkbox is unchecked. Matches the rest of the plugin's fan-out behavior (disabled instances are stored config but skipped by all controllers and scheduled tasks).
- Wrap `refresh()` body in try/catch so a thrown callback can't freeze the gate state under subsequent mutations.
- Surface `console.error` if `#JellyfinEnhancedForm` is missing instead of silently aborting the reactive wireup.

## Test plan

- [x] Built with `dotnet build` (0 warnings, 0 errors)
- [x] Deployed and tested on Jellyfin 10.11.x dev instance
- [x] No new console errors
- [x] Doesn't break existing functionality
- [x] Playwright E2E (31 checks) for the *arr fix: Sonarr/Radarr/Bazarr setup boxes editable when no service is configured; `*arr UI Links` + `Tags Sync` gate banner visible initially; banner clears in real-time after typing URL+key; banner restores when enabled-checkbox unchecked; banner restores after instance removal; Seerr tab gating still works correctly
- [x] Playwright multi-viewport verification (40 checks across 8 viewports × 5 tabs) for the portrait/hint fix: 0px horizontal overflow at 375/390/393/412/768/820/844/1440px, desktop multi-column preserved (2 columns at 575px each on 1440px), parent-dep hint wraps below label on Pages tab

## AI assistance

This PR was developed with AI assistance (Claude). All changes have been reviewed, tested, and understood.