### PR TITLE
fix: duplicate approval notifications and un-approvable pending requests on available shows

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -5528,6 +5528,13 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                             posterUrl = posterUrl,
                             tmdbId = tmdbId,
                             mediaStatus = mediaStatus,
+                            // Raw Seerr request status (1=Pending, 2=Approved, 3=Declined,
+                            // 4=Failed, 5=Completed). Exposed separately from mediaStatus
+                            // because mediaStatus collapses to the media's availability
+                            // (e.g. "Partially Available" for a show that already has some
+                            // seasons), which masks a still-pending request and prevents the
+                            // approve/decline buttons from rendering.
+                            requestStatus = reqStatus,
                             requestedBy = displayName ?? username ?? "Unknown",
                             requestedByAvatar = avatarUrl,
                             createdAt = createdAtStr,

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests-page.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests-page.js
@@ -1999,8 +1999,18 @@
       });
     }
 
-    // Add click handlers for cards and watch buttons
-    container.addEventListener('click', (e) => {
+    // Add click handlers for cards and watch buttons.
+    // This delegated listener is attached to `container`, which persists across
+    // renders (see custom-tab reuse of state._customTabContainer and the
+    // container.innerHTML rebuild above). renderPage() runs on initial load, on
+    // every poll cycle, on tab switches and on search input, so binding here
+    // unconditionally stacks a new listener every render. A single Approve/Decline
+    // click would then fire once per accumulated listener, firing N approve POSTs
+    // (N duplicate Seerr "Request Approved" notifications) and ultimately failing
+    // the request. Bind exactly once per container element instead.
+    if (!container._jeRequestsActionsBound) {
+      container._jeRequestsActionsBound = true;
+      container.addEventListener('click', (e) => {
       // Handle play/watch button clicks
       const playBtn = e.target.closest('.je-request-watch-btn');
       if (playBtn) {
@@ -2050,7 +2060,8 @@
           window.Emby.Page.showItem(mediaId);
         }
       }
-    });
+      });
+    }
   }
 
   /**

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests-page.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests-page.js
@@ -1387,7 +1387,12 @@
     }
 
     let approvalButtons = "";
-    if (state.canApproveRequests && item.mediaStatus === "Pending" && item.id) {
+    // Gate on the request's own status (1 = Pending), NOT item.mediaStatus.
+    // mediaStatus collapses to the media's availability, so a pending request
+    // for a new season of an already-(partially-)available show reports
+    // "Partially Available"/"Available" and would otherwise hide the buttons,
+    // making the request impossible to approve from the UI.
+    if (state.canApproveRequests && item.requestStatus === 1 && item.id) {
       approvalButtons = `
         <button class="je-request-approve-btn" data-request-id="${escapeHtml(String(item.id))}" title="Approve"><span class="material-icons">check</span></button>
         <button class="je-request-decline-btn" data-request-id="${escapeHtml(String(item.id))}" title="Decline"><span class="material-icons">close</span></button>


### PR DESCRIPTION
## Description

Fixes two bugs in the Requests page (`js/arr/requests-page.js`) and its backing endpoint:

1. **Approving a request from the JE UI sends duplicate Seerr notifications and can fail the request.**
2. **A pending request for a new season of an already‑(partially‑)available show cannot be approved from the UI** (the approve/decline buttons never render).

### Bug 1 — duplicate approvals

The delegated `click` listener for the approve/decline/card/watch buttons was attached to the page **container inside `renderPage()`**. That container persists across renders (custom‑tab reuse of `state._customTabContainer`, and the standard page only resets `container.innerHTML`), while `renderPage()` runs on initial load, every poll cycle (default 30 s), tab switches and search input. So a new listener was added on **every** render and they stacked up on the same element. A single **Approve** click then fired `handleRequestAction` once per accumulated listener, sending N near‑simultaneous `POST …/arr/requests/{id}/approve`.

Seerr's approve route is a lock‑free read‑modify‑save, so N concurrent approvals on a still‑pending request each emit a "Request Approved" notification and each dispatch to Sonarr — producing the duplicate‑notification spam (and a failed request when the concurrent Sonarr sends collide). Native Seerr sends exactly one.

**Fix:** bind the delegated listener exactly once per container element (`container._jeRequestsActionsBound` guard). One click → one approve POST.

### Bug 2 — can't approve a pending season on an existing show

`renderRequestCard` gated the approve/decline buttons on `item.mediaStatus === "Pending"`. But `mediaStatus` comes from `GetMediaStatus()`, which returns the media's overall **availability** (e.g. `"Partially Available"` for a show that already has some seasons) **before** considering the request status — masking a still‑pending request. So pending season requests on existing shows showed no buttons and were impossible to approve from the UI (reported for "The Boys", Partially Available).

**Fix:** expose the raw Seerr request status as a new `requestStatus` field from the `arr/requests` endpoint and gate the buttons on `item.requestStatus === 1` (Pending) instead of the collapsed media status.

## Implementation Notes

This PR was developed with AI assistance (Claude Code). I have reviewed and tested all changes and understand the implementation.

- Changes are minimal and additive: a bind‑once guard, a one‑line gate change (`mediaStatus === "Pending"` → `requestStatus === 1`), and one new additive `requestStatus` field on the existing `arr/requests` response object. No existing fields, signatures, or other consumers are affected.
- The other per‑render listeners (`.je-refresh-btn`, `.je-downloads-tab`, `.je-downloads-search-*`) are intentionally left unguarded — they bind to freshly‑rendered child nodes that are discarded each render, so they do not leak.

## Reproduction (how it was verified)

- Reproduced Bug 1 live against a dev Seerr with the exact reported show: one pending request + 6 concurrent approvals → 1 `MEDIA_PENDING` + 6 `MEDIA_APPROVED` webhook notifications (matching the reporter's screenshot); a single approval → 1 notification and the unaired request stays queued.
- Verified the duplicate‑listener mechanism by executing the actual shipped `renderPage` binding block in a DOM harness: 7 renders + 1 click → 7 approve POSTs before the fix, 1 after.
- Verified Bug 2 against a running build: the `arr/requests` endpoint now returns `requestStatus`, and the real `renderRequestCard` renders approve/decline buttons for a `Partially Available` + pending item (and correctly hides them for approved/declined).

## Testing

- [x] Tested on Jellyfin 10.11 (10.11.10, plugin built and loaded as 11.12.0.0)
- [x] No plugin load/runtime errors in server logs
- [x] Verified served `requests-page.js` is byte‑identical to the patched source and behaves correctly in a DOM harness
- [x] Doesn't break existing functionality (approve gate fails closed when `requestStatus` is absent; XSS escaping via `escapeHtml` retained)

## Breaking changes

None.
