### PR TITLE
fix(tags): memory-bounded tag cache builds + honor Server-Side Tag Cache setting (startup OOM crash loop)

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -330,7 +330,7 @@
 
                             <div class="checkboxContainer"><label><input id="tagCacheServerMode" is="emby-checkbox" type="checkbox"/><span>Server-Side Tag Cache</span></label></div>
                             <div class="je-setting-description" data-desc-for="tagCacheServerMode">
-                                <div class="fieldDescription je-field-desc-sm-font-lg">Pre-computes tag data on the server and serves it in a single request. Tags load instantly without per-page API calls. Disable to use the legacy per-page batch mode (not recommended).</div>
+                                <div class="fieldDescription je-field-desc-sm-font-lg">Pre-computes tag data on the server and serves it in a single request. Tags load instantly without per-page API calls. Disable to use the legacy per-page batch mode: the cache is not loaded, built, or maintained while off, and the in-memory cache is released. Re-enabling restores the last snapshot and catches up on missed changes automatically in the background.</div>
                             </div>
 
                             <div id="tagsLocalStorageFallbackContainer" class="checkboxContainer">

--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -5897,7 +5897,12 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                 return authorizationResult;
             }
 
-            var items = _tagCacheService.GetCacheForUser(user, since);
+            // Version/timestamp come from the same generation capture as the
+            // cache contents (see GetCacheForUser): a cursor newer than the
+            // returned items would let clients skip updates permanently, and a
+            // mixed pre-publish stamp (timestamp 0) would disable their delta
+            // refresh entirely.
+            var items = _tagCacheService.GetCacheForUser(user, out var cacheVersion, out var cacheTimestamp, since);
 
             // Spoiler Guard tag-strip: when SpoilerBlur is on with any tag-relevant
             // strip toggle, walk the cache and zero out matching fields for unwatched
@@ -6094,8 +6099,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
 
             return Ok(new
             {
-                version = _tagCacheService.Version,
-                timestamp = _tagCacheService.LastModified,
+                version = cacheVersion,
+                timestamp = cacheTimestamp,
                 count = items.Count,
                 items
             });

--- a/Jellyfin.Plugin.JellyfinEnhanced/JellyfinEnhanced.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/JellyfinEnhanced.cs
@@ -197,13 +197,19 @@ namespace Jellyfin.Plugin.JellyfinEnhanced
             base.OnUninstalling();
         }
 
-        // Flush every Seerr-related cache the moment the admin saves config.
-        // Without this, fixing a bad URL/key/blocklist takes 10-30 minutes to
-        // take effect because of the user-id and response caches — admins see
-        // "still broken" after their fix and assume it didn't work
-        //.
+        // Config-save side effects: flush every Seerr-related cache (fixing a bad
+        // URL/key/blocklist must not take 10-30 minutes of cache TTL to appear
+        // fixed), and hand Server-Side Tag Cache OFF<->ON flips to the tag-cache
+        // transition queue — turning it off must actually release the cache
+        // memory, and turning it on must catch up on the off window right away
+        // rather than serving a stale snapshot until the daily 3 AM refresh.
         public override void UpdateConfiguration(BasePluginConfiguration configuration)
         {
+            // Capture the outgoing value BEFORE base.UpdateConfiguration replaces
+            // Configuration, so an actual OFF<->ON transition is distinguishable
+            // from an unrelated config save (this method fires on every save).
+            var tagCacheWasEnabled = Configuration?.TagCacheServerMode == true;
+
             base.UpdateConfiguration(configuration);
             try
             {
@@ -213,6 +219,13 @@ namespace Jellyfin.Plugin.JellyfinEnhanced
             catch (Exception ex)
             {
                 _logger.Warning($"Jellyfin Enhanced: failed to clear Seerr caches on config update: {ex.Message}");
+            }
+
+            // The transitions themselves run on a serialized background queue in
+            // TagCacheService (the save request must not block behind cache work).
+            if (tagCacheWasEnabled != (Configuration?.TagCacheServerMode == true))
+            {
+                Services.TagCacheService.Instance?.QueueServerModeTransition();
             }
         }
         private void CleanupOldScript()

--- a/Jellyfin.Plugin.JellyfinEnhanced/ScheduledTasks/BuildTagCacheTask.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/ScheduledTasks/BuildTagCacheTask.cs
@@ -48,9 +48,25 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.ScheduledTasks
 
         public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
         {
-            _tagCacheService.ReconcileCache(progress, cancellationToken);
-            // Ensure the monitor is subscribed to events after the first build
+            // Honor the "Server-Side Tag Cache" admin setting: when disabled, the
+            // cache is fully out of service (released by the config transition
+            // hook), so this task must not build or reconcile anything. Re-enable
+            // catch-up is handled by that hook; this gate just keeps the daily
+            // trigger and manual runs from doing work the admin opted out of.
+            if (JellyfinEnhanced.Instance?.Configuration?.TagCacheServerMode != true)
+            {
+                _logger.Info("[TagCache] Server-Side Tag Cache is disabled; skipping cache refresh (tags will use batch fallback).");
+                progress.Report(100);
+                return Task.CompletedTask;
+            }
+
+            // Subscribe BEFORE building, not after: on the first run after
+            // re-enabling the setting, no monitor is attached yet, and a long
+            // full build would miss every item changed while it runs. Subscribed
+            // first, those changes queue as pending ids (the flush defers while
+            // the rebuild lock is held) and apply to the new cache after the swap.
             _tagCacheMonitor.EnsureSubscribed();
+            _tagCacheService.ReconcileCache(progress, cancellationToken);
             return Task.CompletedTask;
         }
     }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/StartupService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/StartupService.cs
@@ -62,21 +62,37 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                 // A full rebuild runs daily at 3 AM or can be triggered manually.
                 // Wrapped in try/catch so a cache failure never prevents the rest of
                 // the plugin from working (tags just fall back to batch mode).
-                try
+                //
+                // Honor the "Server-Side Tag Cache" admin setting here: when it is
+                // disabled, the cache is fully out of service, so skip the load,
+                // the monitor, and the initial full build — an admin who opted out
+                // must not pay any cache cost at startup (historically the
+                // unconditional build here OOM-killed large-library servers in a
+                // startup crash loop; the build is paged now, but off means off).
+                // Clients fall back to per-page batch tag requests while the
+                // tag-cache endpoint returns 404 with the setting off.
+                if (JellyfinEnhanced.Instance?.Configuration?.TagCacheServerMode != true)
                 {
-                    _tagCacheService.LoadFromDisk();
-                    _tagCacheMonitor.Initialize();
-
-                    // First install: if no cache exists, build it now so tags work immediately
-                    if (_tagCacheService.Count == 0)
-                    {
-                        _logger.Info("[TagCache] No cache on disk, building initial cache...");
-                        _tagCacheService.BuildFullCache(null, CancellationToken.None);
-                    }
+                    _logger.Info("[TagCache] Server-Side Tag Cache is disabled; skipping cache load and build (tags will use batch fallback).");
                 }
-                catch (System.Exception ex)
+                else
                 {
-                    _logger.Error($"[TagCache] Failed to initialize tag cache (tags will use batch fallback): {ex.Message}");
+                    try
+                    {
+                        _tagCacheService.LoadFromDisk();
+                        _tagCacheMonitor.Initialize();
+
+                        // First install: if no cache exists, build it now so tags work immediately
+                        if (_tagCacheService.Count == 0)
+                        {
+                            _logger.Info("[TagCache] No cache on disk, building initial cache...");
+                            _tagCacheService.BuildFullCache(null, CancellationToken.None);
+                        }
+                    }
+                    catch (System.Exception ex)
+                    {
+                        _logger.Error($"[TagCache] Failed to initialize tag cache (tags will use batch fallback): {ex.Message}");
+                    }
                 }
 
                 _logger.Info("Jellyfin Enhanced Startup Task completed successfully.");

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheMonitor.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheMonitor.cs
@@ -13,13 +13,31 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         private readonly ILibraryManager _libraryManager;
         private readonly TagCacheService _tagCacheService;
         private readonly Logger _logger;
+        private volatile bool _disposed;
+
+        // Serializes subscribe/unsubscribe against each other and against
+        // Dispose: without it, an EnsureSubscribed that passed the disposed
+        // check could re-attach handlers after Dispose already detached them
+        // (leaking a live monitor), and two concurrent EnsureSubscribed calls
+        // could interleave their -=/+= pairs into a double subscription.
+        private readonly object _subscriptionLock = new();
 
         public TagCacheMonitor(ILibraryManager libraryManager, TagCacheService tagCacheService, Logger logger)
         {
             _libraryManager = libraryManager;
             _tagCacheService = tagCacheService;
             _logger = logger;
+
+            // DI singleton, exposed for the plugin's config-save transition hook
+            // (see TagCacheService.Instance for the rationale).
+            Instance = this;
         }
+
+        /// <summary>
+        /// The running singleton, used by the server-mode transition queue in
+        /// <see cref="TagCacheService"/> to re-subscribe on re-enable.
+        /// </summary>
+        internal static TagCacheMonitor? Instance { get; private set; }
 
         /// <summary>
         /// Subscribe to library events. Always subscribes regardless of cache state
@@ -27,29 +45,49 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         /// </summary>
         public void Initialize()
         {
-            _libraryManager.ItemAdded += OnItemChanged;
-            _libraryManager.ItemUpdated += OnItemChanged;
-            _libraryManager.ItemRemoved += OnItemRemoved;
-            _logger.Info("[TagCacheMonitor] Subscribed to ItemAdded, ItemUpdated, and ItemRemoved events");
+            // Same idempotent -=/+= as EnsureSubscribed: a bare += here could
+            // double-subscribe if a transition's EnsureSubscribed completed
+            // during startup's disk-load window (Dispose removes only one
+            // occurrence per handler, so a duplicate would outlive teardown).
+            EnsureSubscribed();
         }
 
         /// <summary>
-        /// Re-subscribe after a full cache rebuild (ensures no double-subscription).
+        /// Idempotently (re)attach the library event handlers — the -= before +=
+        /// guarantees exactly one subscription no matter how often or from where
+        /// this is called (startup, the daily task, re-enable transitions).
         /// </summary>
         public void EnsureSubscribed()
         {
-            _libraryManager.ItemAdded -= OnItemChanged;
-            _libraryManager.ItemUpdated -= OnItemChanged;
-            _libraryManager.ItemRemoved -= OnItemRemoved;
+            lock (_subscriptionLock)
+            {
+                // A queued re-enable transition can land during teardown;
+                // subscribing then would leak live handlers on a disposed
+                // monitor. Checked under the lock so Dispose can't slip between
+                // the check and the re-subscribe.
+                if (_disposed) return;
 
-            _libraryManager.ItemAdded += OnItemChanged;
-            _libraryManager.ItemUpdated += OnItemChanged;
-            _libraryManager.ItemRemoved += OnItemRemoved;
+                _libraryManager.ItemAdded -= OnItemChanged;
+                _libraryManager.ItemUpdated -= OnItemChanged;
+                _libraryManager.ItemRemoved -= OnItemRemoved;
+
+                _libraryManager.ItemAdded += OnItemChanged;
+                _libraryManager.ItemUpdated += OnItemChanged;
+                _libraryManager.ItemRemoved += OnItemRemoved;
+            }
+
             _logger.Info("[TagCacheMonitor] Event subscriptions active");
         }
 
         private void OnItemChanged(object? sender, ItemChangeEventArgs e)
         {
+            // If the admin disabled the Server-Side Tag Cache after these handlers
+            // were subscribed, stop maintaining the cache: it has been released and
+            // the endpoint is 404 while the setting is off, so incremental
+            // rebuilds/disk saves would be wasted work. The re-enable transition
+            // reconciles by item save timestamps, which covers events skipped here.
+            if (JellyfinEnhanced.Instance?.Configuration?.TagCacheServerMode != true) return;
+
             var item = e.Item;
             if (item == null) return;
 
@@ -75,15 +113,45 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
 
         private void OnItemRemoved(object? sender, ItemChangeEventArgs e)
         {
-            if (e.Item == null) return;
-            _tagCacheService.EnqueueRemoval(e.Item.Id);
+            // Same gate as OnItemChanged: no cache maintenance while the
+            // Server-Side Tag Cache is disabled. Stale removals are swept by the
+            // re-enable transition's live-id reconciliation.
+            if (JellyfinEnhanced.Instance?.Configuration?.TagCacheServerMode != true) return;
+
+            var item = e.Item;
+            if (item == null) return;
+            _tagCacheService.EnqueueRemoval(item.Id);
+
+            // Parent Series/Season entries derive data from their first episode
+            // (streams, genres, ratings), so removing an episode must requeue the
+            // parents just like changing one does — otherwise their cached entries
+            // keep reflecting the deleted file until something else touches them.
+            if (item is MediaBrowser.Controller.Entities.TV.Episode ep)
+            {
+                _tagCacheService.EnqueueUpdate(ep.SeriesId);
+                _tagCacheService.EnqueueUpdate(ep.SeasonId);
+            }
+            else if (item is MediaBrowser.Controller.Entities.TV.Season season)
+            {
+                _tagCacheService.EnqueueUpdate(season.SeriesId);
+            }
         }
 
         public void Dispose()
         {
-            _libraryManager.ItemAdded -= OnItemChanged;
-            _libraryManager.ItemUpdated -= OnItemChanged;
-            _libraryManager.ItemRemoved -= OnItemRemoved;
+            lock (_subscriptionLock)
+            {
+                _disposed = true;
+
+                _libraryManager.ItemAdded -= OnItemChanged;
+                _libraryManager.ItemUpdated -= OnItemChanged;
+                _libraryManager.ItemRemoved -= OnItemRemoved;
+            }
+
+            if (ReferenceEquals(Instance, this))
+            {
+                Instance = null;
+            }
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
@@ -26,6 +26,14 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         private readonly Logger _logger;
         private volatile ConcurrentDictionary<string, TagCacheEntry> _cache = new();
         private readonly object _saveLock = new();
+
+        // Guards the {_cacheReleased, _cache, _version, _lastModified} generation
+        // as one unit for readers. Publish/release sites mutate all four inside
+        // this lock (nested within _saveLock, always in that order), and snapshot
+        // readers (GetCacheForUser) take ONLY this lock — its critical sections
+        // are a handful of field accesses, so readers never stall behind a
+        // multi-second SaveToDisk serialization the way they would on _saveLock.
+        private readonly object _publishLock = new();
         private readonly SemaphoreSlim _rebuildLock = new(1, 1);
         private long _version;
         private long _lastModified;
@@ -61,6 +69,16 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         // starts empty (client falls back to the live/per-batch strip) until rebuild.
         private const int CurrentCacheSchemaVersion = 2;
 
+        // Page size for hydrating library items during full builds and
+        // reconciliation. Fetching the whole library with one GetItemList call
+        // materializes every BaseItem (full metadata, people, streams) at once,
+        // which on very large libraries (tens of thousands of items) can exceed
+        // the server's memory and OOM-kill Jellyfin. Fetching ids first and then
+        // hydrating in fixed-size pages bounds peak memory to one page of items
+        // regardless of library size. The resulting TagCacheEntry objects are
+        // small (a few hundred bytes) so the cache itself stays cheap.
+        private const int HydrationPageSize = 500;
+
         // User access cache: avoids expensive GetItemIds query on every request
         private readonly ConcurrentDictionary<string, (HashSet<string> Ids, DateTime CachedAt)> _userAccessCache = new();
         private static readonly TimeSpan UserAccessCacheTtl = TimeSpan.FromSeconds(60);
@@ -79,7 +97,57 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             _libraryManager = libraryManager;
             _applicationPaths = applicationPaths;
             _logger = logger;
+
+            // The service is a DI singleton; expose it so the plugin's
+            // UpdateConfiguration override can reach the running instance when the
+            // admin toggles the Server-Side Tag Cache setting (same pattern as
+            // JellyfinEnhanced.Instance — the plugin class has no DI access).
+            Instance = this;
         }
+
+        /// <summary>
+        /// The running singleton, for the config-save transition hook in
+        /// <see cref="JellyfinEnhanced.UpdateConfiguration"/>. Null until DI
+        /// constructs the service (and again after disposal).
+        /// </summary>
+        internal static TagCacheService? Instance { get; private set; }
+
+        /// <summary>
+        /// Live read of the admin "Server-Side Tag Cache" setting. Long-running
+        /// builds re-check this at page boundaries so an admin turning the cache
+        /// off (e.g. under memory pressure) actually stops the work instead of
+        /// only preventing the next run.
+        /// </summary>
+        private static bool ServerModeEnabled => JellyfinEnhanced.Instance?.Configuration?.TagCacheServerMode == true;
+
+        /// <summary>
+        /// Shared abort condition for every expensive or state-publishing cache
+        /// phase (build pages, reconcile rebuild/sweep loops, publishes, saves):
+        /// stop when the admin turned the setting off OR the service is being
+        /// torn down. Checked mid-run, not just at entry, so neither a disable
+        /// nor a shutdown has to wait behind a large-library operation.
+        /// </summary>
+        private bool ShouldAbortCacheWork => _disposed || !ServerModeEnabled;
+
+        // True whenever the in-memory cache is NOT a published complete state:
+        // from construction until the first successful LoadFromDisk/full-build
+        // publish, and again between OnServerModeDisabled releasing the cache and
+        // the next publish. Distinguishes "empty/placeholder" from "has real
+        // entries": an incremental flush landing while unpublished (e.g. after a
+        // failed startup build, or in the release->re-enable window) would make
+        // the cache non-empty with a stray entry, and gating full builds and
+        // snapshot reloads on IsEmpty alone would then mistake that near-empty
+        // cache for a complete one — delta-reconciling and even persisting it.
+        // While true: flushes defer, SaveToDisk refuses, reconcile full-builds.
+        private volatile bool _cacheReleased = true;
+
+        // Serializes server-mode transitions (and orders them after one another)
+        // off the config-save thread. ContinueWith chaining keeps strict FIFO
+        // order for rapid toggles; each queued transition re-reads the CURRENT
+        // setting when it runs, so intermediate flips converge on the final state
+        // instead of racing each other's release/reload work.
+        private Task _transitionQueue = Task.CompletedTask;
+        private readonly object _transitionQueueLock = new();
 
         public long Version => Interlocked.Read(ref _version);
         public long LastModified => Interlocked.Read(ref _lastModified);
@@ -110,40 +178,80 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             _logger.Info("[TagCache] Starting full cache build...");
             var sw = System.Diagnostics.Stopwatch.StartNew();
 
-            var allItems = _libraryManager.GetItemList(new InternalItemsQuery
+            // Ids only — a Guid list is tiny even for huge libraries. The heavy
+            // BaseItem hydration happens page by page below so the build never
+            // holds more than HydrationPageSize full items at a time.
+            var allIds = _libraryManager.GetItemIds(new InternalItemsQuery
             {
                 IncludeItemTypes = TaggableTypes.ToArray(),
                 IsVirtualItem = false,
                 Recursive = true
-            }).ToList();
+            });
 
-            _logger.Info($"[TagCache] Found {allItems.Count} taggable items");
+            _logger.Info($"[TagCache] Found {allIds.Count} taggable items");
 
             var newCache = new ConcurrentDictionary<string, TagCacheEntry>();
             var processed = 0;
 
-            foreach (var item in allItems)
+            foreach (var page in HydrateInPages(allIds, cancellationToken))
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var entry = BuildEntryForItem(item);
-                if (entry != null)
+                // Stop promptly if the admin turned the cache off (or the server
+                // is shutting down) mid-build; the partial result is discarded,
+                // not published.
+                if (ShouldAbortCacheWork)
                 {
-                    var key = item.Id.ToString("N").ToLowerInvariant();
-                    newCache[key] = entry;
+                    _logger.Info("[TagCache] Full build aborted (setting disabled or server shutting down); nothing published.");
+                    return;
                 }
 
-                processed++;
-                if (processed % 500 == 0)
+                foreach (var item in page)
                 {
-                    progress?.Report((double)processed / allItems.Count * 100);
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var entry = BuildEntryForItem(item);
+                    if (entry != null)
+                    {
+                        var key = item.Id.ToString("N").ToLowerInvariant();
+                        newCache[key] = entry;
+                    }
+                }
+
+                // An item deleted between the id query and its page hydration just
+                // doesn't come back, so advance by the page's actual size.
+                processed += page.Count;
+                progress?.Report((double)processed / allIds.Count * 100);
+            }
+
+            // Final gate before publishing (the loop check can't run when the
+            // setting flips after the last page). The swap below happens while
+            // this thread holds _rebuildLock and OnServerModeDisabled also runs
+            // under that lock, so a disable can't interleave with the publish —
+            // it either aborts the build here or releases the published cache
+            // afterwards.
+            if (ShouldAbortCacheWork)
+            {
+                _logger.Info("[TagCache] Full build aborted (setting disabled or server shutting down); nothing published.");
+                return;
+            }
+
+            // Atomic reference swap — readers see old or new cache, never partial.
+            // Flag, swap AND version/timestamp under _saveLock: a stale-armed save
+            // timer can't observe the cleared flag with the placeholder still in
+            // _cache, and a snapshot read (GetCacheForUser) can't pair the new
+            // dictionary with the previous generation's version/timestamp — a
+            // request stamped with a pre-first-publish timestamp of 0 would
+            // permanently disable that client's delta refresh.
+            lock (_saveLock)
+            {
+                lock (_publishLock)
+                {
+                    _cacheReleased = false;
+                    _cache = newCache;
+                    Interlocked.Increment(ref _version);
+                    Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
                 }
             }
 
-            // Atomic reference swap — readers see old or new cache, never partial
-            _cache = newCache;
-            Interlocked.Increment(ref _version);
-            Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
             Interlocked.Exchange(ref _lastReconciledUtcTicks, reconciliationStartedUtc.Ticks);
             // Invalidate user access cache since items may have changed
             _userAccessCache.Clear();
@@ -178,7 +286,11 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             var reconciliationStartedUtc = DateTime.UtcNow;
             var previousTicks = Interlocked.Read(ref _lastReconciledUtcTicks);
 
-            if (_cache.IsEmpty)
+            // _cacheReleased also forces the full path: after a release, "has a
+            // few entries" (e.g. from any stray incremental work) must not be
+            // mistaken for a complete cache — a delta reconcile of it would serve
+            // a near-empty library as if whole.
+            if (_cacheReleased || _cache.IsEmpty)
             {
                 _logger.Info("[TagCache] Cache is empty; running full build");
                 BuildFullCacheCore(progress, cancellationToken, reconciliationStartedUtc);
@@ -195,44 +307,69 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             var changedSinceUtc = new DateTime(previousTicks, DateTimeKind.Utc).Subtract(TimeSpan.FromMinutes(2));
             _logger.Info($"[TagCache] Reconciling changes since {changedSinceUtc:O}");
 
-            var changedItems = _libraryManager.GetItemList(new InternalItemsQuery
+            // Same paged hydration as the full build: after a sweeping change
+            // (e.g. a full metadata refresh) this delta can cover most of the
+            // library, so materializing it with one GetItemList call has the
+            // same OOM potential as the unpaged full build.
+            var changedIds = _libraryManager.GetItemIds(new InternalItemsQuery
             {
                 IncludeItemTypes = TaggableTypes.ToArray(),
                 IsVirtualItem = false,
                 Recursive = true,
                 MinDateLastSaved = changedSinceUtc
-            }).ToList();
+            });
 
             var idsToRebuild = new HashSet<Guid>();
-            foreach (var item in changedItems)
+            foreach (var page in HydrateInPages(changedIds, cancellationToken))
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                idsToRebuild.Add(item.Id);
-
-                if (item is MediaBrowser.Controller.Entities.TV.Episode episode)
+                // Same mid-run gate as the full build: stop when the admin turns
+                // the cache off instead of finishing expensive work they opted out of.
+                if (ShouldAbortCacheWork)
                 {
-                    if (episode.SeriesId != Guid.Empty)
-                    {
-                        idsToRebuild.Add(episode.SeriesId);
-                    }
+                    _logger.Info("[TagCache] Reconciliation aborted (setting disabled or server shutting down).");
+                    return;
+                }
 
-                    if (episode.SeasonId != Guid.Empty)
+                foreach (var item in page)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    idsToRebuild.Add(item.Id);
+
+                    if (item is MediaBrowser.Controller.Entities.TV.Episode episode)
                     {
-                        idsToRebuild.Add(episode.SeasonId);
+                        if (episode.SeriesId != Guid.Empty)
+                        {
+                            idsToRebuild.Add(episode.SeriesId);
+                        }
+
+                        if (episode.SeasonId != Guid.Empty)
+                        {
+                            idsToRebuild.Add(episode.SeasonId);
+                        }
                     }
                 }
             }
 
             var changed = false;
-            var processed = 0;
+            var rebuilt = 0;
             foreach (var id in idsToRebuild)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                // After a sweeping change (full metadata refresh) this loop can
+                // cover most of the library, so it needs the same mid-run abort
+                // as the hydration pages — otherwise a disable mid-reconcile
+                // keeps doing per-item probe work the admin just opted out of.
+                if (ShouldAbortCacheWork)
+                {
+                    _logger.Info("[TagCache] Reconciliation aborted (setting disabled or server shutting down).");
+                    return;
+                }
+
                 changed |= RebuildEntry(id);
-                processed++;
-                progress?.Report(idsToRebuild.Count == 0 ? 50 : (double)processed / idsToRebuild.Count * 80);
+                rebuilt++;
+                progress?.Report(idsToRebuild.Count == 0 ? 50 : (double)rebuilt / idsToRebuild.Count * 80);
             }
 
             var currentIds = _libraryManager.GetItemIds(new InternalItemsQuery
@@ -246,20 +383,118 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                 .Select(id => id.ToString("N").ToLowerInvariant())
                 .ToHashSet(StringComparer.Ordinal);
 
+            // Collect the keys to sweep WITHOUT mutating the cache: entry updates
+            // above are idempotent and safe to abort mid-way (the marker didn't
+            // advance, so the next run redoes them), but removals are not — a
+            // removed entry takes its stored SeriesId with it, so an abort after
+            // partial removals could persist a cache whose deleted entries can
+            // never get their parent repair, with no version bump to make
+            // delta-polling clients drop them.
+            var keysToSweep = new List<string>();
             foreach (var cachedKey in _cache.Keys)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (!liveKeys.Contains(cachedKey) && _cache.TryRemove(cachedKey, out _))
+                if (!liveKeys.Contains(cachedKey))
+                {
+                    keysToSweep.Add(cachedKey);
+                }
+            }
+
+            // Single commit gate. Everything after it — removals, parent Series/
+            // Season repairs, version bump, marker advance, disk save — runs as
+            // one unit with no further abort points, so the swept state is only
+            // ever observed (and persisted) complete. A disable landing during
+            // the commit waits on _rebuildLock for the bounded remainder.
+            if (ShouldAbortCacheWork)
+            {
+                _logger.Info("[TagCache] Reconciliation aborted before commit (setting disabled or server shutting down); nothing saved.");
+                return;
+            }
+
+            // Parents of swept entries. Removals that happened while the monitor
+            // wasn't listening (server-mode-off window, plugin stopped) never
+            // enqueued their parent Series rebuild, so a Series entry can keep
+            // serving first-episode data derived from a deleted item. The swept
+            // entry's stored SeriesId lets the sweep queue that repair here.
+            var parentSeriesToRebuild = new HashSet<Guid>();
+            foreach (var key in keysToSweep)
+            {
+                if (_cache.TryRemove(key, out var removedEntry))
                 {
                     changed = true;
+                    if (removedEntry?.SeriesId != null && Guid.TryParse(removedEntry.SeriesId, out var seriesId))
+                    {
+                        parentSeriesToRebuild.Add(seriesId);
+                    }
+                }
+            }
+
+            // Log-and-continue on every repair step, never throw: the removals
+            // above are already applied, so an exception escaping this loop would
+            // skip the version bump and save below — delta-polling clients would
+            // then keep the removed (phantom) entries until some unrelated change
+            // bumps the version. Failed steps are requeued by their own id via
+            // the incremental pipeline (EnqueueUpdate is O(1) and never throws;
+            // the flush retries once this lock frees), so a transient failure
+            // doesn't strand a parent entry either.
+            foreach (var seriesId in parentSeriesToRebuild)
+            {
+                try
+                {
+                    changed |= RebuildEntry(seriesId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warning($"[TagCache] Failed to repair series entry {seriesId}: {ex.Message}");
+                    EnqueueUpdate(seriesId);
+                }
+
+                // The removed entry only records its SeriesId, so the deleted
+                // item's former Season can't be identified directly — but Season
+                // entries also derive first-episode data, so rebuild all of the
+                // affected series' seasons (a handful of items) rather than leave
+                // one serving streams from a deleted file indefinitely.
+                IReadOnlyList<BaseItem> seasons;
+                try
+                {
+                    seasons = GetSeasonsOfSeries(seriesId);
+                }
+                catch (Exception ex)
+                {
+                    // Season ids are unknowable without this query, so they can't
+                    // be requeued individually — the one residual staleness gap.
+                    _logger.Warning($"[TagCache] Failed to get seasons for series {seriesId}: {ex.Message}");
+                    continue;
+                }
+
+                foreach (var season in seasons)
+                {
+                    try
+                    {
+                        changed |= RebuildEntry(season.Id);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Warning($"[TagCache] Failed to repair season entry {season.Id}: {ex.Message}");
+                        EnqueueUpdate(season.Id);
+                    }
                 }
             }
 
             if (changed)
             {
-                Interlocked.Increment(ref _version);
-                Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                // Under both locks so a snapshot read pairs the bumped version
+                // with the swept cache state (see the build-publish comment).
+                lock (_saveLock)
+                {
+                    lock (_publishLock)
+                    {
+                        Interlocked.Increment(ref _version);
+                        Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                    }
+                }
+
                 _userAccessCache.Clear();
             }
 
@@ -267,7 +502,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             progress?.Report(100);
             SaveToDisk();
 
-            _logger.Info($"[TagCache] Reconciliation complete: {changedItems.Count} changed items, {idsToRebuild.Count} entries checked");
+            _logger.Info($"[TagCache] Reconciliation complete: {changedIds.Count} changed items, {idsToRebuild.Count} entries checked");
         }
 
         /// <summary>
@@ -380,20 +615,81 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                 return;
             }
 
+            var retryLater = false;
             try
             {
-                Interlocked.Exchange(ref _firstPendingTicks, 0);
-                if (ApplyBatch(_pending.Drain(), RebuildEntry, RemoveEntry))
+                // A full build/reconcile (or a server-mode transition) owns the
+                // cache: applying the batch now would write into a dictionary
+                // about to be swapped away — after having been drained from
+                // _pending. Defer instead; the queued ids apply to the NEW cache
+                // once the lock is free. (Wait(0): never block the timer thread
+                // for the duration of a large-library build.)
+                if (!_rebuildLock.Wait(0))
                 {
-                    Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
-                    ScheduleDebouncedSave();
+                    // Restart the cap clock while deferring: the cap exists to stop
+                    // a busy scan from starving flushes, but flushes CANNOT run
+                    // while a rebuild owns the lock — leaving the stamp past the
+                    // cap would make every library event fire a zero-delay timer
+                    // tick for the whole build.
+                    Interlocked.Exchange(ref _firstPendingTicks, DateTime.UtcNow.Ticks);
+                    retryLater = true;
+                    return;
+                }
+
+                try
+                {
+                    // Mode check UNDER the lock (transitions also hold it), so the
+                    // observation can't race a concurrent release: applying a batch
+                    // into a released cache would repopulate memory the admin just
+                    // freed and mark it dirty for persistence. Discarding is safe —
+                    // the re-enable transition reconciles by item save timestamps,
+                    // which covers every id dropped here.
+                    if (!ServerModeEnabled)
+                    {
+                        Interlocked.Exchange(ref _firstPendingTicks, 0);
+                        _pending.Drain();
+                        return;
+                    }
+
+                    // Mode is ON but the cache is still the released placeholder:
+                    // an enable catch-up is queued or between its load/reconcile
+                    // steps. Applying now would seed a near-empty cache that the
+                    // reconcile would then mistake for a live one. Keep the ids
+                    // pending instead — they apply after the catch-up publishes.
+                    if (_cacheReleased)
+                    {
+                        Interlocked.Exchange(ref _firstPendingTicks, DateTime.UtcNow.Ticks);
+                        retryLater = true;
+                        return;
+                    }
+
+                    Interlocked.Exchange(ref _firstPendingTicks, 0);
+                    if (ApplyBatch(_pending.Drain(), RebuildEntry, RemoveEntry))
+                    {
+                        Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                        ScheduleDebouncedSave();
+                    }
+                }
+                finally
+                {
+                    _rebuildLock.Release();
                 }
             }
             finally
             {
                 Interlocked.Exchange(ref _flushing, 0);
-                // Ids recorded while we were draining/applying: run again (cap-aware).
-                if (!_pending.IsEmpty) ScheduleFlush();
+                if (retryLater)
+                {
+                    // Fixed debounce, NOT ScheduleFlush: the cap window has often
+                    // already elapsed here, and a zero-delay reschedule would
+                    // busy-spin the timer for the whole build.
+                    ArmFlushTimer(FlushDebounce);
+                }
+                else if (!_pending.IsEmpty)
+                {
+                    // Ids recorded while we were draining/applying: run again (cap-aware).
+                    ScheduleFlush();
+                }
             }
         }
 
@@ -468,14 +764,37 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         }
 
         /// <summary>
-        /// Get cache entries filtered by a user's library access.
+        /// Get cache entries filtered by a user's library access, together with
+        /// the version and timestamp belonging to the SAME cache generation.
         /// User access IDs are cached for 60 seconds to avoid expensive DB queries.
         /// Optionally returns only entries modified after a given timestamp.
+        /// The out values must come from the same _publishLock-guarded capture as
+        /// the dictionary reference: pairing a freshly published cache with the
+        /// previous generation's version/timestamp would let a client store a
+        /// pre-first-publish timestamp of 0 (which disables its delta refresh)
+        /// or a version the next poll can't detect a rebuild against.
         /// </summary>
-        public Dictionary<string, TagCacheEntry> GetCacheForUser(JUser user, long? since = null)
+        public Dictionary<string, TagCacheEntry> GetCacheForUser(JUser user, out long version, out long timestamp, long? since = null)
         {
-            // Capture local reference for thread safety (cache reference may be swapped)
-            var cache = _cache;
+            ConcurrentDictionary<string, TagCacheEntry> cache;
+            lock (_publishLock)
+            {
+                version = Interlocked.Read(ref _version);
+                timestamp = Interlocked.Read(ref _lastModified);
+                cache = _cache;
+
+                // A request that passed the controller's mode gate can still land
+                // here after a disable released the caches; running the expensive
+                // per-user GetItemIds then would park a large accessible-id set in
+                // _userAccessCache for the whole off window (nothing evicts it
+                // while the endpoint 404s). Serve empty instead — the client falls
+                // back to batch mode, exactly as if it had hit the 404.
+                if (!ServerModeEnabled || _cacheReleased)
+                {
+                    return new Dictionary<string, TagCacheEntry>();
+                }
+            }
+
             var userKey = user.Id.ToString("N");
 
             // Check user access cache
@@ -494,7 +813,21 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                 accessibleSet = new HashSet<string>(
                     accessibleIds.Select(id => id.ToString("N").ToLowerInvariant())
                 );
-                _userAccessCache[userKey] = (accessibleSet, DateTime.UtcNow);
+
+                // Store under _publishLock with the released flag re-checked:
+                // the entry bail above is check-then-act, and a disable can
+                // complete while the GetItemIds query runs. The disable clears
+                // _userAccessCache inside the same lock as it sets the flag, so
+                // this store either lands before the clear (and is cleared) or
+                // sees the flag and skips — it can never repopulate the access
+                // cache for the off window.
+                lock (_publishLock)
+                {
+                    if (ServerModeEnabled && !_cacheReleased)
+                    {
+                        _userAccessCache[userKey] = (accessibleSet, DateTime.UtcNow);
+                    }
+                }
             }
 
             var result = new Dictionary<string, TagCacheEntry>();
@@ -509,9 +842,144 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         }
 
         /// <summary>
-        /// Load the cache from disk on startup.
+        /// Queue a server-mode transition after the admin saved a config where
+        /// the "Server-Side Tag Cache" setting flipped. Runs on a background
+        /// continuation — the config save must never block behind cache work —
+        /// and transitions are strictly serialized in save order, with each one
+        /// re-reading the CURRENT setting when it actually runs. Rapid toggles
+        /// therefore converge on the final state instead of an enable's snapshot
+        /// reload racing a later disable's release (both hooks are idempotent).
+        /// </summary>
+        internal void QueueServerModeTransition()
+        {
+            lock (_transitionQueueLock)
+            {
+                _transitionQueue = _transitionQueue.ContinueWith(
+                    _ => RunServerModeTransition(),
+                    CancellationToken.None,
+                    TaskContinuationOptions.None,
+                    TaskScheduler.Default);
+            }
+        }
+
+        private void RunServerModeTransition()
+        {
+            if (_disposed) return;
+
+            try
+            {
+                if (ServerModeEnabled)
+                {
+                    // Subscribe the monitor FIRST so items changed during the
+                    // (potentially long) catch-up queue as pending ids — the
+                    // flush defers while the rebuild lock is held and applies
+                    // them to the new cache after the swap.
+                    TagCacheMonitor.Instance?.EnsureSubscribed();
+                    OnServerModeEnabled();
+                }
+                else
+                {
+                    OnServerModeDisabled();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error($"[TagCache] Server-mode transition failed (tags fall back to batch mode until the next refresh): {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Transition to OFF. Persists any unsaved changes first — so the on-disk
+        /// snapshot stays current for a later re-enable — then releases the
+        /// in-memory cache and discards queued ids. Freeing memory on the running
+        /// server is precisely why an admin disables this on a memory-constrained
+        /// system, so "off" must mean the memory is actually returned, not just
+        /// that the endpoint 404s. Runs under _rebuildLock: an in-flight
+        /// build/reconcile sees the flipped setting at its next gate and aborts,
+        /// this then waits for that abort, so no rebuild or flush can repopulate
+        /// the released cache or overwrite the snapshot afterwards (their gates
+        /// and the save timer all re-check the setting).
+        /// </summary>
+        internal void OnServerModeDisabled()
+        {
+            _rebuildLock.Wait();
+            try
+            {
+                _pending.Drain();
+                Interlocked.Exchange(ref _firstPendingTicks, 0);
+
+                // _saveLock makes save-then-release atomic against the debounce
+                // save timer: a timer save either completes here first (and
+                // snapshots the still-full cache) or runs after the release and
+                // is rejected by SaveToDisk's _cacheReleased guard. (Monitor
+                // locks are reentrant, so the nested SaveToDisk is fine.)
+                lock (_saveLock)
+                {
+                    if (_dirty) SaveToDisk();
+
+                    // The user-access clear sits INSIDE _publishLock so it is
+                    // atomic with the flag: GetCacheForUser stores into
+                    // _userAccessCache only under this lock with the flag
+                    // re-checked, so no request can repopulate it post-release.
+                    lock (_publishLock)
+                    {
+                        _cacheReleased = true;
+                        _cache = new ConcurrentDictionary<string, TagCacheEntry>();
+                        _userAccessCache.Clear();
+                    }
+                }
+            }
+            finally
+            {
+                _rebuildLock.Release();
+            }
+
+            _logger.Info("[TagCache] Server-Side Tag Cache disabled; in-memory cache released (snapshot kept on disk for re-enable).");
+        }
+
+        /// <summary>
+        /// Transition to ON. Restores the last persisted snapshot for instant
+        /// serving, then reconciles by item save timestamps (a full paged build
+        /// if no usable snapshot exists), so changes made during the off window
+        /// are caught up immediately instead of waiting for the daily task.
+        /// Reloads on _cacheReleased as well as IsEmpty: a single incremental
+        /// flush landing between release and re-enable would otherwise make the
+        /// cache "non-empty" and skip the reload, serving a near-empty cache as
+        /// if complete (the reload replaces such stray entries; the reconcile
+        /// re-covers them via their save timestamps).
+        /// </summary>
+        internal void OnServerModeEnabled()
+        {
+            if (_cacheReleased || _cache.IsEmpty)
+            {
+                LoadFromDisk();
+            }
+
+            ReconcileCache(null, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Load the cache from disk (startup, or the re-enable transition).
+        /// Runs under _rebuildLock so the publish can't interleave with a
+        /// build's swap or a disable's release, and re-checks the setting under
+        /// the lock so a load racing a disable can't resurrect the cache the
+        /// disable just released.
         /// </summary>
         public void LoadFromDisk()
+        {
+            _rebuildLock.Wait();
+            try
+            {
+                if (ShouldAbortCacheWork) return;
+                LoadFromDiskCore();
+            }
+            finally
+            {
+                _rebuildLock.Release();
+            }
+        }
+
+        private void LoadFromDiskCore()
         {
             var path = CacheFilePath;
             if (!File.Exists(path))
@@ -522,8 +990,16 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
 
             try
             {
-                var json = File.ReadAllText(path);
-                var data = JsonSerializer.Deserialize<TagCacheDiskFormat>(json);
+                // Deserialize straight from the file stream: on very large
+                // libraries the serialized cache is tens of MB, and reading it
+                // into an intermediate string would transiently double the load
+                // cost (UTF-16 string + object graph) for no benefit.
+                TagCacheDiskFormat? data;
+                using (var stream = File.OpenRead(path))
+                {
+                    data = JsonSerializer.Deserialize<TagCacheDiskFormat>(stream);
+                }
+
                 if (data?.Items != null)
                 {
                     // Discard a cache written by an older schema (e.g. predating
@@ -534,10 +1010,31 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                         _logger.Info($"[TagCache] On-disk cache schema v{data.SchemaVersion} != current v{CurrentCacheSchemaVersion}; discarding {data.Items.Count} entries and rebuilding on next scan.");
                         return;
                     }
+                    // Re-gate right before publishing: deserializing a large
+                    // snapshot takes long enough for the admin to flip the
+                    // setting off mid-load, and publishing then would park the
+                    // full cache in memory while the mode is off.
+                    if (ShouldAbortCacheWork)
+                    {
+                        _logger.Info("[TagCache] Disk load aborted (setting disabled or server shutting down); discarding.");
+                        return;
+                    }
+
                     var loaded = new ConcurrentDictionary<string, TagCacheEntry>(data.Items);
-                    _cache = loaded;
-                    Interlocked.Exchange(ref _version, data.Version);
-                    Interlocked.Exchange(ref _lastModified, data.LastModified);
+
+                    // Same _saveLock discipline as the build publish: flag, swap
+                    // and version/timestamp change together or not at all from a
+                    // saver's or snapshot-reader's view.
+                    lock (_saveLock)
+                    {
+                        lock (_publishLock)
+                        {
+                            _cacheReleased = false;
+                            _cache = loaded;
+                            Interlocked.Exchange(ref _version, data.Version);
+                            Interlocked.Exchange(ref _lastModified, data.LastModified);
+                        }
+                    }
                     var reconciledTicks = data.LastReconciledUtcTicks;
                     if (reconciledTicks <= 0 && data.Items.Count > 0)
                     {
@@ -561,6 +1058,16 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         {
             lock (_saveLock)
             {
+                // Released cache must never reach disk: a save timer that passed
+                // its dirty/mode check just before the release would otherwise
+                // block on this lock and then snapshot the swapped-in empty
+                // dictionary, overwriting the good snapshot. The release itself
+                // saves BEFORE setting _cacheReleased (under this same lock), and
+                // re-enable clears the flag before anything new needs saving.
+                if (_cacheReleased)
+                {
+                    return;
+                }
                 // Clear the dirty state BEFORE snapshotting, not after the write: a change
                 // applied while serialization is in progress isn't in the snapshot, and
                 // clearing afterwards would wipe its flag — the armed save timer would then
@@ -584,9 +1091,15 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                         Items = new Dictionary<string, TagCacheEntry>(_cache)
                     };
 
-                    var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = false });
+                    // Serialize straight to the temp file: building the whole
+                    // payload as one string first would transiently hold tens of
+                    // MB of UTF-16 on large libraries (see LoadFromDisk).
                     var tempPath = CacheFilePath + ".tmp";
-                    File.WriteAllText(tempPath, json);
+                    using (var stream = File.Create(tempPath))
+                    {
+                        JsonSerializer.Serialize(stream, data, new JsonSerializerOptions { WriteIndented = false });
+                    }
+
                     File.Move(tempPath, CacheFilePath, overwrite: true);
 
                     _logger.Info($"[TagCache] Saved {_cache.Count} entries to disk");
@@ -625,7 +1138,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             // now rather than relying on a debounce timer that will never run.
             if (_disposed)
             {
-                SaveToDisk();
+                if (ServerModeEnabled) SaveToDisk();
                 return;
             }
 
@@ -648,7 +1161,10 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             }
             var timer = new Timer(_ =>
             {
-                if (_dirty) SaveToDisk();
+                // The mode gate keeps a save armed before a disable from writing
+                // the post-release (near-empty) cache over the good snapshot;
+                // OnServerModeDisabled does its own explicit save-if-dirty first.
+                if (_dirty && ServerModeEnabled) SaveToDisk();
             }, null, due, Timeout.InfiniteTimeSpan);
             var old = Interlocked.Exchange(ref _debounceSaveTimer, timer);
             if (old != null && !ReferenceEquals(old, timer))
@@ -663,7 +1179,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             {
                 var orphan = Interlocked.Exchange(ref _debounceSaveTimer, null);
                 orphan?.Dispose();
-                SaveToDisk();
+                if (ServerModeEnabled) SaveToDisk();
             }
         }
 
@@ -673,6 +1189,11 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             // (ArmFlushTimer and ScheduleDebouncedSave both bail on _disposed) instead of
             // resurrecting a timer after teardown.
             _disposed = true;
+
+            if (ReferenceEquals(Instance, this))
+            {
+                Instance = null;
+            }
 
             var flush = Interlocked.Exchange(ref _flushTimer, null);
             flush?.Dispose(); // stops future callbacks; an in-flight one may still be applying
@@ -701,10 +1222,23 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             // would leave those items stale until the next event or the daily rebuild.
             try
             {
-                if (ApplyBatch(_pending.Drain(), RebuildEntry, RemoveEntry))
+                // Only when the cache is actually in service: while the setting is
+                // off (or the cache is an unpublished placeholder) the entries
+                // would be applied into a dictionary whose save is refused anyway
+                // — guaranteed-discarded per-item probe work that can only delay
+                // shutdown. The dropped ids are re-covered by the next full build
+                // or timestamp reconcile.
+                if (ServerModeEnabled && !_cacheReleased)
                 {
-                    Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
-                    _dirty = true;
+                    if (ApplyBatch(_pending.Drain(), RebuildEntry, RemoveEntry))
+                    {
+                        Interlocked.Exchange(ref _lastModified, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                        _dirty = true;
+                    }
+                }
+                else
+                {
+                    _pending.Drain();
                 }
             }
             catch (Exception ex)
@@ -718,7 +1252,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
 
             var timer = Interlocked.Exchange(ref _debounceSaveTimer, null);
             timer?.Dispose();
-            if (_dirty) SaveToDisk();
+            if (_dirty && ServerModeEnabled) SaveToDisk();
         }
 
         /// <summary>
@@ -898,6 +1432,31 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             return (streams, sources, languages.ToArray());
         }
 
+        /// <summary>
+        /// Hydrate library items for the given ids in fixed-size pages
+        /// (<see cref="HydrationPageSize"/>). Only one page of full BaseItems is
+        /// referenced at a time, which keeps full builds and reconciliation
+        /// memory-bounded on arbitrarily large libraries. An id that no longer
+        /// resolves (deleted between the id query and its page) is simply absent
+        /// from the returned page.
+        /// </summary>
+        private IEnumerable<IReadOnlyList<BaseItem>> HydrateInPages(IReadOnlyList<Guid> ids, CancellationToken cancellationToken)
+        {
+            for (var offset = 0; offset < ids.Count; offset += HydrationPageSize)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var count = Math.Min(HydrationPageSize, ids.Count - offset);
+                var pageIds = new Guid[count];
+                for (var i = 0; i < count; i++)
+                {
+                    pageIds[i] = ids[offset + i];
+                }
+
+                yield return _libraryManager.GetItemList(new InternalItemsQuery { ItemIds = pageIds });
+            }
+        }
+
         private BaseItem? GetFirstEpisode(BaseItem container)
         {
             try
@@ -917,6 +1476,26 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                 _logger.Warning($"[TagCache] Failed to get first episode for {container.Id}: {ex.Message}");
                 return null;
             }
+        }
+
+        /// <summary>
+        /// All Season items of a series, for the reconcile sweep's parent repair.
+        /// Query failures propagate — the caller logs them and requeues what it
+        /// can, so swallowing here would silently disable that retry path.
+        /// </summary>
+        private IReadOnlyList<BaseItem> GetSeasonsOfSeries(Guid seriesId)
+        {
+            // IsVirtualItem must match the build/sweep queries: including a
+            // virtual season here would add an entry the next sweep's live-id
+            // set (virtual-excluded) doesn't contain, so it would be removed,
+            // trigger this repair again, and churn the cache version forever.
+            return _libraryManager.GetItemList(new InternalItemsQuery
+            {
+                ParentId = seriesId,
+                IncludeItemTypes = new[] { BaseItemKind.Season },
+                IsVirtualItem = false,
+                Recursive = true
+            });
         }
 
         private BaseItem? GetParentSeries(BaseItem item)

--- a/docs/enhanced/enhanced-settings.md
+++ b/docs/enhanced/enhanced-settings.md
@@ -64,3 +64,15 @@ Most features can be enabled/disabled individually:
 !!! tip
 
     [Custom CSS available](../advanced/css-customization.md#tags)
+
+### Server-Side Tag Cache
+
+By default the server pre-computes tag data for the whole library and serves it to clients in a single request, so tags appear instantly without per-page API calls. The cache is built on first startup, kept up to date by library scan events, and refreshed daily by the **Refresh Tag Cache** scheduled task.
+
+Disabling **Server-Side Tag Cache** (Dashboard → Plugins → Jellyfin Enhanced → Display → Media Tags) switches clients to the legacy per-page batch mode (each client picks this up on its next page load) and completely turns off the server-side cache — it is not loaded, built, or maintained while the setting is off, and the in-memory cache is released immediately.
+
+!!! note "Very large libraries"
+
+    The cache build processes the library in small pages, so server memory use stays bounded even on libraries with tens of thousands of items. If you still prefer not to run a server-side cache, disable the setting — tags keep working via the per-page batch mode.
+
+Turning the setting back on from the dashboard restores the last saved snapshot and catches up on anything that changed while it was off, automatically in the background — no restart or manual task run needed. (Only if you edit the plugin's configuration file by hand instead of using the dashboard: restart the server so the change is picked up, then run the **Refresh Tag Cache** scheduled task to catch up.)


### PR DESCRIPTION
Closes #708

## What

Fixes the startup tag-cache OOM crash loop on very large libraries, and makes the **Server-Side Tag Cache** setting actually control the cache.

### The OOM fix
- `BuildFullCacheCore` / `ReconcileCacheCore` no longer materialize the whole library with one `GetItemList` call. They fetch ids first and hydrate items in **pages of 500** (`GetItemIds` + `InternalItemsQuery.ItemIds`), so peak memory is bounded by one page of `BaseItem`s regardless of library size.
- `tag-cache.json` is now serialized/deserialized straight to/from the file stream (no more tens-of-MB intermediate string on large caches).

### Honoring `TagCacheServerMode`
- `StartupService`, `BuildTagCacheTask`, and the `TagCacheMonitor` event handlers now check the setting (previously only the controller did, so `TagCacheServerMode=false` did not prevent the startup build — the crash-loop reporter's exact situation).
- Long-running builds/reconciles also re-check at page boundaries and abort if the setting turns off mid-run.
- Toggling the setting in the dashboard now runs proper transitions (serialized, in the background):
  - **OFF** → unsaved changes are persisted, then the in-memory cache is released immediately (that's why an admin on a memory-constrained server turns it off).
  - **ON** → the monitor is re-subscribed, the last snapshot is restored, and a timestamp reconcile catches up on the off-window — no restart or manual task run needed.
- Clients keep working in both modes via the existing per-page batch fallback (`tag-data`); the `tag-cache` endpoint 404s while off.

### Correctness hardening that fell out of review
- Incremental flushes now defer while a rebuild owns the cache instead of writing into a dictionary about to be swapped away (lost-update race, pre-existing).
- Cache publishes/releases and the version/timestamp metadata are serialized, and `GET tag-cache` returns a version/timestamp pair from the same generation as its items — closing `?since` delta holes (a cursor covering unreturned updates, and a `timestamp: 0` response that permanently disabled a client's refresh).
- Saves refuse to persist an unpublished placeholder cache, so no toggle/shutdown interleaving can overwrite a good snapshot with a near-empty one.
- Removing an episode/season requeues its parent Series/Season entries, and the reconcile sweep repairs parents of swept entries (with per-step retry), so container entries stop serving stream/genre data derived from deleted items.

Docs (`enhanced-settings.md`) and the config-page description updated to match.

## Test plan

All verified live on fresh Jellyfin **10.11.10** and **12.0.0** servers (STRM-style libraries, mirroring the reporter's setup), plus a 112k-item library for scale:

- **Scale**: full paged build over **112,091 taggable items** ran with flat ~550 MiB total server memory (previously this OOM'd), server responsive throughout.
- Fresh install, mode on → initial paged build runs, saves, serves (`200`, correct count/version/timestamp).
- Mode off at startup → load/build/monitor all skipped, endpoint `404`, tags render via batch fallback (browser-verified from real logins, admin + non-admin).
- Scheduled task while off → skips.
- Dashboard toggle OFF → "in-memory cache released" + `404`; toggle ON → snapshot reload + delta reconcile + `200`, no restart; rapid off/on/off/on toggles converge correctly with the on-disk snapshot intact.
- Cross-user access still `403`.
- Cache content equivalence: paged build output is identical to the previous unpaged build (same entries, zero content differences on a 1856-item library).
- `validate-translations` untouched (no i18n changes); `mkdocs build --strict` passes.

## AI assistance

This PR was developed with AI assistance. I have reviewed, tested, and can explain all the code in this PR (multiple adversarial review rounds were run over the final diff, and every flow above was exercised against live servers on both supported Jellyfin majors).
