### PR TITLE
fix(i18n): validate {{icon:xxx}} placeholders and fix Norwegian typo

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/no.json
@@ -43,7 +43,7 @@
     "feature_tags_hide_on_hover": "{{icon:eye}} Skjul etiketter ved hovering",
     "feature_custom_pause_screen": "{{icon:pip}} Tilpasset pause-skjerm",
     "feature_disable_custom_subtitle_styles": "{{icon:noEntry}} Skru av tilpassede undertekst-stiler",
-    "feature_long_press_2x_speed": "{{icon:fastForward} Trykk og hold for 2x hastighet",
+    "feature_long_press_2x_speed": "{{icon:fastForward}} Trykk og hold for 2x hastighet",
     "panel_settings_long_press_desc": "Trykk og hold hopp-knappen for å hoppe 2x hastighet. (Fungerer best på mobil/touch-enheter)",
     "panel_settings_long_press_2x_speed": "Trykk og hold for 2x hastighet (β)",
     "toast_at_least_one_item_type": "{{icon:warning}} Du må velge minst én elementtype",

--- a/scripts/validate-translations.js
+++ b/scripts/validate-translations.js
@@ -94,8 +94,9 @@ function getAvailableLanguages() {
  * Extract placeholders from a translation string
  */
 function extractPlaceholders(text) {
-    const matches = text.match(/\{[a-zA-Z_][a-zA-Z0-9_]*\}/g);
-    return matches ? [...new Set(matches)].sort() : [];
+    const variables = text.match(/\{[a-zA-Z_][a-zA-Z0-9_]*\}/g) || [];
+    const icons = text.match(/\{\{icon:[a-zA-Z0-9_-]+\}\}/g) || [];
+    return [...new Set([...variables, ...icons])].sort();
 }
 
 /**


### PR DESCRIPTION
## What

The translation validation CI script (`scripts/validate-translations.js`) only checked single-brace `{var}` placeholders. It had no regex coverage for the `{{icon:xxx}}` token syntax used throughout the locale files, so a translation could lose or corrupt an icon token and CI would still pass as long as any other placeholder in the string survived.

This surfaced a real bug immediately: `no.json`'s `feature_long_press_2x_speed` was missing a closing brace (`{{icon:fastForward}` instead of `{{icon:fastForward}}`), silently breaking the icon render in the Norwegian UI. Fixed here and in the matching Weblate translation unit.

## Why

Found while investigating why a vandalized Hebrew string (`toast_speed`, dropped `{{icon:speed}}` and replaced it with junk text) made it through both Weblate and this repo's CI undetected. Root cause was two independent blind spots:
- Weblate's component had `ignore-all-checks` set, disabling all quality checks including the `python-brace-format` one that was already configured (fixed separately in Weblate's component settings).
- This repo's own validator never looked at `{{icon:xxx}}` tokens at all.

## Test plan

- `node scripts/validate-translations.js validate` — all 629 keys pass across all 28 locales.
- Verified the new regex correctly flags a synthetic case with a dropped icon token, and correctly ignores it when both source and translation have no icon tokens.