### PR TITLE
fix(tags): preserve explicit language regions in flag resolution (pt-BR, es-419, zh-Hant…)

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/core/media-language.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/core/media-language.js
@@ -1,0 +1,218 @@
+// /js/core/media-language.js
+// Shared audio-language → flag resolution for the Language Tags overlay
+// (js/tags/languagetags.js) and the details-page audio-language row
+// (js/enhanced/itemdetails/features-details-media-info.js). Single source of
+// truth so the two features can never disagree about which flag a language
+// gets.
+//
+// The resolver understands region subtags: a stream tagged `pt-BR` gets the
+// Brazilian flag while `pt` / `pt-PT` keep the Portuguese one, `es-419` and
+// `es-MX` get the Mexican flag while `es` stays Spain, `zh-Hant` maps to the
+// Taiwanese flag, and so on. A region flag is shown only when the media
+// explicitly carries one — a bare `pt` or `es` is never "guessed" into a
+// regional variant.
+(function(JE) {
+    'use strict';
+
+    JE.core = JE.core || {};
+
+    /**
+     * Language name/ISO-code → flag code, for languages WITHOUT an explicit
+     * region subtag. Values are flag-icons codes (ISO 3166-1 alpha-2, plus
+     * subdivision codes like `es-ct` which the flag-icons set also ships).
+     * Keys cover English display names (as produced by Intl.DisplayNames) and
+     * ISO 639-1/639-2 codes as they appear in real-world media containers.
+     */
+    const baseLanguageFlags = {
+        English: 'gb', eng: 'gb', en: 'gb', Japanese: 'jp', jpn: 'jp', ja: 'jp', Spanish: 'es', spa: 'es', es: 'es',
+        French: 'fr', fre: 'fr', fra: 'fr', fr: 'fr', German: 'de', ger: 'de', deu: 'de', de: 'de',
+        Italian: 'it', ita: 'it', it: 'it', Korean: 'kr', kor: 'kr', ko: 'kr', Chinese: 'cn', chi: 'cn', zho: 'cn', zh: 'cn',
+        Russian: 'ru', rus: 'ru', ru: 'ru', Portuguese: 'pt', por: 'pt', pt: 'pt', Hindi: 'in', hin: 'in', hi: 'in',
+        Dutch: 'nl', dut: 'nl', nld: 'nl', nl: 'nl', Arabic: 'sa', ara: 'sa', ar: 'sa',
+        Bengali: 'in', ben: 'in', bn: 'in', Czech: 'cz', ces: 'cz', cs: 'cz', Danish: 'dk', dan: 'dk', da: 'dk',
+        Greek: 'gr', ell: 'gr', el: 'gr', Finnish: 'fi', fin: 'fi', fi: 'fi', Hebrew: 'il', heb: 'il', he: 'il',
+        Hungarian: 'hu', hun: 'hu', hu: 'hu', Indonesian: 'id', ind: 'id', id: 'id',
+        Norwegian: 'no', nor: 'no', no: 'no', Polish: 'pl', pol: 'pl', pl: 'pl',
+        Persian: 'ir', per: 'ir', fas: 'ir', fa: 'ir', Romanian: 'ro', ron: 'ro', rum: 'ro', ro: 'ro',
+        Swedish: 'se', swe: 'se', sv: 'se', Thai: 'th', tha: 'th', th: 'th', Turkish: 'tr', tur: 'tr', tr: 'tr',
+        Ukrainian: 'ua', ukr: 'ua', uk: 'ua', Vietnamese: 'vn', vie: 'vn', vi: 'vn',
+        Malay: 'my', msa: 'my', may: 'my', ms: 'my', Swahili: 'ke', swa: 'ke', sw: 'ke',
+        Tagalog: 'ph', tgl: 'ph', tl: 'ph', Filipino: 'ph', Tamil: 'in', tam: 'in', ta: 'in',
+        Telugu: 'in', tel: 'in', te: 'in', Marathi: 'in', mar: 'in', mr: 'in', Punjabi: 'in', pan: 'in', pa: 'in',
+        Urdu: 'pk', urd: 'pk', ur: 'pk', Gujarati: 'in', guj: 'in', gu: 'in', Kannada: 'in', kan: 'in', kn: 'in',
+        Malayalam: 'in', mal: 'in', ml: 'in', Sinhala: 'lk', sin: 'lk', si: 'lk', Nepali: 'np', nep: 'np', ne: 'np',
+        Pashto: 'af', pus: 'af', ps: 'af', Kurdish: 'iq', kur: 'iq', ku: 'iq', Slovak: 'sk', slk: 'sk', sk: 'sk',
+        Slovenian: 'si', slv: 'si', sl: 'si', Serbian: 'rs', srp: 'rs', sr: 'rs', Croatian: 'hr', hrv: 'hr', hr: 'hr',
+        Bulgarian: 'bg', bul: 'bg', bg: 'bg', Macedonian: 'mk', mkd: 'mk', mk: 'mk', Albanian: 'al', sqi: 'al', sq: 'al',
+        Estonian: 'ee', est: 'ee', et: 'ee', Latvian: 'lv', lav: 'lv', lv: 'lv', Lithuanian: 'lt', lit: 'lt', lt: 'lt',
+        Icelandic: 'is', isl: 'is', is: 'is', Georgian: 'ge', kat: 'ge', ka: 'ge', Armenian: 'am', hye: 'am', hy: 'am',
+        Mongolian: 'mn', mon: 'mn', mn: 'mn', Kazakh: 'kz', kaz: 'kz', kk: 'kz', Uzbek: 'uz', uzb: 'uz', uz: 'uz',
+        Azerbaijani: 'az', aze: 'az', az: 'az', Belarusian: 'by', bel: 'by', be: 'by',
+        Amharic: 'et', amh: 'et', am: 'et', Zulu: 'za', zul: 'za', zu: 'za', Afrikaans: 'za', afr: 'za', af: 'za',
+        Hausa: 'ng', hau: 'ng', ha: 'ng', Yoruba: 'ng', yor: 'ng', yo: 'ng', Igbo: 'ng', ibo: 'ng', ig: 'ng',
+        Brazilian: 'br', bra: 'br',
+        Catalan: 'es-ct', cat: 'es-ct', ca: 'es-ct', Galician: 'es-ga', glg: 'es-ga', gl: 'es-ga',
+        Basque: 'es-pv', eus: 'es-pv', baq: 'es-pv', eu: 'es-pv'
+    };
+
+    /**
+     * Non-standard codes seen in real media that already IMPLY a region.
+     * `pob`/`pb` are the de-facto Brazilian Portuguese codes used by
+     * OpenSubtitles-era tooling and MKV muxers.
+     */
+    const aliasTags = {
+        pob: { base: 'pt', region: 'br' },
+        pb: { base: 'pt', region: 'br' }
+    };
+
+    /**
+     * Region spellings seen in the wild that are not the ISO 3166-1 code the
+     * flag set uses. `en-UK` is common; flag-icons only ships `gb`.
+     */
+    const regionAliases = { uk: 'gb' };
+
+    /**
+     * Per-base-language region conventions — deliberately NOT global, so
+     * other languages can't inherit them (`en-419` must fall back to gb):
+     * `es-419` (UN M.49 Latin America) uses the Mexican flag per the
+     * community convention — most Latin-American dubs are produced there and
+     * there is no pan-Latin-America flag. `es-LA`/`pt-LA` are widespread
+     * non-ISO "Latin America" tags; taken literally the region would be Laos.
+     */
+    const regionOverridesByBase = {
+        es: { la: 'mx', '419': 'mx' },
+        spa: { la: 'mx', '419': 'mx' },
+        pt: { la: 'br', '419': 'br' },
+        por: { la: 'br', '419': 'br' }
+    };
+
+    /**
+     * ISO 15924 script subtags that imply a flag — Chinese only (all its ISO
+     * 639 spellings). Applying hant/hans to other languages (ja-Hans,
+     * sr-Hant) would be wrong.
+     */
+    const chineseScriptFlags = { hant: 'tw', hans: 'cn' };
+    const scriptFlagsByBase = { zh: chineseScriptFlags, zho: chineseScriptFlags, chi: chineseScriptFlags };
+
+    /**
+     * Every ISO 3166-1 alpha-2 region code. An alpha-2 subtag outside this
+     * set (private-use `pt-XA`, withdrawn codes) is ignored so the resolver
+     * falls back to the base language's flag instead of pointing the flag CDN
+     * at a code it cannot have.
+     */
+    const validRegions = new Set(('ad ae af ag ai al am ao aq ar as at au aw ax az ba bb bd be bf bg bh bi bj bl bm bn bo bq br bs bt bv bw by bz ' +
+        'ca cc cd cf cg ch ci ck cl cm cn co cr cu cv cw cx cy cz de dj dk dm do dz ec ee eg eh er es et fi fj fk fm fo fr ' +
+        'ga gb gd ge gf gg gh gi gl gm gn gp gq gr gs gt gu gw gy hk hm hn hr ht hu id ie il im in io iq ir is it je jm jo jp ' +
+        'ke kg kh ki km kn kp kr kw ky kz la lb lc li lk lr ls lt lu lv ly ma mc md me mf mg mh mk ml mm mn mo mp mq mr ms mt mu mv mw mx my mz ' +
+        'na nc ne nf ng ni nl no np nr nu nz om pa pe pf pg ph pk pl pm pn pr ps pt pw py qa re ro rs ru rw ' +
+        'sa sb sc sd se sg sh si sj sk sl sm sn so sr ss st sv sx sy sz tc td tf tg th tj tk tl tm tn to tr tt tv tw tz ' +
+        'ua ug um us uy uz va vc ve vg vi vn vu wf ws ye yt za zm zw').split(' '));
+
+    /**
+     * Parse a raw language tag into subtags. Accepts BCP-47 (`pt-BR`),
+     * underscore variants (`pt_BR`) and bare ISO 639 codes, case-insensitive.
+     * @param {string} raw
+     * @returns {{base: string, region: string|null, script: string|null}|null}
+     */
+    function parseLanguageTag(raw) {
+        if (!raw || typeof raw !== 'string') return null;
+        const normalized = raw.trim().toLowerCase().replace(/_/g, '-');
+        if (!normalized) return null;
+
+        const alias = aliasTags[normalized];
+        if (alias) return { base: alias.base, region: alias.region, script: null };
+
+        const subtags = normalized.split('-');
+        const base = subtags[0];
+        // Base must look like an ISO 639 code; anything else (display names,
+        // junk) is not parseable as a tag and is handled by the name map.
+        if (!/^[a-z]{2,3}$/.test(base)) return null;
+
+        let region = null;
+        let script = null;
+        for (const subtag of subtags.slice(1)) {
+            // A single-letter subtag starts a BCP-47 extension or private-use
+            // section (en-u-ca-gregory, en-x-us); nothing after it is a
+            // region or script, so stop scanning entirely.
+            if (subtag.length === 1) break;
+            if (/^[a-z]{2}$/.test(subtag) && !region) {
+                region = subtag; // ISO 3166-1 alpha-2 region (br, mx, us…)
+            } else if (/^\d{3}$/.test(subtag) && !region) {
+                region = subtag; // UN M.49 numeric region (419…)
+            } else if (/^[a-z]{4}$/.test(subtag) && !script) {
+                script = subtag; // ISO 15924 script (hant, hans…)
+            }
+        }
+        return { base, region, script };
+    }
+
+    /**
+     * Resolve the flag code for a language entry.
+     *
+     * Resolution order:
+     *  1. Explicit, VALID region subtag → that country's flag (`pt-BR` → br),
+     *     after alias/convention normalization (`en-UK` → gb, `es-LA` → mx,
+     *     `es-419` → mx). Exception: when the base language's curated flag is
+     *     a subdivision of that same region (`ca-ES` → the Catalan flag
+     *     es-ct, not the Spanish one), the curated flag wins — the region
+     *     adds no information the map didn't already encode more precisely.
+     *  2. Script subtag, Chinese only (`zh-Hant` → tw, `zh-Hans` → cn).
+     *  3. The base-language default from the shared map (`pt` → pt). Unknown
+     *     or private-use regions (`pt-XA`) land here instead of producing a
+     *     broken flag.
+     *  4. The language *name* (covers cache entries and display names).
+     *
+     * @param {{name?: string, code?: string}|string} lang - A language entry
+     *   ({name, code}) or a bare code string.
+     * @returns {string|null} A flag-icons code, or null when unknown.
+     */
+    function resolveFlag(lang) {
+        const code = typeof lang === 'string' ? lang : (lang && (lang.code || lang.Code)) || '';
+        const name = (typeof lang === 'object' && lang && (lang.name || lang.Name)) || '';
+
+        const parsed = parseLanguageTag(code);
+        if (parsed) {
+            const baseFlag = baseLanguageFlags[parsed.base] || null;
+            // A region only refines a language we know (pt-BR). For an
+            // unmapped base ('und-419', 'eo-FR') the region alone proves
+            // nothing about the audio language — stay flagless, exactly as
+            // the pre-region behavior did.
+            if (parsed.region && baseFlag) {
+                let region = parsed.region;
+                const overrides = regionOverridesByBase[parsed.base];
+                if (overrides && overrides[region]) {
+                    region = overrides[region];
+                } else if (regionAliases[region]) {
+                    region = regionAliases[region];
+                } else if (/^\d{3}$/.test(region)) {
+                    // A numeric region with no per-language convention names
+                    // an area, not a country — no flag; use the base's.
+                    region = null;
+                }
+                if (region && validRegions.has(region)) {
+                    // Curated-subdivision guard: es-ct/es-ga/es-pv are more
+                    // specific than the es the region would give.
+                    if (baseFlag && (baseFlag === region || baseFlag.indexOf(region + '-') === 0)) {
+                        return baseFlag;
+                    }
+                    return region;
+                }
+            }
+            const scripts = scriptFlagsByBase[parsed.base];
+            if (parsed.script && scripts && scripts[parsed.script]) return scripts[parsed.script];
+            if (baseFlag) return baseFlag;
+        }
+        // Name lookup last: catches English display names ("Portuguese") and
+        // legacy cache entries whose code was already stripped.
+        return baseLanguageFlags[name] || baseLanguageFlags[code] || null;
+    }
+
+    JE.core.mediaLanguage = {
+        parseLanguageTag,
+        resolveFlag,
+        baseLanguageFlags
+    };
+
+    console.log('🪼 Jellyfin Enhanced: Media language core initialized');
+
+})(window.JellyfinEnhanced);

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/core/tag-renderer-base.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/core/tag-renderer-base.js
@@ -252,13 +252,18 @@
             if (!spec.cache || !state.localStorageEnabled) return;
             const CACHE_KEY = spec.cache.key;
             const TIMESTAMP_KEY = `${CACHE_KEY}Timestamp`;
-            const legacy = spec.cache.legacyPrefix;
+            // A renderer can accumulate several generations of dead keys
+            // (un-namespaced, then namespaced-v1, …), so accept one stem or a
+            // list of them — replacing the stem would orphan the older one.
+            const legacyStems = Array.isArray(spec.cache.legacyPrefix)
+                ? spec.cache.legacyPrefix
+                : [spec.cache.legacyPrefix];
 
             const stale = [];
             for (let i = 0; i < localStorage.length; i++) {
                 const key = localStorage.key(i);
                 if (key &&
-                    (key.startsWith(`${legacy}-`) || key === legacy || key === `${legacy}Timestamp`) &&
+                    legacyStems.some(legacy => key.startsWith(`${legacy}-`) || key === legacy || key === `${legacy}Timestamp`) &&
                     key !== CACHE_KEY && key !== TIMESTAMP_KEY) {
                     stale.push(key);
                 }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/itemdetails/features-details-media-info.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/itemdetails/features-details-media-info.js
@@ -324,19 +324,9 @@
         }
     }
 
-    /**
-     * A map of language names/codes to country codes for flag display.
-     */
-    const languageToCountryMap={English:"gb",eng:"gb",Japanese:"jp",jpn:"jp",Spanish:"es",spa:"es",French:"fr",fre:"fr",fra:"fr",German:"de",ger:"de",deu:"de",Italian:"it",ita:"it",Korean:"kr",kor:"kr",
-                                Chinese:"cn",chi:"cn",zho:"cn",Russian:"ru",rus:"ru",Portuguese:"pt",por:"pt",Hindi:"in",hin:"in",Dutch:"nl",dut:"nl",nld:"nl",Arabic:"sa",ara:"sa",Bengali:"in",ben:"in",
-                                Czech:"cz",ces:"cz",Danish:"dk",dan:"dk",Greek:"gr",ell:"gr",Finnish:"fi",fin:"fi",Hebrew:"il",heb:"il",Hungarian:"hu",hun:"hu",Indonesian:"id",ind:"id",Norwegian:"no",nor:"no",
-                                Polish:"pl",pol:"pl",Persian:"ir",per:"ir",fas:"ir",Romanian:"ro",ron:"ro",rum:"ro",Swedish:"se",swe:"se",Thai:"th",tha:"th",Turkish:"tr",tur:"tr",Ukrainian:"ua",ukr:"ua",
-                                Vietnamese:"vn",vie:"vn",Malay:"my",msa:"my",may:"my",Swahili:"ke",swa:"ke",Tagalog:"ph",tgl:"ph",Filipino:"ph",Tamil:"in",tam:"in",Telugu:"in",tel:"in",Marathi:"in",mar:"in",
-                                Punjabi:"in",pan:"in",Urdu:"pk",urd:"pk",Gujarati:"in",guj:"in",Kannada:"in",kan:"in",Malayalam:"in",mal:"in",Sinhala:"lk",sin:"lk",Nepali:"np",nep:"np",Pashto:"af",pus:"af",
-                                Kurdish:"iq",kur:"iq",Slovak:"sk",slk:"sk",Slovenian:"si",slv:"si",Serbian:"rs",srp:"rs",Croatian:"hr",hrv:"hr",Bulgarian:"bg",bul:"bg",Macedonian:"mk",mkd:"mk",Albanian:"al",
-                                sqi:"al",Estonian:"ee",est:"ee",Latvian:"lv",lav:"lv",Lithuanian:"lt",lit:"lt",Icelandic:"is",isl:"is",Georgian:"ge",kat:"ge",Armenian:"am",hye:"am",Mongolian:"mn",mon:"mn",
-                                Kazakh:"kz",kaz:"kz",Uzbek:"uz",uzb:"uz",Azerbaijani:"az",aze:"az",Belarusian:"by",bel:"by",Amharic:"et",amh:"et",Zulu:"za",zul:"za",Afrikaans:"za",afr:"za",Hausa:"ng",hau:"ng",
-                                Yoruba:"ng",yor:"ng",Igbo:"ng",ibo:"ng",Brazilian:"br",bra:"br",Catalan:"es-ct",cat:"es-ct",ca:"es-ct",Galician:"es-ga",glg:"es-ga",gl:"es-ga",Basque:"es-pv",eus:"es-pv",baq:"es-pv",eu:"es-pv"};
+    // Flag resolution is shared with the Language Tags overlay via
+    // js/core/media-language.js — one map, one region-aware resolver
+    // (pt-BR → Brazilian flag, es-419 → Mexican, bare pt/es stay default).
 
     /**
      * Fetches the first episode of a series or season for language detection.
@@ -481,7 +471,7 @@
                 langSpan.dataset.langName = lang.name;
                 langSpan.style.whiteSpace = 'nowrap';
 
-                const countryCode = languageToCountryMap[lang.name] || languageToCountryMap[lang.code];
+                const countryCode = JE.core.mediaLanguage.resolveFlag(lang);
                 if (countryCode) {
                     const flag = document.createElement('img');
                     flag.src = JE.cdn.flagSvg(countryCode);
@@ -489,6 +479,9 @@
                     flag.style.width = '18px';
                     flag.style.marginRight = '0.3em';
                     flag.style.borderRadius = '2px';
+                    // An unknown region subtag would 404 on the flag CDN;
+                    // drop the broken image rather than showing it.
+                    flag.onerror = () => flag.remove();
                     langSpan.appendChild(flag);
                 }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -597,6 +597,7 @@
                 'core/lifecycle.js',
                 'core/dom-observer.js',
                 'core/ui-kit.js',
+                'core/media-language.js',
                 'core/api-client.js',
                 'core/tag-renderer-base.js',
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/languagetags.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/languagetags.js
@@ -10,30 +10,10 @@
     const containerClass = 'language-overlay-container';
     const flagClass = 'language-flag';
     const langDisplayNames = new Intl.DisplayNames(['en'], { type: 'language' });
-
-    // Language to country code mapping (shared with features.js)
-    const languageToCountryMap = {
-        English: 'gb', eng: 'gb', Japanese: 'jp', jpn: 'jp', Spanish: 'es', spa: 'es', French: 'fr', fre: 'fr', fra: 'fr',
-        German: 'de', ger: 'de', deu: 'de', Italian: 'it', ita: 'it', Korean: 'kr', kor: 'kr', Chinese: 'cn', chi: 'cn',
-        zho: 'cn', Russian: 'ru', rus: 'ru', Portuguese: 'pt', por: 'pt', Hindi: 'in', hin: 'in', Dutch: 'nl', dut: 'nl',
-        nld: 'nl', Arabic: 'sa', ara: 'sa', Bengali: 'in', ben: 'in', Czech: 'cz', ces: 'cz', Danish: 'dk',
-        dan: 'dk', Greek: 'gr', ell: 'gr', Finnish: 'fi', fin: 'fi', Hebrew: 'il', heb: 'il', Hungarian: 'hu',
-        hun: 'hu', Indonesian: 'id', ind: 'id', Norwegian: 'no', nor: 'no', Polish: 'pl', pol: 'pl', Persian: 'ir',
-        per: 'ir', fas: 'ir', Romanian: 'ro', ron: 'ro', rum: 'ro', Swedish: 'se', swe: 'se', Thai: 'th', tha: 'th',
-        Turkish: 'tr', tur: 'tr', Ukrainian: 'ua', ukr: 'ua', Vietnamese: 'vn', vie: 'vn', Malay: 'my', msa: 'my',
-        may: 'my', Swahili: 'ke', swa: 'ke', Tagalog: 'ph', tgl: 'ph', Filipino: 'ph', Tamil: 'in', tam: 'in',
-        Telugu: 'in', tel: 'in', Marathi: 'in', mar: 'in', Punjabi: 'in', pan: 'in', Urdu: 'pk', urd: 'pk',
-        Gujarati: 'in', guj: 'in', Kannada: 'in', kan: 'in', Malayalam: 'in', mal: 'in', Sinhala: 'lk', sin: 'lk',
-        Nepali: 'np', nep: 'np', Pashto: 'af', pus: 'af', Kurdish: 'iq', kur: 'iq', Slovak: 'sk', slk: 'sk',
-        Slovenian: 'si', slv: 'si', Serbian: 'rs', srp: 'rs', Croatian: 'hr', hrv: 'hr', Bulgarian: 'bg', bul: 'bg',
-        Macedonian: 'mk', mkd: 'mk', Albanian: 'al', sqi: 'al', Estonian: 'ee', est: 'ee', Latvian: 'lv', lav: 'lv',
-        Lithuanian: 'lt', lit: 'lt', Icelandic: 'is', isl: 'is', Georgian: 'ge', kat: 'ge', Armenian: 'am',
-        hye: 'am', Mongolian: 'mn', mon: 'mn', Kazakh: 'kz', kaz: 'kz', Uzbek: 'uz', uzb: 'uz', Azerbaijani: 'az',
-        aze: 'az', Belarusian: 'by', bel: 'by', Amharic: 'et', amh: 'et', Zulu: 'za', zul: 'za', Afrikaans: 'za',
-        afr: 'za', Hausa: 'ng', hau: 'ng', Yoruba: 'ng', yor: 'ng', Igbo: 'ng', ibo: 'ng', Brazilian: 'br', bra: 'br',
-        Catalan: 'es-ct', cat: 'es-ct', ca: 'es-ct', Galician: 'es-ga', glg: 'es-ga', gl: 'es-ga', Basque: 'es-pv',
-        baq: 'es-pv', eus: 'es-pv'
-    };
+    // Flag resolution lives in the shared core module (js/core/media-language.js)
+    // so this overlay and the details-page audio-language row can never disagree.
+    // It understands region subtags: pt-BR → Brazilian flag, es-419 → Mexican,
+    // zh-Hant → Taiwanese — while a bare pt/es/zh keeps its default flag.
 
     /**
      * Extracts audio languages from a Jellyfin item's media sources.
@@ -82,14 +62,17 @@
             let obj = null;
             if (!entry) continue;
             if (typeof entry === 'string') {
-                // Handle legacy cache that stored ["en", "fr", ...]
-                const code = entry.split('-')[0].toLowerCase();
+                // Handle legacy cache that stored ["en", "fr", ...]. Keep the
+                // full tag — a region subtag (pt-BR) is meaningful and must
+                // survive normalization so the region flag can render.
+                const code = entry.toLowerCase();
                 let name = null;
                 try { name = new Intl.DisplayNames(['en'], { type: 'language' }).of(code) || code.toUpperCase(); }
                 catch { name = code.toUpperCase(); }
                 obj = { name, code };
             } else if (typeof entry === 'object') {
-                const code = (entry.code || entry.Code || '').toString().split('-')[0];
+                // Same here: never strip the region from the code.
+                const code = (entry.code || entry.Code || '').toString();
                 const name = entry.name || entry.Name || null;
                 if (code) {
                     let resolvedName = name;
@@ -134,11 +117,13 @@
         const seenCountries = new Set();
         const uniqueFlags = [];
 
-        // Deduplicate by country code while preserving language info for tooltips
+        // Deduplicate by flag while preserving language info for tooltips.
+        // Regional variants resolve to distinct flags (pt vs pt-BR), so a
+        // movie carrying both tracks correctly shows both.
         normalized.forEach(lang => {
-            const codeKey = (lang.code || '').toString().split('-')[0];
+            const codeKey = (lang.code || '').toString();
             const nameKey = (lang.name || '').toString();
-            const countryCode = languageToCountryMap[nameKey] || languageToCountryMap[codeKey];
+            const countryCode = JE.core.mediaLanguage.resolveFlag(lang);
             if (countryCode && !seenCountries.has(countryCode)) {
                 seenCountries.add(countryCode);
                 uniqueFlags.push({ countryCode, name: nameKey || codeKey.toUpperCase(), allLanguages: [nameKey || codeKey.toUpperCase()] });
@@ -160,6 +145,9 @@
             img.loading = 'lazy';
             img.dataset.lang = flagInfo.countryCode.toLowerCase();
             img.dataset.langName = flagInfo.allLanguages.join(', ');
+            // A region subtag from the wild can name a country the flag set
+            // lacks; drop the broken image rather than showing it.
+            img.onerror = () => img.remove();
             wrap.appendChild(img);
         });
         ctx.commitOverlay(container, wrap);
@@ -173,8 +161,13 @@
         taggedAttr: 'jeLanguageTagged',
         styleId: 'language-tags-styles',
         cache: {
-            key: 'JellyfinEnhanced-languageTagsCache',
-            legacyPrefix: 'languageTagsCache',
+            // v2: entries now keep region subtags (pt-BR) instead of stripped
+            // base codes; the old key is cleaned up via legacyPrefix so stale
+            // stripped entries can't pin the wrong flag for the 30-day TTL.
+            // Both prior generations are listed — dropping the ancient
+            // un-namespaced stem would leave its keys orphaned forever.
+            key: 'JellyfinEnhanced-languageTagsCache-v2',
+            legacyPrefix: ['JellyfinEnhanced-languageTagsCache', 'languageTagsCache'],
             hotBucket: 'language',
         },
         buildCss() {

--- a/docs/advanced/project-structure.md
+++ b/docs/advanced/project-structure.md
@@ -52,6 +52,7 @@ Jellyfin.Plugin.JellyfinEnhanced/
     │   ├── api-client.js
     │   ├── dom-observer.js
     │   ├── lifecycle.js
+    │   ├── media-language.js
     │   ├── navigation.js
     │   ├── tag-renderer-base.js
     │   └── ui-kit.js
@@ -193,6 +194,7 @@ Directory names avoid hyphens (`settingspanel`, not `settings-panel`). Embedded-
     * **`api-client.js`**: The single HTTP layer — `JE.core.api.{fetch,jf,plugin}` with auth headers, retry/backoff, response caching, request deduplication, concurrency limiting and `AbortController` support.
     * **`dom-observer.js`**: Multiplexed `MutationObserver` management — one shared body observer with named subscribers, plus dedicated observers and `waitForElement`.
     * **`lifecycle.js`**: Per-feature registration of observers, timers and listeners so they can be torn down together on navigation.
+    * **`media-language.js`**: Shared audio-language → flag resolution (`JE.core.mediaLanguage.resolveFlag`) used by the Language Tags overlay and the details-page audio-language row. Region-aware: an explicit region subtag (`pt-BR`, `es-419`, `zh-Hant`) resolves to that region's flag; bare base languages keep their default flag.
     * **`navigation.js`**: One deduped SPA navigation dispatcher (`onNavigate`, `onViewPage`), replacing the ad-hoc `hashchange`/`viewshow` listeners that previously double-fired on hash navigation and missed `pushState` navigation.
     * **`tag-renderer-base.js`**: The shared poster-tag engine — overlay creation, positioning, tagged-card deduplication, caching and reinitialisation. The four poster-overlay renderers (genre, language, quality, rating) supply a spec; `peopletags.js` and `userreviewtags.js` do not use it.
     * **`ui-kit.js`**: `escapeHtml`, `toast`, deduped CSS injection, and scroll-friendly tap detection (`addTouchTapListener`).

--- a/docs/enhanced/enhanced-features.md
+++ b/docs/enhanced/enhanced-features.md
@@ -476,6 +476,17 @@ Display available audio languages as country flags on posters.
 - Show up to 3 unique languages
 - Positioned bottom-left by default
 - Also displays on item detail pages
+- Regional variants get their own flag when the audio track is explicitly
+  tagged with a region: `pt-BR` shows the Brazilian flag while `pt` / `pt-PT`
+  keep the Portuguese one, `es-419` / `es-MX` (Latin-American Spanish) show
+  the Mexican flag, `zh-Hant` maps to the Taiwanese flag, and so on. Media
+  tagged with just a base language (`pt`, `es`, `zh`) keeps its default flag —
+  a regional variant is never guessed
+
+!!! note "Tagging matters"
+    Region detection relies on the language tag stored in your media file
+    (`pt-BR`, `es-MX`, `pob`…). Tracks tagged with only a base language code
+    can't be told apart, so they show the language's default flag.
 
 ### Rating Tags
 


### PR DESCRIPTION
## Description

Language flags now respect explicit region variants. An audio track tagged `pt-BR` gets the Brazilian flag while `pt` / `pt-PT` keep the Portuguese one; `es-419` / `es-MX` / `es-LA` (Latin-American Spanish) get the Mexican flag while `es` stays Spain; `zh-Hant` maps to the Taiwanese flag; the de-facto Brazilian Portuguese codes `pob`/`pb` are understood. A bare base language is never guessed into a regional variant.

Closes #544

## Screenshots

Test movie with three audio tracks: `pt-BR`, `es-419`, `por` (Jellyfin 10.11.11, default theme).

| | Before | After |
|---|---|---|
| **Poster overlay** | ![before: single Portuguese flag](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/issue-544-screenshots/before-card.png) | ![after: Brazilian, Mexican and Portuguese flags](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/issue-544-screenshots/after-card.png) |

**Details page, before** — the regioned tracks get no flag at all, only bare `por` does:

![before: details row with flags missing](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/issue-544-screenshots/before-details.png)

**Details page, after** — every track gets its regional flag:

![after: details row with Brazilian, Mexican and Portuguese flags](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/issue-544-screenshots/after-details.png)

## What was wrong

- The Language Tags overlay stripped the region subtag during normalization (`code.split('-')[0]`) in two places, so every regional variant collapsed to the base language's flag.
- The details-page audio row kept the full code but then looked it up in a map that has no regioned entries — and its display name ("Brazilian Portuguese") matched nothing either — so regioned tracks got **no flag at all** there.
- The two features each carried their own copy of the language→country map, already drifting.

## The fix

- New shared module `js/core/media-language.js`: one map + one region-aware resolver used by both features. Resolution order: explicit valid region (alias-normalized: `en-UK`→gb, `es-LA`→mx; validated against the ISO 3166-1 set so a private-use region like `pt-XA` falls back to the base flag instead of a broken image) → Chinese script subtag (`zh-Hant`→tw) → base-language default → display-name lookup.
- Guards that came out of review: the curated Catalan/Galician/Basque subdivision flags win over the generic Spain flag for `ca-ES`/`gl-ES`/`eu-ES`; BCP-47 extension sections are never misread as regions (`en-u-ca-gregory` stays gb); script mapping is Chinese-only (`ja-Hans` stays jp); numeric regions are per-language conventions, not global (`en-419` stays gb); a region on an unmapped base (`und-419`) stays flagless.
- Overlay dedupe is now per flag, so a movie carrying both `pt-PT` and `pt-BR` tracks shows both flags (previously impossible).
- The overlay's localStorage cache key is bumped (`-v2`) so entries cached with stripped codes can't pin the wrong flag for the 30-day TTL; the renderer base's legacy-key cleanup now accepts a list of stems so both prior key generations keep getting removed.
- The pt-BR mapping concern raised in the issue thread is covered: `pob`, `pb`, `pt-BR`, `pt_BR` and the "Brazilian" display name all resolve to the Brazilian flag.

Server-side extraction already preserved regions — the loss was purely client-side, so this is a JS-only change.

## Testing

- [x] Feature works as expected
- [x] No console errors
- [x] Compatible with Jellyfin 10.11.x — verified live on **10.11.11**
- [x] Doesn't break existing functionality — a `por`+`spa` control movie renders identically before/after
- [x] Chrome/Chromium and Firefox (Playwright, real UI injection)
- [x] Jellyfin 12 build compiles; the change is identical shared JS (not separately runtime-tested on 12)
- [x] 50-case resolver matrix (regions, aliases, scripts, extensions, junk, legacy cache shapes) passes
- [x] `mkdocs build --strict` and translation validation pass (no new strings)

Live verification: a movie with `pt-BR` + `es-419` + `por` audio renders Brazilian, Mexican and Portuguese flags on its poster overlay and its details-page audio row, with correct "Brazilian Portuguese" / "Latin American Spanish" tooltips from `Intl.DisplayNames`.

## Implementation Notes

**This PR was developed with AI assistance (Claude).** The changes went through two adversarial review rounds; every confirmed finding (including a regression the first draft introduced for `ca-ES`) was fixed and re-verified.

### Breaking changes

None. Media tagged with bare base languages renders exactly as before; the language-tags localStorage cache rebuilds once under the new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
