### PR TITLE
Remove margin-right from letterboxd icon style

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/others/letterboxd-links.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/others/letterboxd-links.js
@@ -45,7 +45,6 @@
                     background-size: contain;
                     background-repeat: no-repeat;
                     vertical-align: middle;
-                    margin-right: 5px;
                 }
             `;
             document.head.appendChild(style);


### PR DESCRIPTION
Removed margin-right style from letterboxd icon.

Before:
<img width="334" height="47" alt="image" src="https://github.com/user-attachments/assets/1dab8de9-8a12-4a63-8d82-47e6e76caa1f" />

After:
<img width="290" height="45" alt="image" src="https://github.com/user-attachments/assets/5359dc7b-e14c-4e93-92f7-5e109192aeb3" />

The bg being grey is from the theme i'm using :|

(extreme nit pick)
<img width="167" height="48" alt="image" src="https://github.com/user-attachments/assets/597e5de8-e2d7-4313-b988-c396f93ad993" />
idk if you would also like the hover to match the logo color:
<img width="307" height="39" alt="image" src="https://github.com/user-attachments/assets/64ef9ad5-cb3e-4feb-9fd9-eb298fcfe8a3" />