### PR TITLE
fix: config page renders broken on portrait phones

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.css
@@ -1339,6 +1339,14 @@
     display: block;
     font-style: italic;
 }
+/* Parent-dep hints get appended as direct <div class="dep-hint-text"> children
+   of .checkboxContainer (which is display: flex; align-items: center). Without
+   these rules the hint becomes a flex sibling of the label, sharing the row
+   and crushing both pieces on narrow viewports (visible on phones: the label
+   "Use Plugin Pages for Hidden Content" and the hint "Enable X to configure"
+   end up squashed into half-width columns). Wrap the hint onto its own line. */
+#JellyfinEnhancedPage .checkboxContainer { flex-wrap: wrap; }
+#JellyfinEnhancedPage .checkboxContainer > .dep-hint-text { flex-basis: 100%; }
 .dep-required-icon { vertical-align: middle; margin-left: 6px; }
 
 /* ---------------------------------------------------------------------------
@@ -1779,14 +1787,18 @@ body.je-has-filetransformation .je-installed-badge[data-plugin="filetransformati
     }
     .je-save-dock .je-save-dock-btn { width: 100%; justify-content: center; }
     .je-tab-bar { padding: 10px 0; }
-    .jellyfin-tab-button { padding: 8px 14px; }
+    /* Prefix with #JellyfinEnhancedPage to match the base rule's specificity
+       (1,1,0). Class-only selectors (0,1,0) here lose the cascade to the
+       prefixed base, leaving desktop padding/grid values stuck on phones. */
+    #JellyfinEnhancedPage .jellyfin-tab-button { padding: 8px 14px; }
     .je-tab-icon { font-size: 18px !important; }
 
     /* The tab content grid uses minmax(480px, 1fr) for desktop multi-column.
        On viewports narrower than the 480px min, the grid forces horizontal
        overflow (descriptions get cut off, page scrolls sideways). Collapse
-       to single column under 768px so cards stack cleanly. */
-    .jellyfin-tab-content.active {
+       to single column under 768px so cards stack cleanly. The prefix is
+       required for specificity parity with the base rule at line ~654. */
+    #JellyfinEnhancedPage .jellyfin-tab-content.active {
         grid-template-columns: 1fr;
         gap: 12px;
     }


### PR DESCRIPTION
## Summary

Two distinct CSS bugs were combining to make the admin config page unusable in portrait orientation on phones (any viewport below ~480px wide). On a Samsung S20 Ultra (412px) or iPhone 12 Pro (390px), fieldsets/inputs/descriptions were clipping past the right edge, and dep-hint text on gated sub-toggles (e.g. Pages tab "Use Plugin Pages for Hidden Content") was rendering inline beside the label instead of below it. Landscape and desktop layouts were unaffected.

## Bug 1 — Grid stayed at 480px minimum on phones

The mobile media query at `@media (max-width: 768px)` was setting `.jellyfin-tab-content.active { grid-template-columns: 1fr; gap: 12px; }` without the `#JellyfinEnhancedPage` ID prefix, so its specificity (0,2,0) lost to the base rule at line 654: `#JellyfinEnhancedPage .jellyfin-tab-content.active { grid-template-columns: repeat(auto-fit, minmax(480px, 1fr)); }` (1,1,0). The grid stayed pinned to a 480px minimum column even on a 390px viewport, forcing every card 90-100px wider than the screen.

Same specificity bug on `.jellyfin-tab-button` padding inside the same media query. Both rules now carry the prefix.

## Bug 2 — Parent-dep hints rendered side-by-side with the label

Parent-dep hints (e.g. `Enable "Enable Hidden Content" to configure`) are appended as direct `<div class="dep-hint-text">` children of `.checkboxContainer`, which is `display: flex; align-items: center`. So the hint became a flex sibling of the label, sharing the row. On narrow viewports both halves got crushed into ~150px columns.

Added `flex-wrap: wrap` to `.checkboxContainer` and `flex-basis: 100%` to `.checkboxContainer > .dep-hint-text` so the hint falls onto its own line below the label regardless of viewport width. The nested individual-dep hint (which lives inside the label's inner `<span>`) is untouched.

## Test plan

- [x] Built with `dotnet build` (0 warnings, 0 errors)
- [x] Deployed and tested on Jellyfin 10.11.x dev instance
- [x] No new console errors
- [x] Doesn't break existing functionality
- [x] Verified at 375px, 390px, 393px, 412px, 768px, 820px, 844px and 1440px viewports across Overview / Display / Playback / *arr / Seerr tabs: 0px horizontal overflow everywhere, desktop still gets multi-column layout (2 columns at 575px each on 1440px)
- [x] Verified parent-dep hint wrap on Pages tab (Use Plugin Pages / Use Custom Tabs for Hidden Content with Hidden Content unchecked): hint now sits on its own row below the label

## Screenshots

Before (Samsung S20 Ultra 412px, Display tab): fieldset overflows past the right edge, "Watch Progress Default" description truncated mid-word.

After: full description visible, all fieldsets fit within the viewport.

Before (iPhone 12 Pro 390px, Pages tab): "Use Plugin Pages for Hidden Content" label and "Enable 'Enable Hidden Content' to configure" hint cram into the same row, both broken across multiple lines.

After: label on its own row, hint below it, no overlap.

## AI assistance

This PR was developed with AI assistance (Claude). All changes have been reviewed, tested, and understood.