### PR TITLE
docs: Formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The essential enhancement suite for Jellyfin, bundling advanced features and cus
 Quick links:
 - [Installation Guide](https://n00bcodr.github.io/Jellyfin-Enhanced/installation/installation/)
 - [Features Overview](https://n00bcodr.github.io/Jellyfin-Enhanced/enhanced/enhanced-features/)
-- [Seerr Integration](https://n00bcodr.github.io/Jellyfin-Enhanced/jellyseerr/jellyseerr-features/)
+- [Seerr Integration](https://n00bcodr.github.io/Jellyfin-Enhanced/seerr/seerr-features/)
 - [ARR Integration](https://n00bcodr.github.io/Jellyfin-Enhanced/arr/arr-features/)
 - [FAQ & Troubleshooting](https://n00bcodr.github.io/Jellyfin-Enhanced/faq-support/faq/)
 - [CSS Customization](https://n00bcodr.github.io/Jellyfin-Enhanced/advanced/css-customization/)

--- a/docs/advanced/css-customization.md
+++ b/docs/advanced/css-customization.md
@@ -184,10 +184,13 @@ Structure of each link:
 ```
 
 Available hooks:
+
 - `.arr-tag-link` – the anchor element for a single tag
 - `.arr-tag-link-icon` – the icon span inside the link
 - `.arr-tag-link-text` – the label span inside the link
+
 - Data attributes on both the link and text spans:
+
   - `data-id` – a CSS-friendly slug of the raw tag (e.g. `in-netflix`)
   - `data-tag` – full tag text including the prefix
   - `data-tag-name` – tag without the prefix

--- a/docs/enhanced/enhanced-features.md
+++ b/docs/enhanced/enhanced-features.md
@@ -550,6 +550,7 @@ Replace default activity icons with Material Design icons.
 - Better visual distinction
 
 **Configuration:**
+
 Enable in Enhanced panel → Settings → Extras
 
 ### 🎪 Colored Ratings
@@ -580,6 +581,7 @@ Show user profile images on manual login page.
 - Automatic fallback to text
 
 **Configuration:**
+
 Enable in Enhanced panel → Settings → Extras
 
 ### 🧩 Plugin Icons

--- a/docs/enhanced/enhanced-features.md
+++ b/docs/enhanced/enhanced-features.md
@@ -507,6 +507,7 @@ A live stream counter in the Jellyfin header that shows who is currently playing
 **Session card details:**
 
 Each card in the panel shows:
+
 - Poster thumbnail (series poster for episodes, movie poster for films)
 - Title and episode info (S01E01 · Episode Name)
 - Playing / Paused badge

--- a/docs/faq-support/faq.md
+++ b/docs/faq-support/faq.md
@@ -204,15 +204,20 @@ Option B (manual in Seerr):
 <!-- use a custom title -->
 !!! info "How it works"
 
-    Bookmarks are stored server-side but settings are per-browser.
+    **Bookmarks are stored server-side, but settings are per-browser.**
 
-    - Bookmark data stored on Jellyfin server
+    > Same user can access bookmarks from any device
 
-    - Settings stored in browser `localStorage`
+    Stored on Jellyfin server:
+
+    - Bookmark **data** [`bookmarks.json`](../advanced/api.md#bookmark-api--info)
+
+    Stored in browsers' `localStorage`:
+
+    - Users' **settings**
 
     - Each browser has independent settings
 
-    - Same user can access bookmarks from any device
 
 **Syncing Bookmarks:**
 

--- a/docs/faq-support/faq.md
+++ b/docs/faq-support/faq.md
@@ -201,8 +201,8 @@ Option B (manual in Seerr):
 
 ### Bookmarks not syncing across devices?
 
-
-!!!  "How it works"
+<!-- use a custom title -->
+!!! info "How it works"
 
     Bookmarks are stored server-side but settings are per-browser.
 

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -41,12 +41,15 @@
     Why?
 
     - The File Transformation plugin helps avoid permission issues while modifying `index.html`
+    
     - Recommended on all installation types:
+
         - Docker
         - Windows
         - Linux
         - etc
-    - Without it, you may encounter permission errors
+
+    - Without it, you may encounter **permission errors**
 
 
 1. In the **Catalog** tab, search for "file-transformation"


### PR DESCRIPTION
# docs: Formatting fixes

## Fixes

- **lists:** white space lead to hanging ` - ` in plaintext
- **spacing** after 'bold headers':
    -  they require an extra space
- **admonitions** custom title `How it works`:
    - admonitions require a specified 'type' before the title 
    - _Bookmarks FAQ `How it works`: under `FAQ` > `Bookmarks not syncing across devices?`_
- formatting adjustments

## Implementation Notes

This PR was developed **without** the use of AI