### PR TITLE
fix: Seerr results row cannot be touch-scrolled on phones

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/jellyseerr.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/jellyseerr.js
@@ -476,7 +476,12 @@
                 hideHoverPopover();
             }
         }, { passive: true });
-        document.addEventListener('scroll', () => hideHoverPopover(), true);
+        // Scrolling moves the button away from the fixed-position popover, so a
+        // tap-locked popover must unlock too or it would float at stale coordinates.
+        document.addEventListener('scroll', () => {
+            toggleHoverPopoverLock(false);
+            hideHoverPopover();
+        }, true);
 
         // Remove touch overlay when touching outside cards
         document.body.addEventListener('touchstart', (e) => {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
@@ -1037,30 +1037,51 @@
     function addTouchTapListener(element, onTap) {
         // Movement beyond this many pixels means the touch is a scroll/swipe, not a tap.
         const TAP_MOVE_THRESHOLD_PX = 10;
+        let trackedTouchId = null;
         let startX = 0;
         let startY = 0;
         let moved = false;
 
+        const exceedsThreshold = (touch) =>
+            Math.abs(touch.clientX - startX) > TAP_MOVE_THRESHOLD_PX ||
+            Math.abs(touch.clientY - startY) > TAP_MOVE_THRESHOLD_PX;
+
         element.addEventListener('touchstart', (e) => {
-            const touch = e.touches[0];
+            // A second concurrent finger is never a tap — cancel the gesture and
+            // wait for a fresh single-finger touch.
+            if (trackedTouchId !== null || e.touches.length > 1) {
+                trackedTouchId = null;
+                return;
+            }
+            const touch = e.changedTouches[0];
+            trackedTouchId = touch.identifier;
             moved = false;
             startX = touch.clientX;
             startY = touch.clientY;
         }, { passive: true });
 
         element.addEventListener('touchmove', (e) => {
-            if (moved) return;
-            const touch = e.touches[0];
-            if (Math.abs(touch.clientX - startX) > TAP_MOVE_THRESHOLD_PX ||
-                Math.abs(touch.clientY - startY) > TAP_MOVE_THRESHOLD_PX) {
+            if (moved || trackedTouchId === null) return;
+            const touch = Array.from(e.touches).find(t => t.identifier === trackedTouchId);
+            if (touch && exceedsThreshold(touch)) {
                 moved = true;
             }
+        }, { passive: true });
+
+        // System gestures (e.g. iOS edge swipes) cancel the touch without a touchend.
+        element.addEventListener('touchcancel', () => {
+            trackedTouchId = null;
         }, { passive: true });
 
         // Non-passive so onTap may preventDefault() the synthetic click;
         // preventDefault on touchend cannot block scrolling.
         element.addEventListener('touchend', (e) => {
-            if (moved) return;
+            const touch = Array.from(e.changedTouches).find(t => t.identifier === trackedTouchId);
+            if (!touch) return;
+            trackedTouchId = null;
+            // Also compare the final position: fast flicks can outrun touchmove
+            // sampling, ending far from the start without `moved` ever flipping.
+            if (moved || exceedsThreshold(touch)) return;
             onTap(e);
         }, { passive: false });
     }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
@@ -725,7 +725,11 @@
             };
 
             icon.addEventListener('click', handleIconInteraction);
-            icon.addEventListener('touchend', (e) => { e.preventDefault(); handleIconInteraction(); }, { passive: false });
+            // Tap detection (rather than a bare touchend) so a scroll gesture that
+            // happens to start on the icon is not miscounted toward the double-tap
+            // filter toggle; preventDefault() suppresses the synthetic click that
+            // would otherwise double-count the tap via the click listener above.
+            addTouchTapListener(icon, (e) => { e.preventDefault(); handleIconInteraction(); });
             icon.setAttribute('tabindex', '0');
             icon.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter' || e.key === ' ') {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
@@ -1034,28 +1034,43 @@
      *                           May call `event.preventDefault()` to suppress the
      *                           synthetic click that follows a tap.
      */
+    // Timestamp of the most recent scroll anywhere in the document (capture phase
+    // sees the results row's own scroll events too). Lets tap detection tell a
+    // tap-that-stops-a-momentum-fling — for which browsers suppress the synthetic
+    // click, so native cards do nothing — apart from a deliberate tap.
+    let lastScrollTs = 0;
+    document.addEventListener('scroll', () => { lastScrollTs = Date.now(); }, { capture: true, passive: true });
+
     function addTouchTapListener(element, onTap) {
         // Movement beyond this many pixels means the touch is a scroll/swipe, not a tap.
         const TAP_MOVE_THRESHOLD_PX = 10;
+        // A touch starting within this window of a scroll event is stopping a
+        // momentum fling, not tapping — momentum emits scroll events continuously.
+        const SCROLL_QUIET_WINDOW_MS = 100;
         let trackedTouchId = null;
         let startX = 0;
         let startY = 0;
         let moved = false;
+        let stoppedFling = false;
 
         const exceedsThreshold = (touch) =>
             Math.abs(touch.clientX - startX) > TAP_MOVE_THRESHOLD_PX ||
             Math.abs(touch.clientY - startY) > TAP_MOVE_THRESHOLD_PX;
 
         element.addEventListener('touchstart', (e) => {
-            // A second concurrent finger is never a tap — cancel the gesture and
-            // wait for a fresh single-finger touch.
-            if (trackedTouchId !== null || e.touches.length > 1) {
+            // A second concurrent finger on the element is never a tap — cancel the
+            // gesture and wait for a fresh single-finger touch. `targetTouches` is
+            // scoped to this element on purpose: an unrelated resting contact
+            // elsewhere on the screen (palm edge, holding thumb) must not make the
+            // row unresponsive.
+            if (trackedTouchId !== null || e.targetTouches.length > 1) {
                 trackedTouchId = null;
                 return;
             }
             const touch = e.changedTouches[0];
             trackedTouchId = touch.identifier;
             moved = false;
+            stoppedFling = Date.now() - lastScrollTs < SCROLL_QUIET_WINDOW_MS;
             startX = touch.clientX;
             startY = touch.clientY;
         }, { passive: true });
@@ -1073,17 +1088,22 @@
             trackedTouchId = null;
         }, { passive: true });
 
-        // Non-passive so onTap may preventDefault() the synthetic click;
+        // Non-passive so the synthetic click can be suppressed via preventDefault();
         // preventDefault on touchend cannot block scrolling.
         element.addEventListener('touchend', (e) => {
             const touch = Array.from(e.changedTouches).find(t => t.identifier === trackedTouchId);
             if (!touch) return;
             trackedTouchId = null;
-            // Also compare the final position: fast flicks can outrun touchmove
-            // sampling, ending far from the start without `moved` ever flipping.
-            // `e.touches` is surface-wide, so any other finger still down (even one
-            // that started on another element) disqualifies the gesture as a tap.
-            if (moved || e.touches.length > 0 || exceedsThreshold(touch)) return;
+            // Reject flick-stops, second-finger gestures on the element, and
+            // touches that ended far from where they started (fast flicks can
+            // outrun touchmove sampling without `moved` ever flipping).
+            if (moved || stoppedFling || e.targetTouches.length > 0 || exceedsThreshold(touch)) {
+                // The browser's own tap classifier is more tolerant than ours; if it
+                // disagrees, its synthetic click would reach unguarded click
+                // handlers (real request flow, instant modal). Suppress it.
+                e.preventDefault();
+                return;
+            }
             onTap(e);
         }, { passive: false });
     }
@@ -1280,7 +1300,7 @@
 
             // Desktop: use click event
             imageContainer.addEventListener('click', (e) => {
-                // Skip if touch device (touchstart already handled it)
+                // Skip if touch device (the tap handler already handled it)
                 if (e.type === 'click' && 'ontouchstart' in window) {
                     return;
                 }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
@@ -1081,7 +1081,9 @@
             trackedTouchId = null;
             // Also compare the final position: fast flicks can outrun touchmove
             // sampling, ending far from the start without `moved` ever flipping.
-            if (moved || exceedsThreshold(touch)) return;
+            // `e.touches` is surface-wide, so any other finger still down (even one
+            // that started on another element) disqualifies the gesture as a tap.
+            if (moved || e.touches.length > 0 || exceedsThreshold(touch)) return;
             onTap(e);
         }, { passive: false });
     }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
@@ -1034,12 +1034,18 @@
      *                           May call `event.preventDefault()` to suppress the
      *                           synthetic click that follows a tap.
      */
-    // Timestamp of the most recent scroll anywhere in the document (capture phase
-    // sees the results row's own scroll events too). Lets tap detection tell a
+    // Most recent scroll seen anywhere in the document (capture phase sees the
+    // results row's own scroll events too). Lets tap detection tell a
     // tap-that-stops-a-momentum-fling — for which browsers suppress the synthetic
-    // click, so native cards do nothing — apart from a deliberate tap.
+    // click, so native cards do nothing — apart from a deliberate tap. The target
+    // is kept so only scrolls of a container that actually holds the tapped
+    // element count; a sibling row still coasting must not reject taps here.
     let lastScrollTs = 0;
-    document.addEventListener('scroll', () => { lastScrollTs = Date.now(); }, { capture: true, passive: true });
+    let lastScrollTarget = null;
+    document.addEventListener('scroll', (e) => {
+        lastScrollTs = Date.now();
+        lastScrollTarget = e.target;
+    }, { capture: true, passive: true });
 
     function addTouchTapListener(element, onTap) {
         // Movement beyond this many pixels means the touch is a scroll/swipe, not a tap.
@@ -1067,10 +1073,14 @@
                 trackedTouchId = null;
                 return;
             }
-            const touch = e.changedTouches[0];
+            // changedTouches can carry simultaneous contacts from other elements
+            // in one hardware event — track the one that actually began here.
+            const touch = Array.from(e.changedTouches).find(t => element.contains(t.target)) ||
+                e.changedTouches[0];
             trackedTouchId = touch.identifier;
             moved = false;
-            stoppedFling = Date.now() - lastScrollTs < SCROLL_QUIET_WINDOW_MS;
+            stoppedFling = (Date.now() - lastScrollTs < SCROLL_QUIET_WINDOW_MS) &&
+                !!(lastScrollTarget && lastScrollTarget.contains && lastScrollTarget.contains(element));
             startX = touch.clientX;
             startY = touch.clientY;
         }, { passive: true });

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui.js
@@ -1020,6 +1020,52 @@
     }
 
     /**
+     * Registers a scroll-friendly touch "tap" handler on an element.
+     *
+     * A non-passive `touchstart` handler that calls `preventDefault()` cancels the
+     * native scroll gesture, so any swipe starting on the element goes dead — on
+     * phones this froze the horizontal Seerr results row, whose surface is almost
+     * entirely posters/buttons. Instead, listen passively and only treat the touch
+     * as a tap on `touchend` when the finger has not moved beyond a small
+     * threshold; swipes fall through to the browser's native scrolling.
+     *
+     * @param {HTMLElement} element - Element to attach the tap handler to.
+     * @param {Function} onTap - Called with the `touchend` event for genuine taps.
+     *                           May call `event.preventDefault()` to suppress the
+     *                           synthetic click that follows a tap.
+     */
+    function addTouchTapListener(element, onTap) {
+        // Movement beyond this many pixels means the touch is a scroll/swipe, not a tap.
+        const TAP_MOVE_THRESHOLD_PX = 10;
+        let startX = 0;
+        let startY = 0;
+        let moved = false;
+
+        element.addEventListener('touchstart', (e) => {
+            const touch = e.touches[0];
+            moved = false;
+            startX = touch.clientX;
+            startY = touch.clientY;
+        }, { passive: true });
+
+        element.addEventListener('touchmove', (e) => {
+            if (moved) return;
+            const touch = e.touches[0];
+            if (Math.abs(touch.clientX - startX) > TAP_MOVE_THRESHOLD_PX ||
+                Math.abs(touch.clientY - startY) > TAP_MOVE_THRESHOLD_PX) {
+                moved = true;
+            }
+        }, { passive: true });
+
+        // Non-passive so onTap may preventDefault() the synthetic click;
+        // preventDefault on touchend cannot block scrolling.
+        element.addEventListener('touchend', (e) => {
+            if (moved) return;
+            onTap(e);
+        }, { passive: false });
+    }
+
+    /**
      * Creates an individual Seerr result card.
      * @param {Object} item - Search result item from Seerr API.
      * @param {boolean} isJellyseerrActive - If the server is reachable.
@@ -1189,11 +1235,13 @@
                 removeOverview();
             });
 
-            // Mobile/Touch: touchstart to show overview, second tap (click) on overview opens modal
+            // Mobile/Touch: tap to show overview, second tap (click) on overview opens modal
             imageContainer.style.cursor = 'pointer';
 
-            // Use touchstart for mobile to create overview (prevents touchend from immediately opening modal)
-            imageContainer.addEventListener('touchstart', (e) => {
+            // Tap (not swipe) creates the overview; preventDefault() on the tap's
+            // touchend suppresses the synthetic click so the fresh overview isn't
+            // immediately activated. Swipes keep scrolling the results row natively.
+            addTouchTapListener(imageContainer, (e) => {
                 if (e.target.closest('.jellyseerr-overview') || e.target.closest('.jellyseerr-request-button')) {
                     return;
                 }
@@ -1205,7 +1253,7 @@
                         document.addEventListener('click', handleOutsideClick);
                     }, 0);
                 }
-            }, { passive: false });
+            });
 
             // Desktop: use click event
             imageContainer.addEventListener('click', (e) => {
@@ -1814,7 +1862,9 @@
             ui.toggleHoverPopoverLock(false);
             ui.hideHoverPopover();
         });
-        button.addEventListener('touchstart', (e) => {
+        // Tap (not swipe) toggles the popover; swipes starting on the request
+        // button keep scrolling the results row natively.
+        addTouchTapListener(button, (e) => {
             e.preventDefault();
             const popover = fillHoverPopover(item);
             if (popover) {
@@ -1832,7 +1882,7 @@
                     popover.classList.remove('show');
                 }
             }
-        }, { passive: false });
+        });
     }
 
     /**


### PR DESCRIPTION
# fix: Seerr results row cannot be touch-scrolled on phones

Closes #706

## Problem

On touch devices the horizontal Seerr row on the search page could not be scrolled by finger. Two non-passive `touchstart` handlers called `preventDefault()`:

- the poster overview handler on `.cardImageContainer` (`js/jellyseerr/ui.js`)
- the request-button hover-popover handler

`preventDefault()` on `touchstart` cancels the browser's native scroll gesture, and since the row's surface is almost entirely posters and request buttons, any swipe starting on it went dead — exactly the behavior in the issue video (neither posters nor, practically, titles could scroll the row).

## Fix

New `addTouchTapListener()` helper in `js/jellyseerr/ui.js` replaces both handlers with scroll-friendly tap detection:

- **passive** `touchstart`/`touchmove` record the initiating touch (tracked by identifier); swipes fall through to native scrolling
- the tap is decided on `touchend`: ≤10 px movement, including a final-position check so fast flicks that outrun `touchmove` sampling aren't misread as taps
- multi-touch is rejected via `targetTouches` (scoped to the element, so an unrelated resting contact elsewhere on the screen doesn't make the row unresponsive), plus `touchcancel` cleanup
- a touch that starts while scroll events are still streaming from a container holding the element is treated as a fling-stop, not a tap — matching the browser's own suppressed synthetic click
- rejected tracked touches call `preventDefault()` on `touchend` so the browser's more tolerant tap classifier can't leak a synthetic click into unguarded click handlers (which would trigger the real request flow / instant modal)

Additionally:

- the document scroll handler in `js/jellyseerr/jellyseerr.js` now unlocks the tap-locked hover popover before hiding it, so scrolling can't leave it floating at stale fixed coordinates
- the Seerr icon in the search field had the same misclassification in miniature: its bare `touchend` handler counted any touch ending on it as a tap, so a scroll gesture starting on the icon fed the double-tap counter and could toggle the Seerr-only filter. It now goes through the same tap detector (verified by E2E: double-tap toggles the filter, double-swipe-from-icon does not).

Tap behavior is unchanged: first tap shows the overview, second tap opens the modal/link, request-button tap toggles the download-progress popover. Desktop hover/click flows are untouched.

## Testing

- Playwright E2E with mobile emulation (iPhone viewport/UA, `hasTouch`, CDP touch events) against clean throwaway Jellyfin **10.11.10** and **12.0.0** containers, Seerr proxy endpoints stubbed at the browser layer so the real UI code renders real cards:
  - **Before (upstream main):** swipe starting on a poster moves the row 0 px (bug reproduced)
  - **After:** the same swipe scrolls the row (~280 px); a tap on a poster still opens the overview with the Request button
- Reviewed over multiple adversarial rounds (multi-dimension review + verification, plus independent codex reviews); final full-file gate came back clean.
- `node --check` on edited files; translation validation passes (no string changes).

## AI assistance note

This change was developed with AI assistance (Claude); all changes were reviewed, adversarially re-reviewed, and verified end-to-end on live Jellyfin 10.11 and 12.0 instances as described above.
