### PR TITLE
docs: API overhaul

### DIFF
--- a/docs/advanced/api.md
+++ b/docs/advanced/api.md
@@ -104,7 +104,7 @@ curl -X GET \
 ```
 
 <!-- code block annotation -->
-1. Example: `http://localhost:8096:JellyfinEnhanced/jellyseerr/status`
+1. Example: `http://localhost:8096/JellyfinEnhanced/jellyseerr/status`
 
 ### Check User Status
 
@@ -118,7 +118,7 @@ curl -X GET \
 ```
 
 <!-- code block annotation -->
-1. Example: `http://localhost:8096:JellyfinEnhanced/jellyseerr/user-status`
+1. Example: `http://localhost:8096/JellyfinEnhanced/jellyseerr/user-status`
 
 ### Perform A Seerr Search
 
@@ -132,7 +132,7 @@ curl -X GET \
 ```
 
 <!-- code block annotation -->
-1. Example: `http://localhost:8096:JellyfinEnhanced/jellyseerr/search?query=Inception`
+1. Example: `http://localhost:8096/JellyfinEnhanced/jellyseerr/search?query=Inception`
 
 ### Make a Request on Seerr
 

--- a/docs/advanced/api.md
+++ b/docs/advanced/api.md
@@ -13,12 +13,12 @@ curl -X GET \
 
 ### Storage Directory
 Bookmarks are stored in the server's user data directory at:
-```
+``` title="bookmarks.json path" hl_lines="1"
 /config/data/users/{userId}/jellyfin-enhanced/bookmarks.json
 ```
 
 The data structure is:
-```json
+``` json title="bookmarks.json data structure"
 {
   "Bookmarks": {
     "unique-bookmark-id": {
@@ -42,12 +42,16 @@ The data structure is:
 External applications can read and write bookmarks using the Jellyfin Enhanced API endpoints
 
 #### Get Bookmarks
+
+<!-- TODO: change to `curl` ? -->
 ```http
 GET /JellyfinEnhanced/user-settings?fileName=bookmarks.json
 Authorization: MediaBrowser Token="{your-api-key}"
 ```
 
 #### Save Bookmarks
+
+<!-- TODO: change to `curl` ? -->
 ```http
 POST /JellyfinEnhanced/user-settings
 Authorization: MediaBrowser Token="{your-api-key}"
@@ -67,7 +71,7 @@ Plugin exposes proxy endpoints for Seerr:
 
 Checks if the plugin can connect to any of the configured Seerr URLs using the provided API key.
 
-```bash
+``` bash title="Bash" hl_lines="3"
 curl -X GET \
   -H "X-Emby-Token: <API_KEY>" \
   "<JELLYFIN_URL>/JellyfinEnhanced/jellyseerr/status"
@@ -77,7 +81,7 @@ curl -X GET \
 
 Verifies that the currently logged-in Jellyfin user is successfully linked to a Seerr user account.
 
-```bash
+``` bash title="Bash" hl_lines="4"
 curl -X GET \
   -H "X-Emby-Token: <JELLYFIN_API_KEY>" \
   -H "X-Jellyfin-User-Id: <JELLYFIN_USER_ID>" \
@@ -88,7 +92,7 @@ curl -X GET \
 
 Executes a search query through the Seerr instance for the specified user.
 
-```bash
+``` bash title="Bash" hl_lines="4"
 curl -X GET \
   -H "X-Emby-Token: <API_KEY>" \
   -H "X-Jellyfin-User-Id: <USER_ID>" \
@@ -99,10 +103,10 @@ curl -X GET \
 
 Submits a media request to Seerr on behalf of the specified user.
 
-- `mediaType` can be `tv` or `movie`\
+- `mediaType` can be `tv` or `movie`
 - `mediaId` is the **TMDB ID** of the item
 
-```bash
+``` bash title="Bash" hl_lines="6"
 curl -X POST \
   -H "X-Emby-Token: <API_KEY>" \
   -H "X-Jellyfin-User-Id: <USER_ID>" \

--- a/docs/advanced/api.md
+++ b/docs/advanced/api.md
@@ -1,25 +1,62 @@
 # Jellyfin Enhanced's API
 
-``` bash title="Check version of the plugin"
-curl -X GET \
-  "<JELLYFIN_ADDRESS>/JellyfinEnhanced/version"
-```
+???+ dev "Check version"
 
-## Bookmarks
+    **`/JellyfinEnhanced/version`**
 
-Bookmarks are stored as `bookmarks.json` files
+    === "cURL"
+
+
+        ``` bash title="Bash"
+        curl -X GET \
+          "JELLYFIN_SERVER_URL/JellyfinEnhanced/version"
+        ```
+
+    - Jellyfin Server URL (`JELLYFIN_URL`)
+
+<!-- TODO: add more here -->
+
+## Bookmarks API
+
+### Bookmarks Storage Directory
+
+Bookmarks are stored as `bookmarks.json` files:
 
 - `bookmarks.json` are saved in **Jellyfin Server's plugin configurations directory**
-- `bookmarks.json` are saved **for each user**
+- `bookmarks.json` are saved **for each user `userID`**
 
-<!-- Bash: so that annotations work (comments) -->
-``` bash title="bookmarks.json"
-/config/plugins/configurations/Jellyfin.Plugin.JellyfinEnhanced/{JELLYFIN_userId}/jellyfin-enhanced/bookmarks.json # (1)!
+``` title="bookmarks.json"
+/config/plugins/configurations/Jellyfin.Plugin.JellyfinEnhanced/JELLYFIN_USER_ID/jellyfin-enhanced/bookmarks.json
 ```
 
-1. `userId` is from Jellyfin's API. Example: ``
+<!-- collapsed -->
+??? question "`userID`? `JELLYFIN_USER_ID`?"
+    
+    > **`userID` (1) is Jellyfin Server's unique ID for each user**
+    > { .annotate }
+    >    
+    > <!-- annotation -->
+    > 
+    > 1. A.K.A. `X-Jellyfin-User-Id`
+    > 
+    > `JELLYFIN_USER_ID` is a placeholder for the users' `userID`
+    > 
+    > <br>
+    > 
+    > Reference: 
+    > 
+    > [Jellyfin's API documentation on `/Users`](https://api.jellyfin.org/#tag/User)
 
-``` json title="Data structure (Example)"
+    !!! tip 
+    
+        A simple way to **find which `userID` belongs to which user:**
+
+        - [x] Jellyfin Dashboard: `Users`
+        - [x] Click a user's profile
+        - [x] The `userID` for that user appears in the URL. For example: `9285e8b54149414941494edb9e464dcd` in the URL `http://localhost:8096/#/dashboard/users/profile?userId=9285e8b54149414941494edb9e464dcd`
+
+
+``` json title="bookmarks.json: Example Data structure"
 {
   "Bookmarks": {
     "unique-bookmark-id": {
@@ -38,109 +75,136 @@ Bookmarks are stored as `bookmarks.json` files
 }
 ```
 
-### API Access
+### Bookmarks API endpoints
 
-Bookmarks can be accessed via API endpoints
+<!-- TODO: these API endpoints do not work? -->
+<!--! `404` "No matching view found"        -->
 
-!!! info
-    
-    **API keys are required**
+**`/JellyfinEnhanced/user-settings`** (1)
+{ .annotate }
 
-<!-- content tabs for each language/method: each has the content + code blocks embedded within -->
-=== "HTTP Request"
+<!-- annotation -->
 
-    <!-- NOTE: using `bash`, because comments are required for Annotations in code blocks -->
-    ``` txt title="Get Bookmarks"
-    GET /JellyfinEnhanced/user-settings?fileName=bookmarks.json
-    Authorization: MediaBrowser Token="{your-api-key}" # (1)!
-    ```
-    
-    <!-- code block annotation -->
-    1. Pass your **API key** here
+1. Bookmark APIs are under `/user-settings`
 
-    ``` http title="Save Bookmarks"
-    POST /JellyfinEnhanced/user-settings
-    Authorization: MediaBrowser Token="{your-api-key}"
-    Content-Type: application/json
+<!-- custom admonition `api` for each API endpoint -->
+???+ dev "Get Bookmarks"
 
-    {
-      "fileName": "bookmarks.json",
-      "data": { "Bookmarks": {...} }
-    }
-    ```
+    **`/JellyfinEnhanced/user-settings?fileName=bookmarks.json`**
 
-=== "Bash"
+    <!-- content tabs for each language/method: code blocks are embedded within -->
+    === "cURL"
 
-    ``` bash title="Get Bookmarks"
-    curl \
-        -H 'Authorization: MediaBrowser Token="YOUR_API_KEY"' \ # (1)!
-        'https://your-jellyfin-server.com/JellyfinEnhanced/user-settings?fileName=bookmarks.json'
-    ```
+        ``` bash title="Bash" hl_lines="2-3"
+        curl \
+            -H 'Authorization: MediaBrowser Token="JELLYFIN_API_KEY"' \
+            'JELLYFIN_SERVER_URL/JellyfinEnhanced/user-settings?fileName=bookmarks.json'
+        ```
+  
+    === "HTTP"
 
-    1. Pass your **API key** here
+        ``` http
+        GET /JellyfinEnhanced/user-settings?fileName=bookmarks.json
+        Authorization: MediaBrowser Token="JELLYFIN_API_KEY"
+        ```
 
-    ``` http title="Save Bookmarks"
-    POST /JellyfinEnhanced/user-settings
-    Authorization: MediaBrowser Token="{your-api-key}"
-    Content-Type: application/json
+    - Jellyfin Server API key `MediaBrowser Token` (`JELLYFIN_API_KEY`)
+    - Jellyfin Server URL `JELLYFIN_SERVER_URL`
 
-    {
-      "fileName": "bookmarks.json",
-      "data": { "Bookmarks": {...} }
-    }
-    ```
+
+???+ dev "Save Bookmarks"
+
+    **`/JellyfinEnhanced/user-settings`**
+
+    === "cURL"
+
+        ``` bash title="Bash" hl_lines="2-10"
+            curl -X POST \
+                -H 'Content-Type: application/json' \
+                -H 'Authorization: MediaBrowser Token="JELLYFIN_API_KEY"' \
+                -d '{
+                    "fileName": "bookmarks.json",
+                    "data": {
+                        "Bookmarks": {}
+                    }
+                }'
+                '<JELLYFIN_SERVER_URL>/JellyfinEnhanced/user-settings'
+        ```
+
+    === "HTTP"
+
+        <!-- `bash`: provides some syntax highlighting -->
+
+        ``` bash title="HTTP Request"
+        POST /JellyfinEnhanced/user-settings
+        Authorization: MediaBrowser Token="JELLYFIN_API_KEY"
+        Content-Type: application/json
+
+        {
+          "fileName": "bookmarks.json",
+          "data": { "Bookmarks": {...} }
+        }
+        ```
+
+    - Jellyfin Server API key (`JELLYFIN_API_KEY`)
+    - Jellyfin Server URL `JELLYFIN_SERVER_URL`
+    - `bookmarks.json` JSON data
 
 ## Seerr Integration API
 
-Plugin exposes proxy endpoints for Seerr:
+**`/JellyfinEnhanced/jellyseerr`**
 
-### Check Connection Status
+<!-- explain what `JELLYFIN_USER_ID` and `JELLYFIN_API_KEY` are -->
+!!! info "Jellyfin Server's API"
+    
+    These values are from [Jellyfin Server's API:](https://api.jellyfin.org/)
 
-Checks if the plugin can connect to any of the configured Seerr URLs using the provided API key.
+    - `X-Jellyfin-User-Id`:
+      - **User Unique ID (UUID)**
+      - [Jellyfin's documentation: users](https://jellyfin.org/docs/general/server/users/)
+    
+    - `X-Emby-Token`: 
+      - **API key**
 
-``` bash title="Bash" hl_lines="2 3"
-curl -X GET \
-  -H "X-Emby-Token: <API_KEY>" \
-  "<JELLYFIN_URL>/JellyfinEnhanced/jellyseerr/status" #(1)!
-```
+???+ dev "Check Seerr connection"
 
-<!-- code block annotation -->
-1. Example: `http://localhost:8096/JellyfinEnhanced/jellyseerr/status`
+    **`/JellyfinEnhanced/jellyseerr/status`**
 
-### Check User Status
+    === "cURL"
 
-Verifies that the currently logged-in Jellyfin user is successfully linked to a Seerr user account.
+        ``` bash title="Bash" hl_lines="2-3"
+        curl -X GET \
+          -H "X-Emby-Token: JELLYFIN_API_KEY" \
+          "<JELLYFIN_URL>/JellyfinEnhanced/jellyseerr/status"
+        ```
 
-``` bash title="Bash" hl_lines="4"
-curl -X GET \
-  -H "X-Emby-Token: <JELLYFIN_API_KEY>" \
-  -H "X-Jellyfin-User-Id: <JELLYFIN_USER_ID>" \
-  "<JELLYFIN_ADDRESS>/JellyfinEnhanced/jellyseerr/user-status" # (1)!
-```
+    - Jellyfin Server API key (`JELLYFIN_API_KEY`)
+    - Jellyfin Server User ID (`JELLYFIN_USER_ID`)
+    - Jellyfin Server URL (`JELLYFIN_URL`)
 
-<!-- code block annotation -->
-1. Example: `http://localhost:8096/JellyfinEnhanced/jellyseerr/user-status`
+    Using [Seerr configuration](../seerr/seerr-settings.md):
 
-### Perform A Seerr Search
+    - URL(s)
+    - API keys    
 
-Executes a search query through the Seerr instance for the specified user.
 
-``` bash title="Bash" hl_lines="4"
-curl -X GET \
-  -H "X-Emby-Token: <API_KEY>" \
-  -H "X-Jellyfin-User-Id: <USER_ID>" \
-  "<JELLYFIN_URL>/JellyfinEnhanced/jellyseerr/search?query=Inception" # (1)!
-```
+???+ dev "Check if user `X-Jellyfin-User-Id` has a successfully linked Seerr account"
 
-<!-- code block annotation -->
-1. Example: `http://localhost:8096/JellyfinEnhanced/jellyseerr/search?query=Inception`
+    **`/JellyfinEnhanced/jellyseerr/user-status`**
 
-### Make a Request on Seerr
+    === "cURL"
+    
+        ``` bash title="Bash" hl_lines="2-4"
+        curl -X GET \
+          -H "X-Emby-Token: JELLYFIN_API_KEY" \
+          -H "X-Jellyfin-User-Id: JELLYFIN_USER_ID" \
+          "JELLYFIN_SERVER_URL/JellyfinEnhanced/jellyseerr/user-status"
+        ```
 
-Submits a media request to Seerr on behalf of the specified user.
+    - Jellyfin Server API key `X-Emby-Token` (`JELLYFIN_API_KEY`)
+    - Jellyfin Server User ID `X-Jellyfin-User-Id` (`JELLYFIN_USER_ID`)
+    - Jellyfin Server URL (`JELLYFIN_URL`)
 
-- `mediaType` can be `tv` or `movie`
-- `mediaId` is the **TMDB ID** of the item
 
 <!-- TODO: add annotation, on the highlighted line (URL) -->
 Example:

--- a/docs/advanced/api.md
+++ b/docs/advanced/api.md
@@ -9,7 +9,7 @@
     === "cURL"
 
 
-        ``` bash title="Bash"
+        ``` bash title="Bash" hl_lines="2"
         curl -X GET \
           "JELLYFIN_SERVER_URL/JellyfinEnhanced/version"
         ```

--- a/docs/advanced/api.md
+++ b/docs/advanced/api.md
@@ -1,24 +1,24 @@
-## Jellyfin Enhanced API
+# Jellyfin Enhanced's API
 
-### Get Plugin Version
-
-Checks the installed version of the Jellyfin Enhanced plugin:
-
-```bash
+``` bash title="Check version of the plugin"
 curl -X GET \
   "<JELLYFIN_ADDRESS>/JellyfinEnhanced/version"
 ```
 
-## Bookmark API + Info
+## Bookmarks
 
 ### Storage Directory
-Bookmarks are stored in the server's user data directory at:
-``` title="bookmarks.json path" hl_lines="1"
-/config/data/users/{userId}/jellyfin-enhanced/bookmarks.json
+
+Bookmarks are stored as `bookmarks.json` the server's user data directory
+
+<!-- Bash: so that annotations work (comments) -->
+``` bash title="bookmarks.json"
+/config/data/users/{userId}/jellyfin-enhanced/bookmarks.json # (1)!
 ```
 
-The data structure is:
-``` json title="bookmarks.json data structure"
+1. `userId` is from Jellyfin's API. Example: ``
+
+``` json title="Data structure (Example)"
 {
   "Bookmarks": {
     "unique-bookmark-id": {
@@ -39,29 +39,55 @@ The data structure is:
 
 ### API Access
 
-External applications can read and write bookmarks using the Jellyfin Enhanced API endpoints
+Bookmarks can be accessed via API endpoints
 
-#### Get Bookmarks
+!!! info
+    
+    **API keys are required**
 
-<!-- TODO: change to `curl` ? -->
-``` http
-GET /JellyfinEnhanced/user-settings?fileName=bookmarks.json
-Authorization: MediaBrowser Token="{your-api-key}"
-```
+<!-- content tabs for each language/method: each has the content + code blocks embedded within -->
+=== "HTTP Request"
 
-#### Save Bookmarks
+    <!-- NOTE: using `bash`, because comments are required for Annotations in code blocks -->
+    ``` txt title="Get Bookmarks"
+    GET /JellyfinEnhanced/user-settings?fileName=bookmarks.json
+    Authorization: MediaBrowser Token="{your-api-key}" # (1)!
+    ```
+    
+    <!-- code block annotation -->
+    1. Pass your **API key** here
 
-<!-- TODO: change to `curl` ? -->
-``` http
-POST /JellyfinEnhanced/user-settings
-Authorization: MediaBrowser Token="{your-api-key}"
-Content-Type: application/json
+    ``` http title="Save Bookmarks"
+    POST /JellyfinEnhanced/user-settings
+    Authorization: MediaBrowser Token="{your-api-key}"
+    Content-Type: application/json
 
-{
-  "fileName": "bookmarks.json",
-  "data": { "Bookmarks": {...} }
-}
-```
+    {
+      "fileName": "bookmarks.json",
+      "data": { "Bookmarks": {...} }
+    }
+    ```
+
+=== "Bash"
+
+    ``` bash title="Get Bookmarks"
+    curl \
+        -H 'Authorization: MediaBrowser Token="YOUR_API_KEY"' \ # (1)!
+        'https://your-jellyfin-server.com/JellyfinEnhanced/user-settings?fileName=bookmarks.json'
+    ```
+
+    1. Pass your **API key** here
+
+    ``` http title="Save Bookmarks"
+    POST /JellyfinEnhanced/user-settings
+    Authorization: MediaBrowser Token="{your-api-key}"
+    Content-Type: application/json
+
+    {
+      "fileName": "bookmarks.json",
+      "data": { "Bookmarks": {...} }
+    }
+    ```
 
 ## Seerr Integration API
 
@@ -71,7 +97,7 @@ Plugin exposes proxy endpoints for Seerr:
 
 Checks if the plugin can connect to any of the configured Seerr URLs using the provided API key.
 
-``` bash title="Bash" hl_lines="3"
+``` bash title="Bash" hl_lines="2 3"
 curl -X GET \
   -H "X-Emby-Token: <API_KEY>" \
   "<JELLYFIN_URL>/JellyfinEnhanced/jellyseerr/status" #(1)!

--- a/docs/advanced/api.md
+++ b/docs/advanced/api.md
@@ -1,5 +1,18 @@
 # Jellyfin Enhanced's API
 
+Jellyfin Enhanced adds features like **Bookmarks** and **User Reviews/Ratings** that live entirely in this plugin, not in Jellyfin Server itself. A user of any other Jellyfin client (Wholphin, Streamyfin, Afinity, a custom app, etc.) only gets these features if that client talks to the endpoints on this page directly, over plain HTTP with a Jellyfin token or API key. No client-side plugin, SDK, or Jellyfin Enhanced code is required, just an HTTP client and the request shapes documented below.
+
+Requirements before any of this works:
+
+- The Jellyfin Enhanced plugin must be installed and enabled on the target server
+- Your app needs a Jellyfin auth token (per-user, from that user logging in) or a server API key, exactly as it would for any other Jellyfin Server request. See [Quick Start](#quick-start-normal-user-vs-admin) below for how to get one and which calls need which
+- Bookmarks and Reviews both use **TMDB IDs**, not Jellyfin item IDs, to key data server-side (bookmarks also take an `itemId` when adding one, see [Bookmarks API endpoints](#bookmarks-api-endpoints))
+
+What this lets a client build, using only these HTTP endpoints:
+
+- A "bookmark this moment" button on the video player, and a bookmarks list/library screen (see [Bookmarks API](#bookmarks-api))
+- Star ratings and written reviews on a movie/show/season/episode details page, shared across every user on the server (see [Reviews API](#reviews-api))
+
 **`/JellyfinEnhanced`**
 
 ???+ dev "Check version"
@@ -18,47 +31,94 @@
 
 <!-- TODO: add more here -->
 
+## Quick Start: Normal User vs Admin
+
+There are two distinct ways to call the Bookmarks and Reviews endpoints below, depending on who is calling and whose data they are touching.
+
+### As a normal user, your own data only
+
+Log in as that user to get a per-user access token, then use that token in `Authorization: MediaBrowser Token="..."` for every call. With this token you can only read or write your own bookmarks and your own review, never another user's.
+
+??? question "How do I get `JELLYFIN_USER_ACCESS_TOKEN`?"
+
+    Call Jellyfin's own `POST /Users/AuthenticateByName` with that user's username and password. This is not a Jellyfin Enhanced endpoint, it is part of Jellyfin Server's own API.
+
+    === "cURL"
+
+        ``` bash title="Bash" hl_lines="2-4"
+        curl -X POST \
+          -H 'Content-Type: application/json' \
+          -H 'X-Emby-Authorization: MediaBrowser Client="MyApp", Device="MyApp", DeviceId="my-app-1", Version="1.0.0"' \
+          -d '{"Username": "JELLYFIN_USERNAME", "Pw": "JELLYFIN_PASSWORD"}' \
+          'JELLYFIN_SERVER_URL/Users/AuthenticateByName'
+        ```
+
+    The `X-Emby-Authorization` header is required, Jellyfin rejects the request without it even though no token exists yet at this point. `Client`, `Device`, `DeviceId`, and `Version` can be any values that identify your app.
+
+    The response body includes an `AccessToken` field, that is `JELLYFIN_USER_ACCESS_TOKEN`. It does not expire on its own, it stays valid until the user signs out or an admin revokes it from the Jellyfin Dashboard.
+
+    Alternatively, [Quick Connect](https://jellyfin.org/docs/general/clients/quick-connect/) gets a token without the app ever handling the user's password.
+
+- Post your own review: `POST /JellyfinEnhanced/reviews/{mediaType}/{tmdbId}`
+- Delete your own review: `DELETE /JellyfinEnhanced/reviews/{mediaType}/{tmdbId}`
+- Add a bookmark for yourself: `POST /JellyfinEnhanced/user-settings/{yourUserId}/bookmark.json/add`
+- Remove a bookmark for yourself: `DELETE /JellyfinEnhanced/user-settings/{yourUserId}/bookmark.json/{bookmarkId}`
+
+### As an admin, any user's data
+
+Generate a server API key from the Jellyfin Dashboard (Settings > API Keys), created by an Administrator account. Use that key in `X-Emby-Token` (Reviews) or `Authorization: MediaBrowser Token="..."` (Bookmarks), and put the target user's ID directly in the URL. This is the pattern a 3rd-party app should use to manage bookmarks and reviews for every user with a single credential, with no per-user login required.
+
+- Post a review as a specific user: `POST /JellyfinEnhanced/reviews/admin/{userIdN}/{mediaType}/{tmdbId}`
+- Delete a specific user's review: `DELETE /JellyfinEnhanced/reviews/admin/{userIdN}/{mediaType}/{tmdbId}`
+- Add a bookmark for a specific user: `POST /JellyfinEnhanced/user-settings/{userId}/bookmark.json/add`
+- Remove a bookmark for a specific user: `DELETE /JellyfinEnhanced/user-settings/{userId}/bookmark.json/{bookmarkId}`
+
+A non-admin token used against another user's `{userId}` is rejected. Full request and response details for every endpoint are below.
+
+!!! tip "Ratings vs. text reviews"
+
+    `{tmdbId}` in every Reviews endpoint above also accepts `{tmdbId}:s{season}` or `{tmdbId}:s{season}:e{episode}`, so a TV show can carry its own review plus separate ones per season/episode. A review's `rating` (1-5) and `content` are independent: send `rating` alone for a star-rating-only UI, `content` alone for text-only, or both. See [Rating and content rules](#rating-and-content-rules) in the Reviews API section.
+
 ## Bookmarks API
+
+!!! info "New in v11.13.0.0"
+
+    The additive `bookmark.json/add` and `bookmark.json/{bookmarkId}` endpoints below, and admin access to any user's bookmarks via a server API key, are new in v11.13.0.0. Earlier versions only support reading or replacing the whole file with a per-user access token.
 
 ### Bookmarks Storage Directory
 
-Bookmarks are stored as `bookmarks.json` files:
+Bookmarks are stored as `bookmark.json` (singular), inside a folder named after the user's ID, under the plugin's own configuration directory:
 
-- `bookmarks.json` are saved in **Jellyfin Server's plugin configurations directory**
-- `bookmarks.json` are saved **for each user `userID`**
-
-``` title="bookmarks.json"
-/config/plugins/configurations/Jellyfin.Plugin.JellyfinEnhanced/JELLYFIN_USER_ID/jellyfin-enhanced/bookmarks.json
+``` title="bookmark.json"
+{JELLYFIN_DATA_DIR}/plugins/configurations/Jellyfin.Plugin.JellyfinEnhanced/JELLYFIN_USER_ID/bookmark.json
 ```
 
-<!-- collapsed -->
+`JELLYFIN_USER_ID` here is the user's GUID with hyphens stripped and lowercased (e.g. `9285e8b541494149...`), regardless of the casing or format used in the URL.
+
 ??? question "`userID`? `JELLYFIN_USER_ID`?"
-    
-    > **`userID` (1) is Jellyfin Server's unique ID for each user**
+
+    > **`userID` is Jellyfin Server's unique ID for each user**
     > { .annotate }
-    >    
+    >
     > <!-- annotation -->
-    > 
-    > 1. A.K.A. `X-Jellyfin-User-Id`
-    > 
-    > `JELLYFIN_USER_ID` is a placeholder for the users' `userID`
-    > 
+    >
+    > `JELLYFIN_USER_ID` is a placeholder for the user's `userID`
+    >
     > <br>
-    > 
-    > Reference: 
-    > 
+    >
+    > Reference:
+    >
     > [Jellyfin's API documentation on `/Users`](https://api.jellyfin.org/#tag/User)
 
-    !!! tip 
-    
+    !!! tip
+
         A simple way to **find which `userID` belongs to which user:**
 
         - [x] Jellyfin Dashboard: `Users`
         - [x] Click a user's profile
         - [x] The `userID` for that user appears in the URL. For example: `9285e8b54149414941494edb9e464dcd` in the URL `http://localhost:8096/#/dashboard/users/profile?userId=9285e8b54149414941494edb9e464dcd`
 
-
-``` json title="bookmarks.json: Example Data structure"
+``` json title="bookmark.json: Example Data structure"
 {
   "Bookmarks": {
     "unique-bookmark-id": {
@@ -77,80 +137,252 @@ Bookmarks are stored as `bookmarks.json` files:
 }
 ```
 
+### Authentication: two ways to call these
+
+- **As the user themselves**: pass a per-user access token (obtained by that user logging in) in `Authorization: MediaBrowser Token="..."`. Works for the user's own `JELLYFIN_USER_ID` only.
+- **As an admin, for any user**: pass a server **Administrator** API key. The plugin will let an Administrator key act on any `JELLYFIN_USER_ID`, which is what lets a 3rd-party app manage bookmarks for every user with a single credential.
+
+A non-admin user calling with someone else's `JELLYFIN_USER_ID` is rejected.
+
 ### Bookmarks API endpoints
 
-<!-- TODO: these API endpoints do not work? -->
-<!--! `404` "No matching view found"        -->
+`bookmark.json` is one of several per-user settings files served under `/user-settings/{userId}/{file}` (the same pattern covers `settings.json`, `shortcuts.json`, `elsewhere.json`, and `hidden-content.json`).
 
-**`/JellyfinEnhanced/user-settings`** (1)
-{ .annotate }
-
-<!-- annotation -->
-
-1. Bookmark APIs are under `/user-settings`
-
-<!-- custom admonition `api` for each API endpoint -->
 ???+ dev "Get Bookmarks"
 
-    **`/JellyfinEnhanced/user-settings?fileName=bookmarks.json`**
+    **`/JellyfinEnhanced/user-settings/{userId}/bookmark.json`**
 
-    <!-- content tabs for each language/method: code blocks are embedded within -->
     === "cURL"
 
         ``` bash title="Bash" hl_lines="2-3"
-        curl \
-            -H 'Authorization: MediaBrowser Token="JELLYFIN_API_KEY"' \
-            'JELLYFIN_SERVER_URL/JellyfinEnhanced/user-settings?fileName=bookmarks.json'
+        curl -X GET \
+          -H 'Authorization: MediaBrowser Token="JELLYFIN_TOKEN"' \
+          'JELLYFIN_SERVER_URL/JellyfinEnhanced/user-settings/JELLYFIN_USER_ID/bookmark.json'
         ```
-  
+
     === "HTTP"
 
         ``` http
-        GET /JellyfinEnhanced/user-settings?fileName=bookmarks.json
-        Authorization: MediaBrowser Token="JELLYFIN_API_KEY"
+        GET /JellyfinEnhanced/user-settings/JELLYFIN_USER_ID/bookmark.json
+        Authorization: MediaBrowser Token="JELLYFIN_TOKEN"
         ```
 
-    - Jellyfin Server API key `MediaBrowser Token` (`JELLYFIN_API_KEY`)
+    - `JELLYFIN_TOKEN`: a per-user access token for `JELLYFIN_USER_ID`, or an Administrator API key
     - Jellyfin Server URL `JELLYFIN_SERVER_URL`
 
+    Returns the `bookmark.json` contents directly, not wrapped. An empty `{"Bookmarks": {}}` if the user has none yet.
 
-???+ dev "Save Bookmarks"
+???+ dev "Replace all Bookmarks"
 
-    **`/JellyfinEnhanced/user-settings`**
+    **`/JellyfinEnhanced/user-settings/{userId}/bookmark.json`**
+
+    Overwrites the whole file. Use the additive endpoint below instead if you only want to add or remove one bookmark.
 
     === "cURL"
 
-        ``` bash title="Bash" hl_lines="2-10"
-            curl -X POST \
-                -H 'Content-Type: application/json' \
-                -H 'Authorization: MediaBrowser Token="JELLYFIN_API_KEY"' \
-                -d '{
-                    "fileName": "bookmarks.json",
-                    "data": {
-                        "Bookmarks": {}
-                    }
-                }'
-                '<JELLYFIN_SERVER_URL>/JellyfinEnhanced/user-settings'
+        ``` bash title="Bash" hl_lines="2-6"
+        curl -X POST \
+          -H 'Content-Type: application/json' \
+          -H 'Authorization: MediaBrowser Token="JELLYFIN_TOKEN"' \
+          -d '{
+                "Bookmarks": {}
+              }' \
+          'JELLYFIN_SERVER_URL/JellyfinEnhanced/user-settings/JELLYFIN_USER_ID/bookmark.json'
         ```
 
     === "HTTP"
 
-        <!-- `bash`: provides some syntax highlighting -->
-
-        ``` bash title="HTTP Request"
-        POST /JellyfinEnhanced/user-settings
-        Authorization: MediaBrowser Token="JELLYFIN_API_KEY"
+        ``` http
+        POST /JellyfinEnhanced/user-settings/JELLYFIN_USER_ID/bookmark.json
+        Authorization: MediaBrowser Token="JELLYFIN_TOKEN"
         Content-Type: application/json
 
-        {
-          "fileName": "bookmarks.json",
-          "data": { "Bookmarks": {...} }
-        }
+        { "Bookmarks": { ... } }
+        ```
+
+    - `JELLYFIN_TOKEN`: a per-user access token for `JELLYFIN_USER_ID`, or an Administrator API key
+    - Jellyfin Server URL `JELLYFIN_SERVER_URL`
+    - The request body is the raw bookmarks object itself, not wrapped in `{ "fileName": ..., "data": ... }`.
+
+???+ dev "Add one Bookmark"
+
+    **`/JellyfinEnhanced/user-settings/{userId}/bookmark.json/add`**
+
+    Adds a single bookmark without touching the rest of the file. The server generates the bookmark ID and timestamps and returns the new ID.
+
+    === "cURL"
+
+        ``` bash title="Bash" hl_lines="2-4"
+        curl -X POST \
+          -H 'Content-Type: application/json' \
+          -H 'Authorization: MediaBrowser Token="JELLYFIN_TOKEN"' \
+          -d '{
+                "itemId": "jellyfin-item-id",
+                "tmdbId": "1949",
+                "mediaType": "movie",
+                "name": "Zodiac",
+                "timestamp": 1234.5,
+                "label": "Great scene"
+              }' \
+          'JELLYFIN_SERVER_URL/JellyfinEnhanced/user-settings/JELLYFIN_USER_ID/bookmark.json/add'
+        ```
+
+    - `JELLYFIN_TOKEN`: a per-user access token for `JELLYFIN_USER_ID`, or an Administrator API key
+    - `itemId` is required. `tmdbId`, `tvdbId`, `mediaType`, `name`, `timestamp`, `label`, and `syncedFrom` are all optional.
+
+    Response: `{"success": true, "id": "Bm_1234567890_abc123xyz"}`
+
+???+ dev "Remove one Bookmark"
+
+    **`/JellyfinEnhanced/user-settings/{userId}/bookmark.json/{bookmarkId}`**
+
+    === "cURL"
+
+        ``` bash title="Bash" hl_lines="2"
+        curl -X DELETE \
+          -H 'Authorization: MediaBrowser Token="JELLYFIN_TOKEN"' \
+          'JELLYFIN_SERVER_URL/JellyfinEnhanced/user-settings/JELLYFIN_USER_ID/bookmark.json/BOOKMARK_ID'
+        ```
+
+    - `BOOKMARK_ID` is the ID returned by the add endpoint, or a key from the `Bookmarks` object returned by the get endpoint
+    - Returns `404` with `{"success": false, "removed": false}` if no bookmark with that ID exists
+
+## Reviews API
+
+!!! info "New in v11.13.0.0"
+
+    Admin access to any user's reviews via a server API key is new in v11.13.0.0. Earlier versions only support reading reviews or writing your own review with a per-user access token.
+
+User reviews and ratings, shared across all users on the server. Each review is a `content` string and an optional 1-5 star `rating`, keyed by author + item, and reviews for one item are stored together in a single shared `reviews.json` (not a per-user file). This is the API to use if you want to build star ratings, review lists, or an average-rating badge for a client.
+
+### Rating and content rules
+
+Every write endpoint below (self or admin) validates the same `ReviewPayload` body:
+
+- `content` (string, optional): trimmed server-side; rejected with `400` if longer than 2000 characters
+- `rating` (integer, optional): must be `1`-`5` inclusive, or omitted; `0`, `6`, or a non-integer value is rejected with `400`
+- At least one of `content` or `rating` must be present, an empty payload (`{}`) is rejected with `400 {"success": false, "message": "A rating or review text is required."}`
+- This means a **ratings-only** review (`{"rating": 4}`, no text) and a **text-only** review (`{"content": "..."}`, no rating) are both valid
+
+### Reviewing a season or episode of a TV show
+
+`{tmdbId}` in the URL is not just the bare TMDB ID, it also accepts two extended forms so a single `mediaType: tv` item can carry separate reviews per season or per episode:
+
+- `{tmdbId}` — the show as a whole, e.g. `1399`
+- `{tmdbId}:s{season}` — a specific season, e.g. `1399:s1`
+- `{tmdbId}:s{season}:e{episode}` — a specific episode, e.g. `1399:s1:e1`
+
+Any other shape (letters, missing digits, extra segments) is rejected with `400 {"message": "Invalid TmdbId."}`. `mediaType` must always be `movie` or `tv`, both `movie:s1` and any `mediaType` other than `movie`/`tv` are rejected the same way. URL-encode the colons (`%3A`) if your HTTP client doesn't do it for you.
+
+???+ dev "Get reviews for an item"
+
+    **`/JellyfinEnhanced/reviews/{mediaType}/{tmdbId}`**
+
+    === "cURL"
+
+        ``` bash title="Bash" hl_lines="2"
+        curl -X GET \
+          -H "X-Emby-Token: JELLYFIN_API_KEY" \
+          "JELLYFIN_SERVER_URL/JellyfinEnhanced/reviews/movie/TMDB_ID"
         ```
 
     - Jellyfin Server API key (`JELLYFIN_API_KEY`)
-    - Jellyfin Server URL `JELLYFIN_SERVER_URL`
-    - `bookmarks.json` JSON data
+    - `mediaType`: `movie` or `tv`
+    - `TMDB_ID`: the item's TMDB ID, or one of the season/episode forms above
+
+    A plain API key is enough to read reviews, there is no per-user identity involved here. Any authenticated caller (per-user token or API key) sees every non-hidden reviewer's review; an admin caller always sees every review, including ones from hidden or disabled authors, for moderation.
+
+    Response:
+
+    ``` json title="200 OK"
+    {
+      "reviews": [
+        {
+          "userId": "9285e8b541494149...",
+          "userName": "alice",
+          "tmdbId": "TMDB_ID",
+          "mediaType": "movie",
+          "content": "Great movie!",
+          "rating": 5,
+          "createdAt": "2026-01-03T12:00:00.000Z",
+          "updatedAt": "2026-01-03T12:00:00.000Z"
+        }
+      ]
+    }
+    ```
+
+    - `reviews` is `[]`, never missing, when nobody has reviewed the item yet
+    - `rating` is `null` for a text-only review
+    - Average rating and review count are not pre-computed by the server, a client wanting those should reduce over the `rating` field of the returned array itself
+
+???+ dev "Add or edit your own review"
+
+    **`/JellyfinEnhanced/reviews/{mediaType}/{tmdbId}`**
+
+    Creates your review if you don't have one for this item yet, or updates it (both `content` and `rating` are replaced, not merged) if you do.
+
+    === "cURL"
+
+        ``` bash title="Bash" hl_lines="2-3"
+        curl -X POST \
+          -H "Content-Type: application/json" \
+          -H 'Authorization: MediaBrowser Token="JELLYFIN_USER_ACCESS_TOKEN"' \
+          -d '{"content": "Great movie!", "rating": 5}' \
+          "JELLYFIN_SERVER_URL/JellyfinEnhanced/reviews/movie/TMDB_ID"
+        ```
+
+    - A per-user access token (`JELLYFIN_USER_ACCESS_TOKEN`), this writes the review under whichever user the token belongs to
+    - `rating` is optional, omit it to leave a text-only review; see [Rating and content rules](#rating-and-content-rules) above for the accepted values
+    - Response: `{"success": true}`. A `400` with `{"success": false, "message": "..."}` explains which validation rule failed
+
+???+ dev "Delete your own review"
+
+    **`/JellyfinEnhanced/reviews/{mediaType}/{tmdbId}`**
+
+    === "cURL"
+
+        ``` bash title="Bash" hl_lines="2"
+        curl -X DELETE \
+          -H 'Authorization: MediaBrowser Token="JELLYFIN_USER_ACCESS_TOKEN"' \
+          "JELLYFIN_SERVER_URL/JellyfinEnhanced/reviews/movie/TMDB_ID"
+        ```
+
+    - Response: `{"success": true}` whether or not a review existed, this endpoint does not report `404` for a no-op delete (unlike the bookmark and admin-review delete endpoints below)
+
+???+ dev "Add or edit a review as a specific user (admin)"
+
+    **`/JellyfinEnhanced/reviews/admin/{userIdN}/{mediaType}/{tmdbId}`**
+
+    Lets an Administrator API key create or update a review for any user, identified by an explicit `userIdN`. This is what a 3rd-party app should use to manage reviews for multiple users with one credential. Creates the review if none exists yet for that user and item, or updates it otherwise.
+
+    === "cURL"
+
+        ``` bash title="Bash" hl_lines="2-3"
+        curl -X POST \
+          -H "Content-Type: application/json" \
+          -H "X-Emby-Token: JELLYFIN_API_KEY" \
+          -d '{"content": "Great movie!", "rating": 5}' \
+          "JELLYFIN_SERVER_URL/JellyfinEnhanced/reviews/admin/JELLYFIN_USER_ID/movie/TMDB_ID"
+        ```
+
+    - Jellyfin Server **Administrator** API key (`JELLYFIN_API_KEY`)
+    - `JELLYFIN_USER_ID` here is the 32-character hex form with no dashes (the same format returned by the get-bookmarks endpoint, not the dashed form shown in the Jellyfin dashboard URL)
+    - Same [rating and content rules](#rating-and-content-rules) as the self-review endpoint above; `rating` still only allows `1`-`5` or omitted, an admin key does not bypass validation
+    - Response: `{"success": true}`. A non-admin key gets `403 Forbidden`, a malformed `userIdN` gets `400`
+
+???+ dev "Delete a specific user's review (admin)"
+
+    **`/JellyfinEnhanced/reviews/admin/{userIdN}/{mediaType}/{tmdbId}`**
+
+    === "cURL"
+
+        ``` bash title="Bash" hl_lines="2"
+        curl -X DELETE \
+          -H "X-Emby-Token: JELLYFIN_API_KEY" \
+          "JELLYFIN_SERVER_URL/JellyfinEnhanced/reviews/admin/JELLYFIN_USER_ID/movie/TMDB_ID"
+        ```
+
+    Returns `404` with `{"success": false, "removed": false}` if no review exists for that user and item.
 
 ## Seerr Integration API
 
@@ -158,14 +390,14 @@ Bookmarks are stored as `bookmarks.json` files:
 
 <!-- explain what `JELLYFIN_USER_ID` and `JELLYFIN_API_KEY` are -->
 !!! info "Jellyfin Server's API"
-    
+
     These values are from [Jellyfin Server's API:](https://api.jellyfin.org/)
 
     - `X-Jellyfin-User-Id`:
       - **User Unique ID (UUID)**
       - [Jellyfin's documentation: users](https://jellyfin.org/docs/general/server/users/)
-    
-    - `X-Emby-Token`: 
+
+    - `X-Emby-Token`:
       - **API key**
 
 ???+ dev "Check Seerr connection"
@@ -187,7 +419,7 @@ Bookmarks are stored as `bookmarks.json` files:
     Using [Seerr configuration](../seerr/seerr-settings.md):
 
     - URL(s)
-    - API keys    
+    - API keys
 
 
 ???+ dev "Check if user `X-Jellyfin-User-Id` has a successfully linked Seerr account"
@@ -195,7 +427,7 @@ Bookmarks are stored as `bookmarks.json` files:
     **`/JellyfinEnhanced/jellyseerr/user-status`**
 
     === "cURL"
-    
+
         ``` bash title="Bash" hl_lines="2-4"
         curl -X GET \
           -H "X-Emby-Token: JELLYFIN_API_KEY" \

--- a/docs/advanced/api.md
+++ b/docs/advanced/api.md
@@ -1,5 +1,7 @@
 # Jellyfin Enhanced's API
 
+**`/JellyfinEnhanced`**
+
 ???+ dev "Check version"
 
     **`/JellyfinEnhanced/version`**

--- a/docs/advanced/api.md
+++ b/docs/advanced/api.md
@@ -44,7 +44,7 @@ External applications can read and write bookmarks using the Jellyfin Enhanced A
 #### Get Bookmarks
 
 <!-- TODO: change to `curl` ? -->
-```http
+``` http
 GET /JellyfinEnhanced/user-settings?fileName=bookmarks.json
 Authorization: MediaBrowser Token="{your-api-key}"
 ```
@@ -52,7 +52,7 @@ Authorization: MediaBrowser Token="{your-api-key}"
 #### Save Bookmarks
 
 <!-- TODO: change to `curl` ? -->
-```http
+``` http
 POST /JellyfinEnhanced/user-settings
 Authorization: MediaBrowser Token="{your-api-key}"
 Content-Type: application/json
@@ -74,8 +74,11 @@ Checks if the plugin can connect to any of the configured Seerr URLs using the p
 ``` bash title="Bash" hl_lines="3"
 curl -X GET \
   -H "X-Emby-Token: <API_KEY>" \
-  "<JELLYFIN_URL>/JellyfinEnhanced/jellyseerr/status"
+  "<JELLYFIN_URL>/JellyfinEnhanced/jellyseerr/status" #(1)!
 ```
+
+<!-- code block annotation -->
+1. Example: `http://localhost:8096:JellyfinEnhanced/jellyseerr/status`
 
 ### Check User Status
 
@@ -85,8 +88,11 @@ Verifies that the currently logged-in Jellyfin user is successfully linked to a 
 curl -X GET \
   -H "X-Emby-Token: <JELLYFIN_API_KEY>" \
   -H "X-Jellyfin-User-Id: <JELLYFIN_USER_ID>" \
-  "<JELLYFIN_ADDRESS>/JellyfinEnhanced/jellyseerr/user-status"
+  "<JELLYFIN_ADDRESS>/JellyfinEnhanced/jellyseerr/user-status" # (1)!
 ```
+
+<!-- code block annotation -->
+1. Example: `http://localhost:8096:JellyfinEnhanced/jellyseerr/user-status`
 
 ### Perform A Seerr Search
 
@@ -96,8 +102,11 @@ Executes a search query through the Seerr instance for the specified user.
 curl -X GET \
   -H "X-Emby-Token: <API_KEY>" \
   -H "X-Jellyfin-User-Id: <USER_ID>" \
-  "<JELLYFIN_URL>/JellyfinEnhanced/jellyseerr/search?query=Inception"
+  "<JELLYFIN_URL>/JellyfinEnhanced/jellyseerr/search?query=Inception" # (1)!
 ```
+
+<!-- code block annotation -->
+1. Example: `http://localhost:8096:JellyfinEnhanced/jellyseerr/search?query=Inception`
 
 ### Make a Request on Seerr
 
@@ -106,6 +115,8 @@ Submits a media request to Seerr on behalf of the specified user.
 - `mediaType` can be `tv` or `movie`
 - `mediaId` is the **TMDB ID** of the item
 
+<!-- TODO: add annotation, on the highlighted line (URL) -->
+Example:
 ``` bash title="Bash" hl_lines="6"
 curl -X POST \
   -H "X-Emby-Token: <API_KEY>" \

--- a/docs/advanced/api.md
+++ b/docs/advanced/api.md
@@ -7,13 +7,14 @@ curl -X GET \
 
 ## Bookmarks
 
-### Storage Directory
+Bookmarks are stored as `bookmarks.json` files
 
-Bookmarks are stored as `bookmarks.json` the server's user data directory
+- `bookmarks.json` are saved in **Jellyfin Server's plugin configurations directory**
+- `bookmarks.json` are saved **for each user**
 
 <!-- Bash: so that annotations work (comments) -->
 ``` bash title="bookmarks.json"
-/config/data/users/{userId}/jellyfin-enhanced/bookmarks.json # (1)!
+/config/plugins/configurations/Jellyfin.Plugin.JellyfinEnhanced/{JELLYFIN_userId}/jellyfin-enhanced/bookmarks.json # (1)!
 ```
 
 1. `userId` is from Jellyfin's API. Example: ``

--- a/docs/faq-support/faq.md
+++ b/docs/faq-support/faq.md
@@ -210,11 +210,11 @@ Option B (manual in Seerr):
 
     **Stored on Jellyfin server:**
 
-    - [Bookmark **data** `bookmarks.json`](../advanced/api.md#bookmark-api--info)
+    - [Bookmark **data** `bookmark.json`](../advanced/api.md#bookmarks-api)
 
     - Spoiler Guard **per-user list and override prefs** `spoilerblur.json`
 
-   ** Stored in browsers' `localStorage`:**
+    **Stored in browsers' `localStorage`:**
 
     - [Users' **settings**](../enhanced/enhanced-features.md#smart-bookmarks)
 
@@ -226,7 +226,7 @@ Option B (manual in Seerr):
 
 - Check bookmark file exists on server
 
-- Look in `/config/data/users/{userId}/jellyfin-enhanced/bookmarks.json`
+- Look in `{JELLYFIN_DATA_DIR}/plugins/configurations/Jellyfin.Plugin.JellyfinEnhanced/{userId}/bookmark.json`
 
 - Check browser console for errors
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -66,7 +66,7 @@
   border-radius: 4px;
   padding: 2px 5px;
   background: rgba(155, 89, 182, 0.15) !important;
-  color: #d199f5 !important;
+  color: #d199f5 !important; /* this impacts ALL rendered code */
 }
 
 /* Annotations wider, for more content */
@@ -87,6 +87,31 @@
 
 .md-typeset .admonition-title {
   border-radius: 10px 10px 0 0;
+}
+
+/* Custom admonition          */
+/* use as `!!! dev`           */
+:root {
+  /* Icon for the custom admonition:  */
+  /* Fontawesome: `code`              */
+  --md-admonition-icon--dev: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M392.8 65.2C375.8 60.3 358.1 70.2 353.2 87.2L225.2 535.2C220.3 552.2 230.2 569.9 247.2 574.8C264.2 579.7 281.9 569.8 286.8 552.8L414.8 104.8C419.7 87.8 409.8 70.1 392.8 65.2zM457.4 201.3C444.9 213.8 444.9 234.1 457.4 246.6L530.8 320L457.4 393.4C444.9 405.9 444.9 426.2 457.4 438.7C469.9 451.2 490.2 451.2 502.7 438.7L598.7 342.7C611.2 330.2 611.2 309.9 598.7 297.4L502.7 201.4C490.2 188.9 469.9 188.9 457.4 201.4zM182.7 201.3C170.2 188.8 149.9 188.8 137.4 201.3L41.4 297.3C28.9 309.8 28.9 330.1 41.4 342.6L137.4 438.6C149.9 451.1 170.2 451.1 182.7 438.6C195.2 426.1 195.2 405.8 182.7 393.3L109.3 320L182.6 246.6C195.1 234.1 195.1 213.8 182.6 201.3z"/></svg>')
+}
+/* "details" (for collapsed only) */
+.md-typeset .admonition.dev,
+.md-typeset details.dev {
+  border-color: var(--md-primary-fg-color);
+}
+/* title */
+.md-typeset .dev > .admonition-title,
+.md-typeset .dev > summary {
+  background-color: var(--md-primary-fg-color);
+}
+/* icon */
+.md-typeset .dev > .admonition-title::before,
+.md-typeset .dev > summary::before {
+  background-color: #ffffff;
+  -webkit-mask-image: var(--md-admonition-icon--dev);
+          mask-image: var(--md-admonition-icon--dev);
 }
 
 /* ============================================================

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -69,6 +69,12 @@
   color: #d199f5 !important;
 }
 
+/* Annotations wider, for more content */
+:root {
+  --md-tooltip-width: 600px;
+}
+
+
 /* ============================================================
    ADMONITIONS (note, tip, warning etc)
    ============================================================ */


### PR DESCRIPTION
# API documentation overhaul!!

**This is a draft**

You can see a preview here:
https://sgtm-devs.github.io/Jellyfin-Enhanced/advanced/api/

I'd love feedback!

## What changed

> _(so far)_

- restructure completely
- make things pretty:
   - line highlighting
   - create a **custom admonition** (`dev`), and use that for each API endpoint/action
- label/specify method: `cURL`, `Bash`, `HTTP`, etc
- clarify what values are  "Jellyfin Server API" and what are "Jellyfin Enhanced API"
- placeholder values: improve *consistency*
   - Example: _always_ use `JELLYFIN_SERVER_URL`, not `<jellyfin-url>` or `{your-jellyfin-server}`

- etc

## TO-DO:
- **verify API endpoints** (and that i understand them correctly)
  - Example: I don't think **Bookmarks API endpoint commands are functioning as written**

- `Bookmarks Storage Directory`: make it look better

- Cleanup

- Add:
  - More API endpoints:
      - any else i don't know about?
      - **Reviews API**
  - more language/method examples *(HTTP, Python, etc)*


## AI/LLM disclosure

This PR was developed with the **limited use of AI:**
- I wrote 95% of it by hand
- An LLM helped me:
  - Convert HTTP Requests to `curl`
  - When I got stuck on a `git push` issue

