### PR TITLE
fix(tag-cache): stop re-saving the whole cache on no-op library events

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Model/TagCacheEntry.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Model/TagCacheEntry.cs
@@ -77,23 +77,25 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Model
         private static bool SequencesEqual(string[]? a, string[]? b)
         {
             if (ReferenceEquals(a, b)) return true;
-            if (a == null || b == null) return a == null && b == null;
+            if (a == null || b == null) return false;
             if (a.Length != b.Length) return false;
             for (var i = 0; i < a.Length; i++)
             {
-                if (!string.Equals(a[i], b[i], System.StringComparison.Ordinal)) return false;
+                if (!string.Equals(a[i], b[i], StringComparison.Ordinal)) return false;
             }
 
             return true;
         }
 
         /// <summary>
-        /// Exact nullable-float compare. Exactness is safe here: both values are read
-        /// from the same database column, so an unchanged rating is bit-identical.
-        /// Nullable.Equals also treats NaN as equal to NaN, so a NaN rating can't
-        /// keep an entry perpetually "changed".
+        /// Exact nullable-float compare. Exactness is safe on both legs: a freshly
+        /// rebuilt value is read from the same database column as the last rebuild,
+        /// and a disk-loaded value round-trips bit-exactly because System.Text.Json
+        /// writes floats in shortest round-trippable form. Nullable.Equals also
+        /// treats NaN as equal to NaN, so a NaN rating can't keep an entry
+        /// perpetually "changed".
         /// </summary>
-        private static bool NullableFloatEquals(float? a, float? b) => System.Nullable.Equals(a, b);
+        private static bool NullableFloatEquals(float? a, float? b) => Nullable.Equals(a, b);
 
         public TagCacheEntry Clone() => new()
         {
@@ -102,6 +104,9 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Model
             // response, so any field omitted here is silently blanked for the
             // client. TmdbId/SeriesTmdbId/SeasonNumber/EpisodeNumber build the
             // review key — dropping them broke reviews on cloned entries.
+            // When adding a field, also add it to ContentEquals above — a field
+            // missing there makes real changes to it invisible to the incremental
+            // rebuild, so stale data would be served until the next full rebuild.
             TmdbId = TmdbId,
             SeriesTmdbId = SeriesTmdbId,
             SeasonNumber = SeasonNumber,
@@ -142,14 +147,26 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Model
                 && ListsEqual(a.Sources, b.Sources, TagMediaSource.ContentEquals);
         }
 
-        private static bool ListsEqual<T>(List<T>? a, List<T>? b, System.Func<T, T, bool> equals)
+        private static bool ListsEqual<T>(List<T>? a, List<T>? b, Func<T, T, bool> equals)
+            where T : class
         {
             if (ReferenceEquals(a, b)) return true;
             if (a == null || b == null) return false;
             if (a.Count != b.Count) return false;
             for (var i = 0; i < a.Count; i++)
             {
-                if (!equals(a[i], b[i])) return false;
+                var x = a[i];
+                var y = b[i];
+
+                // Guard null ELEMENTS before invoking the comparer: the plugin never
+                // writes them, but the existing side is deserialized from disk and
+                // System.Text.Json happily materializes a JSON null array element as a
+                // null item. Without this, one corrupt entry would throw on every
+                // rebuild — poisoning that item's incremental updates and aborting the
+                // nightly reconcile task, which has no per-item catch.
+                if (ReferenceEquals(x, y)) continue;
+                if (x == null || y == null) return false;
+                if (!equals(x, y)) return false;
             }
 
             return true;

--- a/Jellyfin.Plugin.JellyfinEnhanced/Model/TagCacheEntry.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Model/TagCacheEntry.cs
@@ -37,6 +37,64 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Model
         // Same caveat for StreamData (also reference-shared): treat it as immutable
         // across users — replace the whole object (StreamData = null), never mutate
         // its fields, or every user's cache silently corrupts.
+        /// <summary>
+        /// Value-compare two entries on every client-visible field, ignoring
+        /// <see cref="LastUpdated"/> (a build timestamp, not content). Used by the
+        /// incremental rebuild path to detect no-op ItemUpdated events: nightly
+        /// library scans and chapter/trickplay tasks re-save thousands of items
+        /// without changing any tag-relevant data, and treating each re-save as a
+        /// change caused the whole cache to be re-serialized to disk every ~30s
+        /// for the duration of the scan.
+        /// Compare EVERY content property (same rule as <see cref="Clone"/>): a
+        /// field omitted here makes real changes to that field invisible, so stale
+        /// data would be served until the next full rebuild.
+        /// </summary>
+        public static bool ContentEquals(TagCacheEntry? a, TagCacheEntry? b)
+        {
+            if (ReferenceEquals(a, b)) return true;
+            if (a == null || b == null) return false;
+
+            return a.Type == b.Type
+                && a.TmdbId == b.TmdbId
+                && a.SeriesTmdbId == b.SeriesTmdbId
+                && a.SeasonNumber == b.SeasonNumber
+                && a.EpisodeNumber == b.EpisodeNumber
+                && SequencesEqual(a.Genres, b.Genres)
+                && NullableFloatEquals(a.CommunityRating, b.CommunityRating)
+                && NullableFloatEquals(a.CriticRating, b.CriticRating)
+                && SequencesEqual(a.AudioLanguages, b.AudioLanguages)
+                && TagStreamData.ContentEquals(a.StreamData, b.StreamData)
+                && a.SeriesId == b.SeriesId;
+        }
+
+        /// <summary>
+        /// Ordinal, order-sensitive array compare. Order sensitivity is intentional:
+        /// both sides are built by the same code from the same source, so a stable
+        /// item produces the same order — and a false "different" only costs one
+        /// redundant save, while an order-insensitive compare would cost allocations
+        /// on every rebuilt item.
+        /// </summary>
+        private static bool SequencesEqual(string[]? a, string[]? b)
+        {
+            if (ReferenceEquals(a, b)) return true;
+            if (a == null || b == null) return a == null && b == null;
+            if (a.Length != b.Length) return false;
+            for (var i = 0; i < a.Length; i++)
+            {
+                if (!string.Equals(a[i], b[i], System.StringComparison.Ordinal)) return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Exact nullable-float compare. Exactness is safe here: both values are read
+        /// from the same database column, so an unchanged rating is bit-identical.
+        /// Nullable.Equals also treats NaN as equal to NaN, so a NaN rating can't
+        /// keep an entry perpetually "changed".
+        /// </summary>
+        private static bool NullableFloatEquals(float? a, float? b) => System.Nullable.Equals(a, b);
+
         public TagCacheEntry Clone() => new()
         {
             Type = Type,
@@ -68,6 +126,34 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Model
         public List<TagMediaSource>? Sources { get; set; }
         public string? ItemName { get; set; }
         public string? ItemPath { get; set; }
+
+        /// <summary>
+        /// Value-compare for the no-op-rebuild check (see TagCacheEntry.ContentEquals).
+        /// Compares EVERY property — an omitted field hides real changes from clients.
+        /// </summary>
+        public static bool ContentEquals(TagStreamData? a, TagStreamData? b)
+        {
+            if (ReferenceEquals(a, b)) return true;
+            if (a == null || b == null) return false;
+
+            return a.ItemName == b.ItemName
+                && a.ItemPath == b.ItemPath
+                && ListsEqual(a.Streams, b.Streams, TagMediaStream.ContentEquals)
+                && ListsEqual(a.Sources, b.Sources, TagMediaSource.ContentEquals);
+        }
+
+        private static bool ListsEqual<T>(List<T>? a, List<T>? b, System.Func<T, T, bool> equals)
+        {
+            if (ReferenceEquals(a, b)) return true;
+            if (a == null || b == null) return false;
+            if (a.Count != b.Count) return false;
+            for (var i = 0; i < a.Count; i++)
+            {
+                if (!equals(a[i], b[i])) return false;
+            }
+
+            return true;
+        }
     }
 
     public class TagMediaStream
@@ -82,11 +168,34 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Model
         public string? ChannelLayout { get; set; }
         public string? VideoRangeType { get; set; }
         public string? DisplayTitle { get; set; }
+
+        /// <summary>
+        /// Value-compare for the no-op-rebuild check (see TagCacheEntry.ContentEquals).
+        /// Compares EVERY property — an omitted field hides real changes from clients.
+        /// </summary>
+        public static bool ContentEquals(TagMediaStream a, TagMediaStream b) =>
+            a.Type == b.Type
+            && a.Language == b.Language
+            && a.Codec == b.Codec
+            && a.CodecTag == b.CodecTag
+            && a.Profile == b.Profile
+            && a.Height == b.Height
+            && a.Channels == b.Channels
+            && a.ChannelLayout == b.ChannelLayout
+            && a.VideoRangeType == b.VideoRangeType
+            && a.DisplayTitle == b.DisplayTitle;
     }
 
     public class TagMediaSource
     {
         public string? Path { get; set; }
         public string? Name { get; set; }
+
+        /// <summary>
+        /// Value-compare for the no-op-rebuild check (see TagCacheEntry.ContentEquals).
+        /// Compares EVERY property — an omitted field hides real changes from clients.
+        /// </summary>
+        public static bool ContentEquals(TagMediaSource a, TagMediaSource b) =>
+            a.Path == b.Path && a.Name == b.Name;
     }
 }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
@@ -32,6 +32,15 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         private long _lastReconciledUtcTicks;
         private Timer? _debounceSaveTimer;
         private volatile bool _dirty;
+        private long _firstDirtyTicks; // 0 = nothing dirty since the last disk save
+
+        // Disk-save cadence: a save runs 30s after the last applied change, but under
+        // sustained change (a metadata refresh where values really do change on every
+        // item) the trailing debounce would keep pushing the save out — so cap the
+        // deferral at 5 minutes from the first unsaved change. Worst case is one
+        // full-cache write per 5 minutes instead of one per flush cycle (~30s).
+        private static readonly TimeSpan SaveDebounce = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan SaveMaxWait = TimeSpan.FromMinutes(5);
 
         // Incremental cache maintenance. Library-scan events are recorded here (O(1),
         // no DB/probe work) and drained by a debounced background worker so scans are
@@ -428,6 +437,18 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             if (entry == null) return false;
 
             var key = id.ToString("N").ToLowerInvariant();
+
+            // No-op guard: Jellyfin raises ItemUpdated for every item a nightly
+            // library scan (or chapter/trickplay task) re-saves, whether or not any
+            // tag-relevant data changed. Reporting those rebuilds as changes made
+            // every scan re-serialize the entire cache to disk every ~30s for the
+            // scan's duration. Keeping the existing entry also preserves its
+            // LastUpdated stamp, so delta requests (?since=) correctly skip it.
+            if (_cache.TryGetValue(key, out var existing) && TagCacheEntry.ContentEquals(existing, entry))
+            {
+                return false;
+            }
+
             _cache[key] = entry;
             return true;
         }
@@ -551,6 +572,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                     File.WriteAllText(tempPath, json);
                     File.Move(tempPath, CacheFilePath, overwrite: true);
                     _dirty = false;
+                    Interlocked.Exchange(ref _firstDirtyTicks, 0); // open a fresh debounce/cap window
+
                     _logger.Info($"[TagCache] Saved {_cache.Count} entries to disk");
                 }
                 catch (Exception ex)
@@ -563,6 +586,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         private void ScheduleDebouncedSave()
         {
             _dirty = true;
+            Interlocked.CompareExchange(ref _firstDirtyTicks, DateTime.UtcNow.Ticks, 0);
             // During/after shutdown, persist synchronously instead of arming a timer that a
             // torn-down service would never fire. This is what keeps a flush that finishes
             // AFTER Dispose's (bounded) wait from losing its applied changes — it saves them
@@ -572,6 +596,12 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                 SaveToDisk();
                 return;
             }
+
+            // Trailing debounce with a hard cap (same math as the flush timer): 30s after
+            // the last change, but never more than 5 minutes after the first unsaved one,
+            // so sustained real changes can't starve persistence NOR write every cycle.
+            var due = ComputeFlushDelay(Interlocked.Read(ref _firstDirtyTicks), DateTime.UtcNow, SaveDebounce, SaveMaxWait);
+
             // Reuse existing timer if possible, otherwise create a new one.
             // Change() resets the countdown without creating a new object.
             var existing = _debounceSaveTimer;
@@ -579,7 +609,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             {
                 try
                 {
-                    existing.Change(TimeSpan.FromSeconds(30), Timeout.InfiniteTimeSpan);
+                    existing.Change(due, Timeout.InfiniteTimeSpan);
                     return;
                 }
                 catch (ObjectDisposedException) { }
@@ -587,7 +617,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             var timer = new Timer(_ =>
             {
                 if (_dirty) SaveToDisk();
-            }, null, TimeSpan.FromSeconds(30), Timeout.InfiniteTimeSpan);
+            }, null, due, Timeout.InfiniteTimeSpan);
             var old = Interlocked.Exchange(ref _debounceSaveTimer, timer);
             if (old != null && !ReferenceEquals(old, timer))
             {

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
@@ -595,6 +595,10 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                 {
                     // Failed write: restore the dirty state so Dispose's final
                     // `if (_dirty) SaveToDisk()` and the next debounce cycle retry it.
+                    // Intentionally NOT re-arming the save timer here: with the cap
+                    // window already elapsed the due time would be zero, and a
+                    // persistent disk failure would spin fire-fail-rearm. The next
+                    // library event, shutdown, or daily reconcile retries instead.
                     // Restore the ORIGINAL first-dirty stamp (not "now"): re-seeding
                     // with the current time would restart the SaveMaxWait cap window
                     // on every failed attempt and stretch the retry cadence. If a

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
@@ -456,7 +456,15 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         private bool RemoveEntry(Guid id)
         {
             var key = id.ToString("N").ToLowerInvariant();
-            return _cache.TryRemove(key, out _);
+            if (!_cache.TryRemove(key, out _)) return false;
+
+            // Removals are the one mutation the ?since delta protocol cannot express
+            // (a deleted key simply stops appearing), so clients only purge a removed
+            // entry when the version changes and they do a full reload. Bump it here:
+            // with the no-op rebuild guard, a quiet night no longer bumps the version
+            // via reconciliation, which used to mask this gap.
+            Interlocked.Increment(ref _version);
+            return true;
         }
 
         /// <summary>
@@ -553,6 +561,15 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         {
             lock (_saveLock)
             {
+                // Clear the dirty state BEFORE snapshotting, not after the write: a change
+                // applied while serialization is in progress isn't in the snapshot, and
+                // clearing afterwards would wipe its flag — the armed save timer would then
+                // see _dirty == false and skip, leaving that change unpersisted until the
+                // next event. Cleared first, a concurrent ScheduleDebouncedSave re-marks
+                // dirty and its timer performs a follow-up save that includes the change.
+                _dirty = false;
+                var previousStamp = Interlocked.Exchange(ref _firstDirtyTicks, 0);
+
                 try
                 {
                     var dir = Path.GetDirectoryName(CacheFilePath);
@@ -571,13 +588,24 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                     var tempPath = CacheFilePath + ".tmp";
                     File.WriteAllText(tempPath, json);
                     File.Move(tempPath, CacheFilePath, overwrite: true);
-                    _dirty = false;
-                    Interlocked.Exchange(ref _firstDirtyTicks, 0); // open a fresh debounce/cap window
 
                     _logger.Info($"[TagCache] Saved {_cache.Count} entries to disk");
                 }
                 catch (Exception ex)
                 {
+                    // Failed write: restore the dirty state so Dispose's final
+                    // `if (_dirty) SaveToDisk()` and the next debounce cycle retry it.
+                    // Restore the ORIGINAL first-dirty stamp (not "now"): re-seeding
+                    // with the current time would restart the SaveMaxWait cap window
+                    // on every failed attempt and stretch the retry cadence. If a
+                    // concurrent ScheduleDebouncedSave already stamped a newer window,
+                    // keep that one — a slightly later cap is harmless.
+                    _dirty = true;
+                    if (previousStamp != 0)
+                    {
+                        Interlocked.CompareExchange(ref _firstDirtyTicks, previousStamp, 0);
+                    }
+
                     _logger.Error($"[TagCache] Failed to save cache to disk: {ex.Message}");
                 }
             }


### PR DESCRIPTION
# fix(tag-cache): stop re-saving the whole cache on no-op library events

## Problem

Since #692 (off-thread tag-cache updates), users see the tag cache re-serialized to disk continuously during nightly maintenance windows — `[TagCache] Saved N entries to disk` every ~30–60 seconds for hours, with the entry count never changing:

```
[2026-07-13 03:33:58] [INFO] [TagCache] Saved 10772 entries to disk
[2026-07-13 03:37:59] [INFO] [TagCache] Saved 10772 entries to disk
[2026-07-13 03:42:00] [INFO] [TagCache] Saved 10772 entries to disk
... (continues for the whole task window)
```

## Root cause

Jellyfin raises `ItemUpdated` for every item a library scan / metadata refresh / chapter-image task re-saves, whether or not anything changed. Two behaviors introduced in #692 compound on that:

1. `RebuildEntry` unconditionally reported "changed" whenever it rebuilt an entry — even when the rebuilt entry was byte-for-byte identical to the cached one. So every no-op `ItemUpdated` marked the cache dirty.
2. The flush worker runs at least every 30s under sustained events (`FlushMaxWait`), and each "changed" batch armed the 30s save debounce — producing one full-cache serialize-and-write (potentially many MB) per flush cycle for the duration of the task.

Before #692, the save debounce was reset by every event, so during sustained activity the save fired only after a 30-second quiet gap — noisy in a different way, but writes were rare.

## Fix

- **No-op guard**: `RebuildEntry` now value-compares the rebuilt entry against the cached one across every content field (`LastUpdated` excluded — it's a build timestamp, not content) and reports no change when identical. The existing entry (and its `LastUpdated`) is kept, so delta requests (`?since=`) correctly continue to skip unchanged entries. Comparison helpers live next to `Clone()` in the model with the same "compare EVERY property" contract, so a future field can't silently drift out of either.
- **Capped save debounce**: `ScheduleDebouncedSave` now uses the same debounce-with-max-wait math as the flush timer (via the existing pure `ComputeFlushDelay` helper): save 30s after the last real change, but never deferred more than 5 minutes past the first unsaved change. Under a genuine sustained-change workload (e.g. a metadata refresh that really rewrites ratings), that's at most ~one full-cache write per 5 minutes instead of one per flush cycle, and persistence can no longer be starved by continuous activity either.

Review hardening (from adversarial review of the change):

- **Lost-save race closed**: `SaveToDisk` now clears the dirty state *before* snapshotting (restoring it, with the original cap-window stamp, on write failure). Previously a change applied concurrently during serialization had its dirty flag wiped by the finishing save and sat unpersisted until the next event.
- **Removals bump `_version`**: event-path removals are the one mutation the `?since=` delta protocol can't express; clients purge them only on a version-triggered full reload. The nightly reconcile's incidental daily version bump used to mask this — the no-op guard would have unmasked it.
- **Corrupt-cache resilience**: `ListsEqual` guards null list *elements* (System.Text.Json will materialize a JSON `null` array element from a hand-edited/corrupted `tag-cache.json`), so one bad entry compares as "different" instead of throwing on every rebuild and aborting the nightly reconcile task.

## Result

- Nightly scans / chapter / trickplay tasks over an unchanged library: **zero** cache writes and zero log lines (previously: dozens to hundreds of full-cache writes per night).
- Real metadata changes still persist within 30s of quiescence, bounded at one write per 5 minutes under sustained change.

## Test plan

Verified live on Jellyfin 10.11 (jellyfin-dev, 1856-entry cache):

- [x] No-op window: triggered metadata refreshes (`ReplaceAllMetadata=false`) on 5 movies → `ItemUpdated` fired, flush ran, **no** `Saved N entries` line appeared over the full flush+save window.
- [x] Real change: updated a movie's genres via the API → exactly one `Saved 1856 entries to disk` ~30s later, and the tag-cache endpoint served the new genres.
- [x] Re-verified after review hardening: unchanged POST → 0 saves; genre change → exactly one save 33s later; cache endpoint serves the updated genres.
- [x] Builds clean (0 warnings) for both `jf10` (net9.0 / 10.11) and `jf12` (net10.0 / Jellyfin 12).

## AI assistance disclosure

This PR was developed with AI assistance (Claude Code), with human review and live verification of the behavior described above.
