### PR TITLE
fix: re-scope all per-user state when switching users without a page reload

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -3361,6 +3361,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
 
         [HttpGet("user-settings/{userId}/settings.json")]
         [Authorize]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         public IActionResult GetUserSettingsSettings(string userId)
         {
             var authorizationResult = AuthorizeUserConfigAccess(userId, out var authorizedUserId);
@@ -3439,6 +3440,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
 
         [HttpGet("user-settings/{userId}/shortcuts.json")]
         [Authorize]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         public IActionResult GetUserSettingsShortcuts(string userId)
         {
             var authorizationResult = AuthorizeUserConfigAccess(userId, out var authorizedUserId);
@@ -3453,6 +3455,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
 
         [HttpGet("user-settings/{userId}/elsewhere.json")]
         [Authorize]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         public IActionResult GetUserSettingsElsewhere(string userId)
         {
             var authorizationResult = AuthorizeUserConfigAccess(userId, out var authorizedUserId);
@@ -3540,6 +3543,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
 
         [HttpGet("user-settings/{userId}/bookmark.json")]
         [Authorize]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         [Produces("application/json")]
         public IActionResult GetUserBookmark(string userId)
         {
@@ -3703,6 +3707,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
 
         [HttpGet("user-settings/{userId}/hidden-content.json")]
         [Authorize]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         [Produces("application/json")]
         public IActionResult GetUserHiddenContent(string userId)
         {
@@ -3819,6 +3824,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
         // administrator cannot inspect or repair remotely.
         [HttpGet("user-settings/{userId}/spoilerblur.json")]
         [Authorize]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         [Produces("application/json")]
         public IActionResult GetUserSpoilerBlur(string userId)
         {
@@ -5974,6 +5980,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
 
         [HttpGet("tag-cache/{userId}")]
         [Authorize]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         [Produces("application/json")]
         public IActionResult GetTagCache(Guid userId, [FromQuery] long? since = null)
         {

--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -1034,6 +1034,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
         }
 
         [HttpGet("jellyseerr/user-status")]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         [Authorize]
         public async Task<IActionResult> GetJellyseerrUserStatus()
         {
@@ -2718,6 +2719,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
         public ActionResult GetVersion() => Content(JellyfinEnhanced.Instance?.Version.ToString() ?? "unknown");
 
         [HttpGet("private-config")]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         [Authorize]
         public ActionResult GetPrivateConfig()
         {
@@ -4303,6 +4305,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
         }
 
         [HttpGet("spoiler-blur/series")]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         [Authorize]
         [Produces("application/json")]
         public IActionResult GetSpoilerBlurSeries()
@@ -8089,6 +8092,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
         }
 
         [HttpGet("arr/requests")]
+        [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         [Authorize]
         public async Task<IActionResult> GetRequests([FromQuery] int take = 20, [FromQuery] int skip = 0, [FromQuery] string? filter = null, [FromQuery] bool userOnly = false)
         {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/arr-links.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/arr-links.js
@@ -734,13 +734,30 @@
             }
 
             // Single delegated listener for closing all arr dropdowns on outside click.
-            document.addEventListener('click', function(e) {
-                if (!e.target.closest('.arr-dropdown')) {
-                    document.querySelectorAll('.arr-dropdown.open').forEach(d => d.classList.remove('open'));
-                }
-            });
+            // Guarded so a user-switch re-initialization doesn't stack duplicates.
+            if (!JE._arrDropdownCloserInstalled) {
+                JE._arrDropdownCloserInstalled = true;
+                document.addEventListener('click', function(e) {
+                    if (!e.target.closest('.arr-dropdown')) {
+                        document.querySelectorAll('.arr-dropdown.open').forEach(d => d.classList.remove('open'));
+                    }
+                });
+            }
+
+            // Identity epoch this initialization belongs to. The admin check
+            // above was resolved for THIS user — after a user switch the
+            // observer must retire itself instead of injecting admin-only
+            // links (with stale slugCache data) for the next user.
+            const initEpoch = JE.session ? JE.session.getEpoch() : 0;
 
             observer = JE.helpers.createObserver('arr-links', () => {
+                if (JE.session && !JE.session.isCurrent(initEpoch)) {
+                    if (observer) {
+                        observer.disconnect();
+                        console.log(`${logPrefix} Observer disconnected — user changed`);
+                    }
+                    return;
+                }
                 if (!JE?.pluginConfig?.ArrLinksEnabled) {
                     if (observer) {
                         observer.disconnect();
@@ -774,4 +791,16 @@
             console.error(`${logPrefix} Failed to initialize`, err);
         }
     };
+
+    // Re-run the whole initialization for the incoming user after a switch:
+    // the admin gate, the observer and the slug caches all live in the init
+    // closure, so a fresh call rebuilds them for the new user (the previous
+    // observer retires itself via the epoch guard above). Runs off
+    // je:user-data-loaded so JE.currentUser/currentSettings are already the
+    // new user's when the admin check reads them.
+    document.addEventListener('je:user-data-loaded', () => {
+        if (!JE?.pluginConfig?.ArrLinksEnabled) return;
+        try { JE._arrLinksObserver?.disconnect(); } catch (_) { /* already gone */ }
+        JE.initializeArrLinksScript();
+    });
 })(window.JellyfinEnhanced);

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/arr-links.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/arr-links.js
@@ -10,6 +10,14 @@
             return;
         }
 
+        // Identity epoch this initialization belongs to. Captured BEFORE the
+        // async admin resolution below: if the user switches while those
+        // requests are in flight, this stale invocation must stop — otherwise
+        // it would write user A's admin flag through user B's identity and
+        // install an observer that no longer looks stale to the epoch guard.
+        const initEpoch = JE.session ? JE.session.getEpoch() : 0;
+        const initIsCurrent = () => !JE.session || JE.session.isCurrent(initEpoch);
+
         // Check admin status on every script initialization
         let isAdmin = false;
 
@@ -33,6 +41,11 @@
                 console.error(`${logPrefix} Could not get current user after retries.`);
                 return;
             }
+
+            // The awaits above may have spanned a user switch — this `user`
+            // object belongs to the previous identity. Bail; the
+            // je:user-data-loaded listener re-runs initialization fresh.
+            if (!initIsCurrent()) return;
 
             isAdmin = user?.Policy?.IsAdministrator === true;
 
@@ -744,12 +757,10 @@
                 });
             }
 
-            // Identity epoch this initialization belongs to. The admin check
-            // above was resolved for THIS user — after a user switch the
-            // observer must retire itself instead of injecting admin-only
-            // links (with stale slugCache data) for the next user.
-            const initEpoch = JE.session ? JE.session.getEpoch() : 0;
-
+            // The admin check above was resolved for THIS user (initEpoch) —
+            // after a user switch the observer must retire itself instead of
+            // injecting admin-only links (with stale slugCache data) for the
+            // next user.
             observer = JE.helpers.createObserver('arr-links', () => {
                 if (JE.session && !JE.session.isCurrent(initEpoch)) {
                     if (observer) {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/arr-links.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/arr-links.js
@@ -757,6 +757,11 @@
                 });
             }
 
+            // A stale invocation must never register the shared 'arr-links'
+            // observer: it would later self-disconnect and take the CURRENT
+            // user's subscription down with it (shared subscriber name).
+            if (!initIsCurrent()) return;
+
             // The admin check above was resolved for THIS user (initEpoch) —
             // after a user switch the observer must retire itself instead of
             // injecting admin-only links (with stale slugCache data) for the

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-data.js
@@ -21,14 +21,25 @@
 
   /**
    * Per-user storage key for the show-unmonitored toggle. The unscoped legacy
-   * key leaked the preference across SPA user switches; it is removed on
-   * first read so it can't shadow the scoped value.
+   * key leaked the preference across SPA user switches; its value is adopted
+   * into the current user's scoped key once (preserving the pre-upgrade
+   * choice), then removed so it can't shadow the scoped value.
    * @returns {string}
    */
   function showUnmonitoredKey() {
-    try { window.localStorage?.removeItem(STORAGE_KEYS.showUnmonitored); } catch (_) { /* best effort */ }
-    const userId = (typeof ApiClient !== 'undefined' ? ApiClient.getCurrentUserId?.() : null) || 'anonymous';
-    return `${STORAGE_KEYS.showUnmonitored}:${userId}`;
+    const scoped = JE.session
+      ? JE.session.userScopedKey(STORAGE_KEYS.showUnmonitored)
+      : `${STORAGE_KEYS.showUnmonitored}:anonymous`;
+    try {
+      const legacy = window.localStorage?.getItem(STORAGE_KEYS.showUnmonitored);
+      if (legacy !== null && legacy !== undefined) {
+        if (window.localStorage?.getItem(scoped) === null) {
+          window.localStorage?.setItem(scoped, legacy);
+        }
+        window.localStorage?.removeItem(STORAGE_KEYS.showUnmonitored);
+      }
+    } catch (_) { /* best effort */ }
+    return scoped;
   }
 
   function getStoredShowUnmonitored() {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-data.js
@@ -19,9 +19,21 @@
     showUnmonitored: "je.calendar.showUnmonitored",
   };
 
+  /**
+   * Per-user storage key for the show-unmonitored toggle. The unscoped legacy
+   * key leaked the preference across SPA user switches; it is removed on
+   * first read so it can't shadow the scoped value.
+   * @returns {string}
+   */
+  function showUnmonitoredKey() {
+    try { window.localStorage?.removeItem(STORAGE_KEYS.showUnmonitored); } catch (_) { /* best effort */ }
+    const userId = (typeof ApiClient !== 'undefined' ? ApiClient.getCurrentUserId?.() : null) || 'anonymous';
+    return `${STORAGE_KEYS.showUnmonitored}:${userId}`;
+  }
+
   function getStoredShowUnmonitored() {
     try {
-      const stored = window.localStorage?.getItem(STORAGE_KEYS.showUnmonitored);
+      const stored = window.localStorage?.getItem(showUnmonitoredKey());
       if (stored === null) return null;
       return stored === "true";
     } catch (error) {
@@ -31,7 +43,7 @@
 
   function setStoredShowUnmonitored(value) {
     try {
-      window.localStorage?.setItem(STORAGE_KEYS.showUnmonitored, String(!!value));
+      window.localStorage?.setItem(showUnmonitoredKey(), String(!!value));
     } catch (error) {
     }
   }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-data.js
@@ -82,6 +82,16 @@
     _customTabContainer: null,
   };
 
+  // Watched state, favorites and requested-item highlighting are per-user —
+  // clear them on a user switch so the calendar re-derives everything for
+  // the new user on its next render.
+  JE.session?.onUserChange('calendar-page', () => {
+    state.userDataMap.clear();
+    state.requestedItems.clear();
+    state.requestedLoaded = false;
+    state.requestedLoading = false;
+  });
+
   // Status color mapping
   const STATUS_COLORS = {
     CinemaRelease: "#2196f3",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-data.js
@@ -263,8 +263,9 @@
         });
       });
     } catch (error) {
-      // Silently handle error - highlighting is optional
-      state.userDataMap = new Map();
+      // Silently handle error - highlighting is optional. Stale failures
+      // (from before a user switch) must not clear the new user's map.
+      if (!JE.session || JE.session.isCurrent(epoch)) state.userDataMap = new Map();
     }
   }
 
@@ -315,9 +316,9 @@
         if (state.pageVisible) {
           renderPage();
         }
-      } else {
-        state.requestedLoading = false;
       }
+      // Stale run: leave the state alone entirely — the reset already
+      // cleared the latch, and the current user's own fetch owns it now.
     }
   }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-data.js
@@ -220,6 +220,9 @@
    * Uses POST endpoint to only check specific calendar events, not entire library
    */
   async function fetchUserData() {
+    // Favorites/watched state is per-user — drop a response that resolves
+    // after a user switch instead of refilling the freshly reset map.
+    const epoch = JE.session ? JE.session.getEpoch() : 0;
     if (!state.settings.highlightFavorites && !state.settings.highlightWatchedSeries) {
       state.userDataMap = new Map();
       return;
@@ -249,6 +252,7 @@
         method: "POST",
         body: { events: eventsToCheck },
       });
+      if (JE.session && !JE.session.isCurrent(epoch)) return;
 
       // Build Map for O(1) lookup by event ID
       state.userDataMap = new Map();
@@ -273,6 +277,9 @@
     }
 
     state.requestedLoading = true;
+    // Same per-user guard: the finally below must not install the previous
+    // user's requested-set (or mark it loaded) after a switch.
+    const epoch = JE.session ? JE.session.getEpoch() : 0;
     const requested = new Set();
     const pageSize = 200;
     let page = 1;
@@ -301,11 +308,15 @@
     } catch (error) {
       console.warn(`${logPrefix} Failed to fetch user requests:`, error);
     } finally {
-      state.requestedItems = requested;
-      state.requestedLoaded = true;
-      state.requestedLoading = false;
-      if (state.pageVisible) {
-        renderPage();
+      if (!JE.session || JE.session.isCurrent(epoch)) {
+        state.requestedItems = requested;
+        state.requestedLoaded = true;
+        state.requestedLoading = false;
+        if (state.pageVisible) {
+          renderPage();
+        }
+      } else {
+        state.requestedLoading = false;
       }
     }
   }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-page-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-page-data.js
@@ -72,8 +72,10 @@
    * Fetch download queue from backend
    */
   async function fetchDownloads() {
+    const epoch = JE.session ? JE.session.getEpoch() : 0;
     try {
       const data = await JE.core.api.plugin("/arr/queue");
+      if (JE.session && !JE.session.isCurrent(epoch)) return null;
       state.downloads = data.items || [];
       // Surface per-instance queue errors so a 401 / timeout / SSRF-reject on one
       // instance doesn't silently produce a "looks empty" downloads page.
@@ -123,9 +125,19 @@
   }
 
   /**
+   * Epoch captured before a fetch: a response resolving after a user switch
+   * must not write the previous user's data (or a stale 403 latch) into the
+   * freshly reset state.
+   * @returns {number}
+   */
+  const captureEpoch = () => (JE.session ? JE.session.getEpoch() : 0);
+  const epochCurrent = (e) => !JE.session || JE.session.isCurrent(e);
+
+  /**
    * Fetch requests from backend
    */
   async function fetchRequests() {
+    const epoch = captureEpoch();
     try {
       const skip = (state.requestsPage - 1) * 20;
       const filter = state.requestsFilter !== "all" ? state.requestsFilter : "";
@@ -137,6 +149,7 @@
       });
 
       const data = await JE.core.api.plugin(`/arr/requests?${query.toString()}`);
+      if (!epochCurrent(epoch)) return null;
 
       state.requests = data.requests || [];
       state.requestsTotalPages = data.totalPages || 1;
@@ -145,7 +158,7 @@
       return data;
     } catch (error) {
       console.error(`${logPrefix} Failed to fetch requests:`, error);
-      state.requests = [];
+      if (epochCurrent(epoch)) state.requests = [];
       return null;
     }
   }
@@ -214,6 +227,7 @@
    * Fetch issues from Jellyseerr
    */
   async function fetchIssues() {
+    const epoch = captureEpoch();
     if (!JE.pluginConfig?.JellyseerrEnabled || !JE.pluginConfig?.DownloadsPageShowIssues) {
       state.issues = [];
       state.issuesTotalPages = 1;
@@ -252,12 +266,14 @@
         );
       }
 
+      if (!epochCurrent(epoch)) return null;
       state.issues = issues;
       state.issuesTotalPages = data?.pageInfo?.pages || data?.totalPages || 1;
       state.issuesError = false;
       return data;
     } catch (error) {
       console.error(`${logPrefix} Failed to fetch issues:`, error);
+      if (!epochCurrent(epoch)) return null; // stale failure (incl. 403) belongs to the previous user
       state.issues = [];
       state.issuesTotalPages = 1;
       state.issuesError = true;
@@ -282,6 +298,7 @@
       return null;
     }
 
+    const epoch = captureEpoch();
     try {
       const skip = (state.historyPage - 1) * 20;
 
@@ -291,6 +308,7 @@
       });
 
       const data = await JE.core.api.plugin(`/arr/history?${query.toString()}`);
+      if (!epochCurrent(epoch)) return null;
 
       state.history = data.items || [];
       state.historyVisible = data.visible !== false;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-page-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-page-data.js
@@ -59,6 +59,7 @@
     state.issuesPage = 1;
     state.issuesTotalPages = 1;
     state.issuesError = false;
+    state.issuesPermissionDenied = false; // sticky 403 gate belongs to the previous user
     state.history = [];
     state.historyPage = 1;
     state.historyTotalPages = 1;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-page-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-page-data.js
@@ -46,6 +46,25 @@
     _customTabContainer: null,
   };
 
+  // Requests/issues/history and the approve permission all belong to the
+  // signed-in Seerr-linked user — wipe them on a user switch so the page
+  // re-fetches as the new user instead of rendering the previous user's data.
+  JE.session?.onUserChange('requests-page', () => {
+    state.downloads = [];
+    state.requests = [];
+    state.requestsPage = 1;
+    state.requestsTotalPages = 1;
+    state.canApproveRequests = false;
+    state.issues = [];
+    state.issuesPage = 1;
+    state.issuesTotalPages = 1;
+    state.issuesError = false;
+    state.history = [];
+    state.historyPage = 1;
+    state.historyTotalPages = 1;
+    issueMediaCache.clear();
+  });
+
   const issueMediaCache = new Map();
 
   /**

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-page-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-page-data.js
@@ -83,7 +83,7 @@
       return data;
     } catch (error) {
       console.error(`${logPrefix} Failed to fetch downloads:`, error);
-      state.downloads = [];
+      if (!JE.session || JE.session.isCurrent(epoch)) state.downloads = [];
       return null;
     }
   }
@@ -208,6 +208,9 @@
       ? `/JellyfinEnhanced/jellyseerr/tv/${tmdbId}`
       : `/JellyfinEnhanced/jellyseerr/movie/${tmdbId}`;
 
+    // Seerr media details carry per-user request state — don't let a
+    // response spanning a user switch repopulate the reset cache.
+    const epoch = captureEpoch();
     try {
       const data = await ApiClient.ajax({
         type: "GET",
@@ -215,10 +218,10 @@
         dataType: "json",
         headers: { "X-Jellyfin-User-Id": ApiClient.getCurrentUserId() },
       });
-      issueMediaCache.set(cacheKey, data || null);
+      if (epochCurrent(epoch)) issueMediaCache.set(cacheKey, data || null);
       return data || null;
     } catch (error) {
-      issueMediaCache.set(cacheKey, null);
+      if (epochCurrent(epoch)) issueMediaCache.set(cacheKey, null);
       return null;
     }
   }
@@ -316,7 +319,7 @@
       return data;
     } catch (error) {
       console.error(`${logPrefix} Failed to fetch history:`, error);
-      state.history = [];
+      if (epochCurrent(epoch)) state.history = [];
       return null;
     }
   }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/core/api-client.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/core/api-client.js
@@ -585,6 +585,12 @@
                 init.signal = signal;
             }
 
+            // Identity epoch at request start: a response that finishes after
+            // a user switch must not repopulate the (already flushed) cache —
+            // cache keys carry no user id, so a late write would hand user
+            // A's response to user B.
+            const requestEpoch = JE.session ? JE.session.getEpoch() : 0;
+
             try {
                 const response = await fetchWithRetry(
                     url,
@@ -595,7 +601,7 @@
                 const text = await response.text();
                 const data = text ? JSON.parse(text) : {};
 
-                if (isGet && cacheKey) {
+                if (isGet && cacheKey && (!JE.session || JE.session.isCurrent(requestEpoch))) {
                     setCache(cacheKey, data);
                 }
                 return data;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/core/api-client.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/core/api-client.js
@@ -353,6 +353,14 @@
         }
     }
 
+    // Cache keys never include a user id, but proxied responses (Seerr, tag
+    // data) ARE per-user server-side — flush everything when the signed-in
+    // user changes so user B never reads user A's cached responses.
+    JE.session?.onUserChange('core-api', () => {
+        responseCache.clear();
+        inFlightRequests.clear();
+    });
+
     // Metrics API
 
     /**

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/core/api-client.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/core/api-client.js
@@ -220,7 +220,12 @@
 
         const promise = fetchFn()
             .finally(() => {
-                inFlightRequests.delete(key);
+                // Only remove OUR entry: after a user-switch flush a new
+                // request may already occupy this key — deleting it would let
+                // a third caller start a duplicate fetch.
+                if (inFlightRequests.get(key) === promise) {
+                    inFlightRequests.delete(key);
+                }
             });
 
         inFlightRequests.set(key, promise);

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/core/session.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/core/session.js
@@ -17,9 +17,7 @@
 //      credentials change, even when no navigation happens.
 //   2. The shared je:navigate pipeline (login/logout always navigates), which
 //      also covers hosts where the wrapper could not be installed.
-//   3. A 'storage' listener on 'jellyfin_credentials' for sign-ins that
-//      happen in another tab of the same browser profile.
-//   4. A slow reconcile interval that re-installs the wrapper if the host
+//   3. A slow reconcile interval that re-installs the wrapper if the host
 //      ever replaces window.ApiClient wholesale (multi-server switching).
 //
 // Transitions are numbered with a monotonically increasing "epoch". Async

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/core/session.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/core/session.js
@@ -178,11 +178,16 @@
             if (original.__jeSessionWrapped) return true;
 
             const wrapped = function(/** @type {any} */ accessKey, /** @type {any} */ userId) {
+                // The wrapper lives on the shared prototype, so it also fires
+                // for secondary ApiClient instances (multi-server hosts keep
+                // one per server). Only the ACTIVE client's credentials define
+                // the plugin's identity — ignore the rest.
+                const isActiveClient = typeof ApiClient === 'undefined' || !ApiClient || this === ApiClient;
                 // Clear the old user's state before the host installs the new
                 // credentials; serverId is unchanged by this call.
                 try {
                     const nextUserId = userId || null;
-                    if (adopted && nextUserId !== currentUserId) {
+                    if (isActiveClient && adopted && nextUserId !== currentUserId) {
                         transition(nextUserId, currentServerId, 'authentication');
                     }
                 } catch (err) {
@@ -191,7 +196,9 @@
                 const result = original.apply(this, arguments);
                 // Post-check picks up anything the pre-check couldn't know
                 // (first adoption, serverId changes surfaced by the client).
-                try { checkNow('authentication'); } catch (_) { /* logged in transition */ }
+                if (isActiveClient) {
+                    try { checkNow('authentication'); } catch (_) { /* logged in transition */ }
+                }
                 return result;
             };
             wrapped.__jeSessionWrapped = true;
@@ -209,6 +216,13 @@
         }
     }
 
+    /**
+     * Install all identity detectors: adopt the currently signed-in user,
+     * hook setAuthenticationInfo, follow the shared navigation pipeline, and
+     * start the slow reconcile timer. Runs once at module load.
+     * Side effects: wraps a host ApiClient method and registers a persistent
+     * navigation callback and interval.
+     */
     function initialize() {
         // Adopt whoever is signed in right now (component scripts only load
         // after login, so this normally lands the first epoch immediately).
@@ -218,11 +232,6 @@
         // Every login/logout navigates, so this alone would eventually catch
         // all transitions even if the auth hook failed to install.
         JE.core.navigation.onNavigate(() => checkNow('navigate'));
-
-        // Credentials changed by ANOTHER tab of the same browser profile.
-        window.addEventListener('storage', (e) => {
-            if (e.key === 'jellyfin_credentials') checkNow('storage');
-        });
 
         // Slow reconcile: catches window.ApiClient being replaced wholesale
         // (multi-server switching creates a fresh client our wrapper isn't
@@ -247,6 +256,20 @@
          * @param {number} capturedEpoch
          */
         isCurrent: (capturedEpoch) => capturedEpoch === epoch,
+        /**
+         * Build a per-user localStorage key: `${base}:${userId}`. Shared by
+         * every module that scopes a preference per user so the format stays
+         * consistent. Falls back to 'anonymous' on the login screen so reads
+         * and writes stay well-formed.
+         * @param {string} base - The unscoped key name.
+         * @returns {string}
+         */
+        userScopedKey: (base) => {
+            const userId = currentUserId
+                || (typeof ApiClient !== 'undefined' ? ApiClient.getCurrentUserId?.() : null)
+                || 'anonymous';
+            return `${base}:${userId}`;
+        },
         onUserChange,
         checkNow
     };

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/core/session.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/core/session.js
@@ -1,0 +1,258 @@
+// @ts-check
+// /js/core/session.js
+//
+// Single owner of the "who is signed in" question for the whole plugin.
+//
+// Jellyfin's web client is an SPA: logging out and logging back in as a
+// DIFFERENT user is just a route change — index.html is NOT reloaded, so
+// every module-level snapshot taken at boot (JE.userConfig, JE.currentUser,
+// JE.currentSettings, per-feature in-memory caches) silently keeps the
+// previous user's data until a hard refresh. This module detects identity
+// transitions and fans them out so every per-user cache can reset itself.
+//
+// Detection is belt-and-braces, because no single signal is reliable across
+// Jellyfin 10.11 and 12:
+//   1. A wrapper around ApiClient.setAuthenticationInfo — the one call every
+//      login/logout path goes through — so the reset runs the moment
+//      credentials change, even when no navigation happens.
+//   2. The shared je:navigate pipeline (login/logout always navigates), which
+//      also covers hosts where the wrapper could not be installed.
+//   3. A 'storage' listener on 'jellyfin_credentials' for sign-ins that
+//      happen in another tab of the same browser profile.
+//   4. A slow reconcile interval that re-installs the wrapper if the host
+//      ever replaces window.ApiClient wholesale (multi-server switching).
+//
+// Transitions are numbered with a monotonically increasing "epoch". Async
+// work that loads per-user data must capture the epoch before awaiting and
+// drop its result if the epoch moved on — that closes the race where user A's
+// slow fetch resolves after user B has already signed in.
+//
+// Public surface: JE.session { getUserId, getServerId, getEpoch,
+// onUserChange(name, fn), isCurrent(epoch), checkNow(reason) }.
+// Transition order: reset handlers run synchronously (registration order),
+// then a 'je:user-changed' CustomEvent is dispatched on document.
+(function(JE) {
+    'use strict';
+
+    JE.core = JE.core || {};
+
+    const logPrefix = '🪼 Jellyfin Enhanced: Session:';
+
+    // Monotonic identity generation. 0 = pre-adoption (never seen a user).
+    let epoch = 0;
+    /** @type {string|null} */
+    let currentUserId = null;
+    /** @type {string|null} */
+    let currentServerId = null;
+    // First read adopts silently (boot is already loading this user's data);
+    // only LATER changes are real transitions that must reset state.
+    let adopted = false;
+
+    /** @type {Map<string, Function>} Reset handlers, keyed by feature name (insertion order preserved). */
+    const resetHandlers = new Map();
+
+    /**
+     * Read the signed-in identity from the host ApiClient. Never throws.
+     * ApiClient.serverId is a function on 10.11/12 apiclients but has been a
+     * bare property on older builds, so both shapes are probed.
+     * @returns {{userId: string|null, serverId: string|null}}
+     */
+    function readIdentity() {
+        try {
+            if (typeof ApiClient === 'undefined' || !ApiClient) return { userId: null, serverId: null };
+            const userId = (typeof ApiClient.getCurrentUserId === 'function' ? ApiClient.getCurrentUserId() : null) || null;
+            let serverId = null;
+            try {
+                serverId = (typeof ApiClient.serverId === 'function' ? ApiClient.serverId() : ApiClient.serverId)
+                    || ApiClient._serverInfo?.Id
+                    || null;
+            } catch (_) { serverId = null; }
+            return { userId, serverId };
+        } catch (_) {
+            return { userId: null, serverId: null };
+        }
+    }
+
+    /**
+     * Register a reset handler that runs synchronously on every identity
+     * transition (user switch, logout, server switch). Handlers must only
+     * CLEAR state — reloading data for the new user belongs in a
+     * 'je:user-changed' / 'je:user-data-loaded' listener, because at reset
+     * time the new credentials may not be installed yet.
+     * Registering again under the same name replaces the previous handler
+     * (safe for modules that re-run).
+     * @param {string} name - Feature identifier, used for error logging.
+     * @param {(change: {userId: string|null, serverId: string|null, epoch: number, previousUserId: string|null, reason: string}) => void} fn
+     * @returns {Function} Unregister function.
+     */
+    function onUserChange(name, fn) {
+        resetHandlers.set(name, fn);
+        return () => { resetHandlers.delete(name); };
+    }
+
+    /**
+     * Run an identity transition: bump the epoch, run every reset handler,
+     * then announce the change. Synchronous so no stale-data window exists
+     * between the credential swap and the cache clears.
+     * @param {string|null} userId
+     * @param {string|null} serverId
+     * @param {string} reason - Which detector fired (for logging).
+     * @returns {boolean} True if a transition actually happened.
+     */
+    function transition(userId, serverId, reason) {
+        if (userId === currentUserId && serverId === currentServerId) return false;
+
+        // First sighting of a user: adopt without resetting. Boot (plugin.js)
+        // is fetching this same user's data right now — a reset here would
+        // wipe state that was never another user's.
+        if (!adopted && currentUserId === null && userId !== null) {
+            adopted = true;
+            epoch++;
+            currentUserId = userId;
+            currentServerId = serverId;
+            return false;
+        }
+
+        const previousUserId = currentUserId;
+        epoch++;
+        const myEpoch = epoch;
+        currentUserId = userId;
+        currentServerId = serverId;
+        console.log(`${logPrefix} identity transition (${reason}): ${previousUserId || 'none'} → ${userId || 'none'} (epoch ${myEpoch})`);
+
+        const change = { userId, serverId, epoch: myEpoch, previousUserId, reason };
+        for (const [name, fn] of resetHandlers) {
+            // A reset handler may itself trigger a nested transition (it
+            // shouldn't, but never loop on it) — stop applying a stale change.
+            if (epoch !== myEpoch) break;
+            try {
+                fn(change);
+            } catch (err) {
+                console.error(`${logPrefix} reset handler "${name}" failed:`, err);
+            }
+        }
+
+        if (epoch === myEpoch) {
+            try {
+                document.dispatchEvent(new CustomEvent('je:user-changed', { detail: change }));
+            } catch (err) {
+                console.error(`${logPrefix} je:user-changed dispatch failed:`, err);
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Compare the live ApiClient identity against the last known one and
+     * transition if they differ. Cheap (two property reads) — safe to call
+     * from every navigation.
+     * @param {string} reason
+     */
+    function checkNow(reason) {
+        const { userId, serverId } = readIdentity();
+        transition(userId, serverId, reason);
+    }
+
+    /**
+     * Wrap ApiClient.setAuthenticationInfo so the identity transition runs
+     * the moment credentials change. The wrapper transitions BEFORE calling
+     * through for a *different* user (previous user's caches are cleared
+     * before the new token exists — no window where B's token can read A's
+     * snapshot) and re-checks after, covering logout (null user).
+     * Walks the prototype chain: the method usually lives on
+     * ApiClient's prototype, not the instance.
+     * @param {object} client - The ApiClient instance to hook.
+     * @returns {boolean} True when the hook is (already) installed.
+     */
+    function installAuthHook(client) {
+        try {
+            if (!client) return false;
+            /** @type {object|null} */
+            let owner = client;
+            while (owner && !Object.prototype.hasOwnProperty.call(owner, 'setAuthenticationInfo')) {
+                owner = Object.getPrototypeOf(owner);
+            }
+            if (!owner) return false;
+            const original = owner.setAuthenticationInfo;
+            if (typeof original !== 'function') return false;
+            if (original.__jeSessionWrapped) return true;
+
+            const wrapped = function(/** @type {any} */ accessKey, /** @type {any} */ userId) {
+                // Clear the old user's state before the host installs the new
+                // credentials; serverId is unchanged by this call.
+                try {
+                    const nextUserId = userId || null;
+                    if (adopted && nextUserId !== currentUserId) {
+                        transition(nextUserId, currentServerId, 'authentication');
+                    }
+                } catch (err) {
+                    console.error(`${logPrefix} pre-auth transition failed:`, err);
+                }
+                const result = original.apply(this, arguments);
+                // Post-check picks up anything the pre-check couldn't know
+                // (first adoption, serverId changes surfaced by the client).
+                try { checkNow('authentication'); } catch (_) { /* logged in transition */ }
+                return result;
+            };
+            wrapped.__jeSessionWrapped = true;
+            try {
+                owner.setAuthenticationInfo = wrapped;
+            } catch (_) {
+                // Prototype property not writable — fall back to shadowing on
+                // the instance itself.
+                client.setAuthenticationInfo = wrapped;
+            }
+            return true;
+        } catch (err) {
+            console.warn(`${logPrefix} could not hook setAuthenticationInfo:`, err);
+            return false;
+        }
+    }
+
+    function initialize() {
+        // Adopt whoever is signed in right now (component scripts only load
+        // after login, so this normally lands the first epoch immediately).
+        checkNow('startup');
+        installAuthHook(typeof ApiClient !== 'undefined' ? ApiClient : null);
+
+        // Every login/logout navigates, so this alone would eventually catch
+        // all transitions even if the auth hook failed to install.
+        JE.core.navigation.onNavigate(() => checkNow('navigate'));
+
+        // Credentials changed by ANOTHER tab of the same browser profile.
+        window.addEventListener('storage', (e) => {
+            if (e.key === 'jellyfin_credentials') checkNow('storage');
+        });
+
+        // Slow reconcile: catches window.ApiClient being replaced wholesale
+        // (multi-server switching creates a fresh client our wrapper isn't
+        // on) and any path none of the event-driven detectors saw. Two
+        // property reads per tick — no observable cost.
+        setInterval(() => {
+            installAuthHook(typeof ApiClient !== 'undefined' ? ApiClient : null);
+            checkNow('reconcile');
+        }, 1000);
+    }
+
+    JE.session = {
+        /** @returns {string|null} The signed-in user id (null on the login screen). */
+        getUserId: () => currentUserId,
+        /** @returns {string|null} The current server id, when the client exposes one. */
+        getServerId: () => currentServerId,
+        /** @returns {number} The current identity epoch (bumps on every transition). */
+        getEpoch: () => epoch,
+        /**
+         * Whether a captured epoch is still the live one. Async loaders use
+         * this to drop results that finished after a user switch.
+         * @param {number} capturedEpoch
+         */
+        isCurrent: (capturedEpoch) => capturedEpoch === epoch,
+        onUserChange,
+        checkNow
+    };
+
+    initialize();
+
+    console.log(`${logPrefix} initialized`);
+
+})(window.JellyfinEnhanced);

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/core/tag-renderer-base.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/core/tag-renderer-base.js
@@ -210,12 +210,38 @@
 
         // ── localStorage cache ─────────────────────────────────────────
 
+        /**
+         * The persisted payload can contain per-user data (tag entries are
+         * spoiler-stripped for the user that fetched them), but the cache key
+         * NAME is frozen — renaming it to embed a user id would orphan every
+         * existing user's cache. Instead a sibling "<key>:identity-owner"
+         * sentinel records which server:user wrote the payload; on mismatch
+         * (or a legacy cache with no sentinel, which is untrusted) the payload
+         * is dropped before it can be served to the wrong user.
+         */
+        function enforceCacheOwnership() {
+            if (!spec.cache || !state.localStorageEnabled) return;
+            try {
+                const ownerKey = `${spec.cache.key}:identity-owner`;
+                const userId = JE.session?.getUserId()
+                    || (typeof ApiClient !== 'undefined' ? ApiClient.getCurrentUserId?.() : null) || '';
+                const expected = `${JE.session?.getServerId() || ''}:${userId}`;
+                if (localStorage.getItem(ownerKey) !== expected) {
+                    localStorage.removeItem(spec.cache.key);
+                    localStorage.setItem(ownerKey, expected);
+                }
+            } catch (e) {
+                console.warn(`${logPrefix} cache ownership check failed`, e);
+            }
+        }
+
         function loadCacheSettings() {
             state.localStorageEnabled =
                 JE.pluginConfig?.TagCacheServerMode === false ||
                 JE.pluginConfig?.EnableTagsLocalStorageFallback === true;
             state.cacheTtl = (JE.pluginConfig?.TagsCacheTtlDays || 30) * 24 * 60 * 60 * 1000;
             if (!spec.cache) return;
+            enforceCacheOwnership();
             state.cache = state.localStorageEnabled
                 ? (JSON.parse(localStorage.getItem(spec.cache.key) || '{}') || {})
                 : {};
@@ -339,6 +365,24 @@
                 return true;
             },
         };
+
+        // Wipe both the in-memory and the persisted cache on a user switch,
+        // and stamp the new owner so a later hard reload doesn't wipe the new
+        // user's freshly-built cache a second time.
+        JE.session?.onUserChange(`tag-cache-${name}`, (change) => {
+            state.cache = {};
+            if (state.hot) state.hot.clear();
+            if (!spec.cache) return;
+            try {
+                localStorage.removeItem(spec.cache.key);
+                localStorage.setItem(
+                    `${spec.cache.key}:identity-owner`,
+                    `${change.serverId || ''}:${change.userId || ''}`
+                );
+            } catch (e) {
+                console.warn(`${logPrefix} cache clear on user switch failed`, e);
+            }
+        });
 
         // ── Lifecycle ──────────────────────────────────────────────────
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/elsewhere.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/elsewhere/elsewhere.js
@@ -442,11 +442,16 @@
 
         // Load saved settings
         function loadSettings() {
-            const settings = JE.userConfig.elsewhere;
+            const settings = JE.userConfig.elsewhere || {};
             userRegion = settings.Region || DEFAULT_REGION;
             userRegions = settings.Regions || [];
             userServices = settings.Services || [];
         }
+
+        // This closure survives an SPA logout/login, so re-read the incoming
+        // user's saved regions/services once their config has been reloaded —
+        // otherwise user B keeps browsing with user A's Elsewhere preferences.
+        document.addEventListener('je:user-data-loaded', loadSettings);
 
         function createServiceBadge(service, tmdbId, mediaType) {
             const badge = document.createElement('div');

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/bookmarks/bookmarks-library-render.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/bookmarks/bookmarks-library-render.js
@@ -21,6 +21,22 @@
   let lastRenderTs = 0;
   let lastMountedContainer = null;
 
+  // The mounted-container guard suppresses re-renders while the same DOM
+  // node stays populated — which is exactly what happens across an SPA user
+  // switch (the Custom Tabs panel survives logout/login), leaving user A's
+  // rendered bookmarks visible to user B (upstream discussion about stale
+  // bookmarks after switching accounts). Drop the guard on the transition,
+  // then force a fresh render once the new user's bookmarks are loaded.
+  window.JellyfinEnhanced.session?.onUserChange('bookmarks-library-render', () => {
+    lastMountedContainer = null;
+    lastRenderTs = 0;
+  });
+  document.addEventListener('je:user-data-loaded', () => {
+    lastMountedContainer = null;
+    lastRenderTs = 0;
+    renderIfSectionExists();
+  });
+
   /**
    * Render when section exists or bookmarks updated
    */

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/helpers.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/helpers.js
@@ -96,6 +96,15 @@
         if (includeInFlight) avatarFetchPromises.clear();
     }
 
+    // Item lookups are keyed `${userId}:${itemId}` so they can't collide
+    // across users, but flush anyway on a switch (frees memory and drops
+    // entries fetched with a token that is about to be revoked). Avatars are
+    // the Seerr-linked user's own.
+    JE.session?.onUserChange('helpers', () => {
+        itemCache.clear();
+        clearAvatarObjectUrlCache(true);
+    });
+
     /**
      * Deduplicated item fetch with short TTL cache.
      * Prevents multiple modules from requesting the same item concurrently on detail page navigation.

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-data.js
@@ -471,6 +471,9 @@
     document.addEventListener('je:user-data-loaded', () => {
         resetFromUserConfig();
         emitChange();
+        // Re-apply the incoming user's policy to whatever is on screen (the
+        // filter reset stripped the previous user's hide marks and verdicts).
+        refreshNativeCardVisibility();
     });
 
     Object.assign(internal, {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-data.js
@@ -459,6 +459,20 @@
         rebuildSets();
     }
 
+    // Hidden-content data is per-user. Clear the local mirror the moment the
+    // identity changes (don't read JE.userConfig here — reset handlers run in
+    // registration order and the globals may not be wiped yet), then rebuild
+    // from the incoming user's config once the re-bootstrap has loaded it.
+    JE.session?.onUserChange('hidden-content-data', () => {
+        hiddenData = null;
+        hiddenIdSet.clear();
+        hiddenTmdbIdSet.clear();
+    });
+    document.addEventListener('je:user-data-loaded', () => {
+        resetFromUserConfig();
+        emitChange();
+    });
+
     Object.assign(internal, {
         hiddenIdSet,
         getHiddenData,

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-dialogs.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-dialogs.js
@@ -17,15 +17,18 @@
     const SUPPRESS_DURATION_MS = 15 * 60 * 1000;
     /**
      * LocalStorage key for the "don't ask again" suppression timestamp.
-     * Scoped per user — an unscoped key let user A's "don't ask again" carry
-     * over to user B after an SPA user switch. The legacy unscoped key is
-     * removed on first use.
+     * Scoped per user (via the shared JE.session.userScopedKey format) — an
+     * unscoped key let user A's "don't ask again" carry over to user B after
+     * an SPA user switch. The legacy unscoped key is removed on first use;
+     * its value is deliberately NOT adopted (a 15-minute convenience window
+     * is not worth carrying across an ownership change).
      * @returns {string}
      */
     function suppressStorageKey() {
         try { localStorage.removeItem('je_hide_confirm_suppressed_until'); } catch (_) { /* best effort */ }
-        const userId = (typeof ApiClient !== 'undefined' ? ApiClient.getCurrentUserId?.() : null) || 'anonymous';
-        return `je_hide_confirm_suppressed_until:${userId}`;
+        return JE.session
+            ? JE.session.userScopedKey('je_hide_confirm_suppressed_until')
+            : 'je_hide_confirm_suppressed_until:anonymous';
     }
 
     // ============================================================

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-dialogs.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-dialogs.js
@@ -15,8 +15,18 @@
     const UNDO_TOAST_DURATION = 8000;
     /** How long the "don't ask again" suppression lasts (15 minutes). */
     const SUPPRESS_DURATION_MS = 15 * 60 * 1000;
-    /** LocalStorage key for "don't ask again" suppression timestamp. */
-    const SUPPRESS_STORAGE_KEY = 'je_hide_confirm_suppressed_until';
+    /**
+     * LocalStorage key for the "don't ask again" suppression timestamp.
+     * Scoped per user — an unscoped key let user A's "don't ask again" carry
+     * over to user B after an SPA user switch. The legacy unscoped key is
+     * removed on first use.
+     * @returns {string}
+     */
+    function suppressStorageKey() {
+        try { localStorage.removeItem('je_hide_confirm_suppressed_until'); } catch (_) { /* best effort */ }
+        const userId = (typeof ApiClient !== 'undefined' ? ApiClient.getCurrentUserId?.() : null) || 'anonymous';
+        return `je_hide_confirm_suppressed_until:${userId}`;
+    }
 
     // ============================================================
     // Undo toast
@@ -88,7 +98,7 @@
     function isConfirmationSuppressed() {
         const settings = getSettings();
         if (settings.showHideConfirmation === false) return true;
-        const until = localStorage.getItem(SUPPRESS_STORAGE_KEY);
+        const until = localStorage.getItem(suppressStorageKey());
         if (until && new Date(until) > new Date()) return true;
         return false;
     }
@@ -264,7 +274,7 @@
         hideBtn.addEventListener('click', () => {
             if (suppress15Check.checked) {
                 const until = new Date(Date.now() + SUPPRESS_DURATION_MS).toISOString();
-                localStorage.setItem(SUPPRESS_STORAGE_KEY, until);
+                localStorage.setItem(suppressStorageKey(), until);
             }
             closeDialog();
             onConfirm();

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-filter.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-filter.js
@@ -21,10 +21,23 @@
     const parentSeriesRequestMap = new Map();
 
     // Item lookups were fetched as the previous user (library access and
-    // spoiler stripping differ per user) — drop them on a user switch.
+    // spoiler stripping differ per user) — drop them on a user switch, and
+    // un-hide + un-mark every card the previous user's policy touched so the
+    // new user's list is re-evaluated from scratch (the "checked" marker
+    // would otherwise keep the old verdict until a full re-render).
     window.JellyfinEnhanced.session?.onUserChange('hidden-content-filter', () => {
         parentSeriesCache.clear();
         parentSeriesRequestMap.clear();
+        try {
+            document.querySelectorAll('.je-hidden').forEach((el) => el.classList.remove('je-hidden'));
+            document.querySelectorAll(`[${PROCESSED_ATTR}]`).forEach((el) => {
+                el.removeAttribute(PROCESSED_ATTR);
+                el.removeAttribute(HIDDEN_PARENT_ATTR);
+                el.removeAttribute(HIDDEN_DIRECT_ATTR);
+            });
+        } catch (e) {
+            console.warn('🪼 Jellyfin Enhanced: hidden-content DOM reset on user switch failed', e);
+        }
     });
     const sectionSurfaceCache = new WeakMap();
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-filter.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-filter.js
@@ -19,6 +19,13 @@
 
     const parentSeriesCache = new Map();
     const parentSeriesRequestMap = new Map();
+
+    // Item lookups were fetched as the previous user (library access and
+    // spoiler stripping differ per user) — drop them on a user switch.
+    window.JellyfinEnhanced.session?.onUserChange('hidden-content-filter', () => {
+        parentSeriesCache.clear();
+        parentSeriesRequestMap.clear();
+    });
     const sectionSurfaceCache = new WeakMap();
 
     /** Delay for first detail-page rescan (async episode loading). */

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-page-state.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-page-state.js
@@ -43,6 +43,22 @@
     adminLoadToken: 0,           // increments per fetch so stale responses are ignored
   };
 
+  // The admin gate and the cross-user view are resolved for the signed-in
+  // user; after a user switch the new user must re-resolve (a non-admin must
+  // never inherit an admin's cached gate, and vice versa).
+  window.JellyfinEnhanced.session?.onUserChange('hidden-content-page', () => {
+    state.adminIsAdmin = null;
+    state.adminUsers = null;
+    state.adminUsersLoading = false;
+    state.selectedAdminUserId = null;
+    state.adminEditMode = false;
+    state.adminUserName = '';
+    state.adminItems = null;
+    state.adminItemsUserId = null;
+    state.adminLoadError = false;
+    state.adminLoadToken++; // in-flight admin fetches see a stale token and drop their result
+  });
+
   function scopeBadgeText(scope) {
     const s = (scope || '').toLowerCase();
     if (s === 'continuewatching') return JE.t('hidden_content_scope_cw_label');

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-save.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-save.js
@@ -37,10 +37,10 @@
                 // JE.saveUserSettings swallows errors, which would leave a pending retry firing later and
                 // clobbering server state.
                 const sent = await directSaveHiddenContent();
-                reconcileAfterSave(sent);
+                reconcileAfterSave(sent, scheduledGeneration);
             } catch (e) {
                 console.warn('🪼 Jellyfin Enhanced: debouncedSave failed; scheduling background retry', e);
-                if (pendingRetryHandle == null) scheduleFlushRetry(0);
+                if (pendingRetryHandle == null) scheduleFlushRetry(0, scheduledGeneration);
             }
         }, SAVE_DEBOUNCE_MS);
     }
@@ -168,7 +168,12 @@
     // - Mismatch: state moved during the await; schedule another save.
     // The retry-timer body explicitly clears RETRY_INFLIGHT before calling this so a same-state mismatch
     // doesn't leave the sentinel stuck; cancelPendingRetry refuses to clear an in-flight retry from another path.
-    function reconcileAfterSave(snapshotSent) {
+    // `generation` is the saveGeneration captured BEFORE the POST that
+    // produced `snapshotSent` — a save spanning a user switch must not
+    // reschedule itself under the new user (it would serialize the reset
+    // store to the incoming user's file).
+    function reconcileAfterSave(snapshotSent, generation) {
+        if (generation !== saveGeneration) return;
         if (snapshotSent === JSON.stringify(getHiddenData())) {
             cancelPendingRetry();
         } else {
@@ -202,9 +207,9 @@
             pendingRetryHandle = null;
             return;
         }
-        const scheduledGeneration = saveGeneration;
+        if (generation !== saveGeneration) return; // save chain belongs to a previous user
         pendingRetryHandle = setTimeout(async () => {
-            if (scheduledGeneration !== saveGeneration) { pendingRetryHandle = null; return; } // user switched since scheduling
+            if (generation !== saveGeneration) { pendingRetryHandle = null; return; } // user switched since scheduling
             pendingRetryHandle = RETRY_INFLIGHT; // mark in-flight so a concurrent debouncedSave failure doesn't spawn a parallel ladder
             // Guard for ApiClient teardown / signed-out state during the window.
             if (typeof ApiClient === 'undefined' || typeof ApiClient.getCurrentUserId !== 'function' || !ApiClient.getCurrentUserId()) {
@@ -218,10 +223,10 @@
                 // reschedule via debouncedSave doesn't leave the sentinel stuck (cancelPendingRetry from
                 // other code paths intentionally refuses to clear RETRY_INFLIGHT).
                 if (pendingRetryHandle === RETRY_INFLIGHT) pendingRetryHandle = null;
-                reconcileAfterSave(sent);
+                reconcileAfterSave(sent, generation);
             } catch (err) {
                 console.warn(`🪼 Jellyfin Enhanced: hidden-content save retry ${attempt + 1} failed`, err);
-                scheduleFlushRetry(attempt + 1);
+                scheduleFlushRetry(attempt + 1, generation);
             }
         }, FLUSH_RETRY_DELAYS_MS[attempt]);
     }
@@ -232,12 +237,13 @@
         if (!saveTimeout) return;
         clearTimeout(saveTimeout);
         saveTimeout = null;
+        const generation = saveGeneration;
         try {
             const sent = await directSaveHiddenContent();
-            reconcileAfterSave(sent);
+            reconcileAfterSave(sent, generation);
         } catch (e) {
             console.warn('🪼 Jellyfin Enhanced: flushPendingSave failed; scheduling background retry', e);
-            if (pendingRetryHandle == null) scheduleFlushRetry(0);
+            if (pendingRetryHandle == null) scheduleFlushRetry(0, generation);
             throw e;
         }
     }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-save.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-save.js
@@ -195,7 +195,7 @@
         pendingRetryHandle = null;
     }
 
-    function scheduleFlushRetry(attempt) {
+    function scheduleFlushRetry(attempt, generation) {
         if (attempt >= FLUSH_RETRY_DELAYS_MS.length) {
             console.error('🪼 Jellyfin Enhanced: hidden-content save retries exhausted; local change may be lost on reload');
             // User-visible toast — the bulk-save endpoint is genuinely down at this point.

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-save.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-save.js
@@ -20,10 +20,17 @@
      * Persists the hidden-content data to the server after a debounce.
      * Coalesces rapid writes (e.g. bulk-unhide) into a single save.
      */
+    // Bumped on every user switch: a save/retry timer scheduled under the
+    // previous user must not fire under the new one — it would serialize the
+    // reset (empty) store to the NEW user's file and erase their data.
+    let saveGeneration = 0;
+
     function debouncedSave() {
         if (saveTimeout) clearTimeout(saveTimeout);
+        const scheduledGeneration = saveGeneration;
         saveTimeout = setTimeout(async () => {
             saveTimeout = null;
+            if (scheduledGeneration !== saveGeneration) return; // user switched since scheduling
             try {
                 // Route through directSaveHiddenContent (not JE.saveUserSettings) so a successful save can
                 // reconcile against any in-flight retry and a failure can re-enter the retry ladder.
@@ -195,7 +202,9 @@
             pendingRetryHandle = null;
             return;
         }
+        const scheduledGeneration = saveGeneration;
         pendingRetryHandle = setTimeout(async () => {
+            if (scheduledGeneration !== saveGeneration) { pendingRetryHandle = null; return; } // user switched since scheduling
             pendingRetryHandle = RETRY_INFLIGHT; // mark in-flight so a concurrent debouncedSave failure doesn't spawn a parallel ladder
             // Guard for ApiClient teardown / signed-out state during the window.
             if (typeof ApiClient === 'undefined' || typeof ApiClient.getCurrentUserId !== 'function' || !ApiClient.getCurrentUserId()) {
@@ -238,6 +247,15 @@
     try {
         window.addEventListener('pagehide', cancelPendingRetry);
     } catch (_) { /* non-browser env, harmless */ }
+
+    // Invalidate every scheduled save/retry on a user switch (the generation
+    // guard in the timer bodies covers the in-flight sentinel this
+    // cancellation cannot reach).
+    window.JellyfinEnhanced.session?.onUserChange('hidden-content-save', () => {
+        saveGeneration++;
+        if (saveTimeout) { clearTimeout(saveTimeout); saveTimeout = null; }
+        cancelPendingRetry();
+    });
 
     Object.assign(internal, {
         debouncedSave,

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/itemdetails/features-details-media-info.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/itemdetails/features-details-media-info.js
@@ -237,15 +237,19 @@
                     totalRuntimeTicks: itemResult?.totalRuntimeTicks ?? 0,
                     ts: now
                 };
+                // A stale response must neither render (the DOM now belongs
+                // to the new user's session) nor be cached.
+                if (!isCurrent()) return;
                 placeholder.innerHTML = getIconSpan(watchProgress.progress);
                 placeholder.appendChild(getWatchProgressValue(watchProgress));
 
-                if (isCurrent()) watchProgressCache.set(itemId, watchProgress);
+                watchProgressCache.set(itemId, watchProgress);
             } catch (error) {
                 console.error('🪼 Jellyfin Enhanced: Error fetching watch progress for ID %s:', itemId, error);
+                if (!isCurrent()) return;
                 // Keep placeholder with 0 to prevent repeated calls
                 renderUnavailable();
-                if (isCurrent()) watchProgressCache.set(itemId, { progress: 0, totalPlaybackTicks: 0, totalRuntimeTicks: 0, ts: now });
+                watchProgressCache.set(itemId, { progress: 0, totalPlaybackTicks: 0, totalRuntimeTicks: 0, ts: now });
             }
         };
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/itemdetails/features-details-media-info.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/itemdetails/features-details-media-info.js
@@ -220,6 +220,10 @@
                 return;
             }
 
+            // Watch progress is per-user: a response resolving after a user
+            // switch must not repopulate the cache that was just reset.
+            const requestEpoch = JE.session ? JE.session.getEpoch() : 0;
+            const isCurrent = () => !JE.session || JE.session.isCurrent(requestEpoch);
             try {
                 const itemResult = await ApiClient.ajax({
                     type: 'GET',
@@ -236,12 +240,12 @@
                 placeholder.innerHTML = getIconSpan(watchProgress.progress);
                 placeholder.appendChild(getWatchProgressValue(watchProgress));
 
-                watchProgressCache.set(itemId, watchProgress);
+                if (isCurrent()) watchProgressCache.set(itemId, watchProgress);
             } catch (error) {
                 console.error('🪼 Jellyfin Enhanced: Error fetching watch progress for ID %s:', itemId, error);
                 // Keep placeholder with 0 to prevent repeated calls
                 renderUnavailable();
-                watchProgressCache.set(itemId, { progress: 0, totalPlaybackTicks: 0, totalRuntimeTicks: 0, ts: now });
+                if (isCurrent()) watchProgressCache.set(itemId, { progress: 0, totalPlaybackTicks: 0, totalRuntimeTicks: 0, ts: now });
             }
         };
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/itemdetails/features-details-media-info.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/itemdetails/features-details-media-info.js
@@ -16,6 +16,14 @@
     const fileSizeCache = new Map(); // Map<itemId, { size: number|null, unavailable: boolean, ts: number }>
     const audioLanguageCache = new Map(); // Map<itemId, { languages: Array, unavailable: boolean, ts: number }>
 
+    // Watch progress is per-user (and item metadata is fetched with the
+    // signed-in user's access) — never carry it across a user switch.
+    JE.session?.onUserChange('details-media-info', () => {
+        watchProgressCache.clear();
+        fileSizeCache.clear();
+        audioLanguageCache.clear();
+    });
+
     /**
      * Converts bytes into a human-readable format (e.g., KB, MB, GB).
      * @param {number} bytes The size in bytes.

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/player/osd-rating.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/player/osd-rating.js
@@ -8,6 +8,12 @@
   // Hot cache (per session) so each item is fetched once
   const ratingCache = new Map();
   const pendingRatings = new Map();
+
+  // Ratings are the signed-in user's own — drop them on a user switch.
+  window.JellyfinEnhanced.session?.onUserChange('osd-rating', () => {
+    ratingCache.clear();
+    pendingRatings.clear();
+  });
   let scheduledUpdate = null;
   let osdObserver = null;
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/player/pausescreen.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/player/pausescreen.js
@@ -98,7 +98,11 @@
             try {
               activeServerId = (typeof ApiClient.serverId === 'function' ? ApiClient.serverId() : ApiClient.serverId) || null;
             } catch { activeServerId = null; }
-            const server = (activeServerId && servers.find(s => s.Id === activeServerId)) || servers[0];
+            // Fail closed: when the active server is known but has no stored
+            // entry, do NOT fall back to another server's token/user id.
+            const server = activeServerId
+              ? servers.find(s => s.Id === activeServerId)
+              : servers[0];
             return server ? { token: server.AccessToken, userId: server.UserId } : null;
           } catch {
             return null;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/player/pausescreen.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/player/pausescreen.js
@@ -91,7 +91,14 @@
           if (!creds) return null;
           try {
             const parsed = JSON.parse(creds);
-            const server = parsed.Servers?.[0];
+            const servers = Array.isArray(parsed.Servers) ? parsed.Servers : [];
+            // Prefer the ACTIVE server's entry — with multiple stored servers
+            // Servers[0] may hold another server's user id/token.
+            let activeServerId = null;
+            try {
+              activeServerId = (typeof ApiClient.serverId === 'function' ? ApiClient.serverId() : ApiClient.serverId) || null;
+            } catch { activeServerId = null; }
+            const server = (activeServerId && servers.find(s => s.Id === activeServerId)) || servers[0];
             return server ? { token: server.AccessToken, userId: server.UserId } : null;
           } catch {
             return null;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/player/pausescreen.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/player/pausescreen.js
@@ -61,6 +61,24 @@
           this.userId = credentials.userId;
           this.token = credentials.token;
 
+          // Credentials are captured once above; without this they would keep
+          // serving the PREVIOUS user's token after an SPA user switch. The
+          // re-read is deferred a tick because the reset fires before the host
+          // finishes writing the new credentials to localStorage.
+          JE.session?.onUserChange('pause-screen', () => {
+            for (const url of this.imgBlobCache.values()) URL.revokeObjectURL(url);
+            this.imgBlobCache.clear();
+            this.imgProbeCache.clear();
+            this.itemCache.clear();
+            this.userId = null;
+            this.token = null;
+            setTimeout(() => {
+              const fresh = this.getCredentials();
+              this.userId = fresh?.userId || null;
+              this.token = fresh?.token || null;
+            }, 0);
+          });
+
           this.injectStyles();
           this.createOverlay();
           this.setupKeyboardAccessibility();

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/spoilerguard/identity.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/spoilerguard/identity.js
@@ -37,4 +37,21 @@
     };
 
     internal.primeIdentityCookie();
+
+    // The cookie identifies the browser to the server for anonymous <img>
+    // requests, so it must follow user switches: rewrite it for the incoming
+    // user (the change payload carries the new id — ApiClient may not expose
+    // it yet at reset time) and delete it on logout so the server never
+    // resolves the previous user's spoiler policy.
+    JE.session?.onUserChange('spoilerguard-identity', (change) => {
+        try {
+            if (change.userId) {
+                document.cookie = `je-spoiler-uid=${encodeURIComponent(change.userId)}; path=/; SameSite=Lax`;
+            } else {
+                document.cookie = 'je-spoiler-uid=; path=/; SameSite=Lax; Max-Age=0';
+            }
+        } catch (e) {
+            console.warn(`${logPrefix} identity cookie update on user switch failed:`, e);
+        }
+    });
 })(window.JellyfinEnhanced);

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/spoilerguard/state.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/spoilerguard/state.js
@@ -27,8 +27,12 @@
 
     internal.loadState = function() {
         if (statePromise) return statePromise;
+        // A response resolving after a user switch must not populate the
+        // (already reset) state with the previous user's data.
+        const requestEpoch = JE.session ? JE.session.getEpoch() : 0;
         statePromise = request('/spoiler-blur/series')
             .then(function(data) {
+                if (JE.session && !JE.session.isCurrent(requestEpoch)) return;
                 const value = data || {};
                 enabledSeries.clear();
                 enabledMovies.clear();
@@ -52,6 +56,7 @@
                 }
             })
             .catch(function(err) {
+                if (JE.session && !JE.session.isCurrent(requestEpoch)) return;
                 console.error(`${logPrefix} state load failed; downstream consumers will fail closed:`, err);
                 loaded = true;
                 loadOk = false;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/spoilerguard/state.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/spoilerguard/state.js
@@ -181,4 +181,20 @@
                 throw err;
             });
     };
+
+    // Spoiler Guard state (enabled series/movies/collections, prefs) is
+    // per-user and memoized for the whole SPA session via statePromise.
+    // Drop it on a user switch so the next whenLoaded() fetches the new
+    // user's state instead of serving the previous user's.
+    JE.session?.onUserChange('spoilerguard-state', () => {
+        statePromise = null;
+        loaded = false;
+        loadOk = false;
+        enabledSeries.clear();
+        enabledMovies.clear();
+        enabledCollections.clear();
+        enabledPendingTmdb.clear();
+        tmdbToJellyfin.clear();
+        userPrefs = {};
+    });
 })(window.JellyfinEnhanced);

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/extras/active-streams.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/extras/active-streams.js
@@ -793,9 +793,16 @@
         }
     };
 
+    // Bumped by destroy(): in-flight session fetches and header-inject retry
+    // timers from a torn-down (previous user's) instance must not touch the
+    // DOM a re-initialized instance now owns.
+    let _generation = 0;
+
     // ── Counter updater ──────────────────────────────────────────────────────
     const updateCounter = async () => {
+        const startGeneration = _generation;
         const sessions = await fetchSessions();
+        if (startGeneration !== _generation) return; // torn down / user switched mid-fetch
         _lastUpdated = new Date();
         const btn = document.getElementById('je-active-streams');
         if (!btn) return;
@@ -1133,13 +1140,14 @@
     };
 
     // ── Header button ────────────────────────────────────────────────────────
-    const tryInjectHeader = (attempts = 0) => {
+    const tryInjectHeader = (attempts = 0, generation = _generation) => {
+        if (generation !== _generation) return; // torn down while retrying
         if (document.getElementById('je-active-streams')) return;
         if (attempts > 20) return;
 
         const headerRight = JE.helpers.getHeaderRightContainer();
         if (!headerRight) {
-            setTimeout(() => tryInjectHeader(attempts + 1), 500);
+            setTimeout(() => tryInjectHeader(attempts + 1, generation), 500);
             return;
         }
 
@@ -1211,6 +1219,7 @@
 
         destroy() {
             console.log(`${LOG} Active Streams: destroying.`);
+            _generation++; // invalidate in-flight fetches and header-inject retries
             stopPolling();
             stopObserver();
             if (_lifecycle) { _lifecycle.teardown(); _lifecycle = null; }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/extras/active-streams.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/extras/active-streams.js
@@ -1224,4 +1224,15 @@
         }
     };
 
+    // The panel shows other users' now-playing sessions (admin view) and its
+    // visibility gate was evaluated for the OLD user — tear everything down
+    // on a user switch and re-initialize once the new user's data (incl. the
+    // admin policy) is loaded, so a non-admin never inherits the admin panel.
+    JE.session?.onUserChange('active-streams', () => {
+        JE.activeStreams.destroy();
+    });
+    document.addEventListener('je:user-data-loaded', () => {
+        JE.activeStreams.initialize();
+    });
+
 })(window.JellyfinEnhanced);

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/api.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/api.js
@@ -904,6 +904,18 @@
         return baseUrl;
     };
 
+    // The Seerr identity (linked user, permissions, override rules) is
+    // per-Jellyfin-user; a sticky success cached for user A must not answer
+    // for user B after an SPA user switch.
+    JE.session?.onUserChange('jellyseerr-api', () => {
+        cachedUserStatus = null;
+        cachedUserStatusAt = 0;
+        cachedOverrideRules = null;
+        overrideRulesCachedAt = 0;
+        // Allow the status banner to surface again for the new user.
+        window.__JE_userStatusBannerShown = null;
+    });
+
     // Expose the API module on the global JE object
     JE.jellyseerrAPI = api;
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/api.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/api.js
@@ -139,13 +139,19 @@
             }
         }
 
+        // A status resolved after a user switch belongs to the previous user
+        // — return it to the caller that asked, but never cache it.
+        const requestEpoch = JE.session ? JE.session.getEpoch() : 0;
+        const isCurrent = () => !JE.session || JE.session.isCurrent(requestEpoch);
         try {
             const status = await get('/user-status', { skipCache: true });
-            cachedUserStatus = status;
-            cachedUserStatusAt = Date.now();
-            // Surface the typed reason as a banner so users aren't left staring
-            // at silently-hidden discovery sections.
-            api.surfaceUserStatusBanner(status);
+            if (isCurrent()) {
+                cachedUserStatus = status;
+                cachedUserStatusAt = Date.now();
+                // Surface the typed reason as a banner so users aren't left staring
+                // at silently-hidden discovery sections.
+                api.surfaceUserStatusBanner(status);
+            }
             return status;
         } catch (error) {
             console.warn(`${logPrefix} Status check failed:`, error);
@@ -155,9 +161,11 @@
                 reason: error?.responseJSON?.code || 'unreachable',
                 message: error?.responseJSON?.message
             };
-            cachedUserStatus = fallback;
-            cachedUserStatusAt = Date.now();
-            api.surfaceUserStatusBanner(fallback);
+            if (isCurrent()) {
+                cachedUserStatus = fallback;
+                cachedUserStatusAt = Date.now();
+                api.surfaceUserStatusBanner(fallback);
+            }
             return fallback;
         }
     };
@@ -346,11 +354,16 @@
         if (cachedOverrideRules !== null && Date.now() - overrideRulesCachedAt < OVERRIDE_RULES_TTL) {
             return cachedOverrideRules;
         }
+        const requestEpoch = JE.session ? JE.session.getEpoch() : 0;
         try {
             const rules = await get('/overrideRule');
-            cachedOverrideRules = Array.isArray(rules) ? rules : [];
-            overrideRulesCachedAt = Date.now();
-            return cachedOverrideRules;
+            const normalized = Array.isArray(rules) ? rules : [];
+            // Don't cache a result that resolved after a user switch.
+            if (!JE.session || JE.session.isCurrent(requestEpoch)) {
+                cachedOverrideRules = normalized;
+                overrideRulesCachedAt = Date.now();
+            }
+            return normalized;
         } catch (error) {
             console.error(`${logPrefix} Failed to fetch override rules:`, error);
             return cachedOverrideRules || [];

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/discovery/discovery-base.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/discovery/discovery-base.js
@@ -954,6 +954,12 @@
             }
         }
 
+        // Cached Seerr results carry per-user availability/request state.
+        // Navigation normally runs cleanup() before a logout can complete,
+        // but run it on the identity transition too so no path leaks user A's
+        // results into user B's session.
+        JE.session?.onUserChange(`discovery-${key}`, cleanup);
+
         /** Handles page navigation — renders when the URL matches the module. */
         function handlePageNavigation() {
             const id = spec.getIdFromUrl();

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/issue-reporter.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/issue-reporter.js
@@ -9,6 +9,12 @@
     // Cache for user permission to report
     let cachedUserCanReport = null;
 
+    // Reporting permission belongs to the signed-in Seerr-linked user;
+    // re-resolve it after a user switch.
+    JE.session?.onUserChange('issue-reporter', () => {
+        cachedUserCanReport = null;
+    });
+
     /**
      * Issue type definitions matching Jellyseerr's 4 core issue types
      * Jellyseerr uses: VIDEO (1), AUDIO (2), SUBTITLES (3), OTHER (4)

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -274,12 +274,17 @@
      * @returns {Promise<void>}
      */
     async function loadPrivateConfig() {
+        // A response resolving after a user switch was authorized as the
+        // PREVIOUS user — merging it would leak admin config into the next
+        // session and clobber the strip list the reset relies on.
+        const requestEpoch = JE.session ? JE.session.getEpoch() : 0;
         try {
             const privateConfig = await ApiClient.ajax({
                 type: 'GET',
                 url: ApiClient.getUrl('/JellyfinEnhanced/private-config'),
                 dataType: 'json'
             });
+            if (JE.session && !JE.session.isCurrent(requestEpoch)) return;
             // Merge the sensitive keys into the main config object
             privateConfigKeys = Object.keys(privateConfig && typeof privateConfig === 'object' ? privateConfig : {});
             Object.assign(JE.pluginConfig, privateConfig);
@@ -932,15 +937,33 @@
             // Must happen after loadScripts so JE.session exists.
             registerSessionIntegration();
 
-            // A user switch during the stage-2 fetches happens BEFORE the
+            // A user switch during the stage-1/2 fetches happens BEFORE the
             // session module exists, so it was adopted silently with no reset
-            // — the config fetched above belongs to the previous user.
-            // Re-fetch for whoever is actually signed in now.
+            // — EVERYTHING fetched above belongs to the previous user.
+            // Re-fetch it all for whoever is actually signed in now (mirrors
+            // the je:user-changed re-bootstrap in registerSessionIntegration).
             const liveUserId = ApiClient.getCurrentUserId();
             if (liveUserId && liveUserId !== userId) {
                 console.warn('🪼 Jellyfin Enhanced: User changed during boot — reloading user-scoped data.');
                 userId = liveUserId;
-                JE.userConfig = await fetchUserScopedConfig(liveUserId);
+                // Session exists now — epoch-guard this recovery too, so yet
+                // another switch during these fetches can't restore this
+                // user's data over the next user's reset.
+                const recoveryEpoch = JE.session ? JE.session.getEpoch() : 0;
+                const recoveryCurrent = () => !JE.session || JE.session.isCurrent(recoveryEpoch);
+                const recoveredConfig = await fetchUserScopedConfig(liveUserId);
+                if (recoveryCurrent()) JE.userConfig = recoveredConfig;
+                // The stage-2 prefetch may have resolved BEFORE the switch,
+                // leaving the previous user's object (and admin flag) behind.
+                JE.currentUser = null;
+                try {
+                    const liveUser = await ApiClient.getCurrentUser();
+                    if (recoveryCurrent() && liveUser?.Id === ApiClient.getCurrentUserId()) JE.currentUser = liveUser;
+                } catch (_) { /* non-fatal — consumers null-check */ }
+                // Same for the admin-only private config fetched in stage 1.
+                for (const key of privateConfigKeys) delete JE.pluginConfig[key];
+                privateConfigKeys = [];
+                await loadPrivateConfig(); // internally epoch-guarded
             }
 
             // Stage 4: Initialize core settings/shortcuts using potentially defined functions

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -952,18 +952,24 @@
                 const recoveryEpoch = JE.session ? JE.session.getEpoch() : 0;
                 const recoveryCurrent = () => !JE.session || JE.session.isCurrent(recoveryEpoch);
                 const recoveredConfig = await fetchUserScopedConfig(liveUserId);
-                if (recoveryCurrent()) JE.userConfig = recoveredConfig;
-                // The stage-2 prefetch may have resolved BEFORE the switch,
-                // leaving the previous user's object (and admin flag) behind.
-                JE.currentUser = null;
-                try {
-                    const liveUser = await ApiClient.getCurrentUser();
-                    if (recoveryCurrent() && liveUser?.Id === ApiClient.getCurrentUserId()) JE.currentUser = liveUser;
-                } catch (_) { /* non-fatal — consumers null-check */ }
-                // Same for the admin-only private config fetched in stage 1.
-                for (const key of privateConfigKeys) delete JE.pluginConfig[key];
-                privateConfigKeys = [];
-                await loadPrivateConfig(); // internally epoch-guarded
+                if (recoveryCurrent()) {
+                    JE.userConfig = recoveredConfig;
+                    // The stage-2 prefetch may have resolved BEFORE the
+                    // switch, leaving the previous user's object (and admin
+                    // flag) behind.
+                    JE.currentUser = null;
+                    try {
+                        const liveUser = await ApiClient.getCurrentUser();
+                        if (recoveryCurrent() && liveUser?.Id === ApiClient.getCurrentUserId()) JE.currentUser = liveUser;
+                    } catch (_) { /* non-fatal — consumers null-check */ }
+                    // Same for the admin-only private config fetched in stage 1.
+                    for (const key of privateConfigKeys) delete JE.pluginConfig[key];
+                    privateConfigKeys = [];
+                    await loadPrivateConfig(); // internally epoch-guarded
+                }
+                // If ANOTHER switch happened during this recovery, the
+                // je:user-changed re-bootstrap owns the repair — this stale
+                // recovery must not touch the globals further.
             }
 
             // Stage 4: Initialize core settings/shortcuts using potentially defined functions

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -431,6 +431,168 @@
     const MAX_MISMATCH_RETRIES = 100; // ~30s at 300ms intervals
 
     /**
+     * Fetches the five per-user config files (settings, shortcuts, bookmark,
+     * elsewhere, hidden-content) and assembles a fresh userConfig object.
+     * Shared by first boot and by the user-switch re-bootstrap so both paths
+     * build the object identically.
+     * @param {string} userId - The user to load config for.
+     * @returns {Promise<object>} A freshly-built userConfig object.
+     */
+    async function fetchUserScopedConfig(userId) {
+        const fetchPromises = [
+            ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinEnhanced/user-settings/${userId}/settings.json?_=${Date.now()}`), dataType: 'json' })
+                     .then(data => ({ name: 'settings', status: 'fulfilled', value: data }))
+                     .catch(e => ({ name: 'settings', status: 'rejected', reason: e })),
+            ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinEnhanced/user-settings/${userId}/shortcuts.json?_=${Date.now()}`), dataType: 'json' })
+                     .then(data => ({ name: 'shortcuts', status: 'fulfilled', value: data }))
+                     .catch(e => ({ name: 'shortcuts', status: 'rejected', reason: e })),
+            ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinEnhanced/user-settings/${userId}/bookmark.json?_=${Date.now()}`), dataType: 'json' })
+                     .then(data => ({ name: 'bookmark', status: 'fulfilled', value: data }))
+                     .catch(e => ({ name: 'bookmark', status: 'rejected', reason: e })),
+            ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinEnhanced/user-settings/${userId}/elsewhere.json?_=${Date.now()}`), dataType: 'json' })
+                     .then(data => ({ name: 'elsewhere', status: 'fulfilled', value: data }))
+                     .catch(e => ({ name: 'elsewhere', status: 'rejected', reason: e })),
+            ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinEnhanced/user-settings/${userId}/hidden-content.json?_=${Date.now()}`), dataType: 'json' })
+                     .then(data => ({ name: 'hiddenContent', status: 'fulfilled', value: data }))
+                     .catch(e => ({ name: 'hiddenContent', status: 'rejected', reason: e }))
+        ];
+        // Use allSettled to get results even if some fetches fail
+        const results = await Promise.allSettled(fetchPromises);
+
+        const userConfig = { settings: {}, shortcuts: { Shortcuts: [] }, bookmark: { bookmarks: {} }, elsewhere: {}, hiddenContent: { items: {}, settings: {} } };
+        results.forEach(result => {
+            if (result.status === 'fulfilled' && result.value) {
+                const data = result.value;
+                if (data.status === 'fulfilled' && data.value && typeof data.value === 'object') {
+                    // *** CONVERT PASCALCASE TO CAMELCASE ***
+                    if (data.name === 'settings' || data.name === 'bookmark' || data.name === 'hiddenContent') {
+                        userConfig[data.name] = toCamelCase(data.value);
+                    } else {
+                        userConfig[data.name] = data.value;
+                    }
+                } else if (data.status === 'rejected') {
+                    if (data.name === 'shortcuts') userConfig.shortcuts = { Shortcuts: [] };
+                    else if (data.name === 'bookmark') userConfig.bookmark = { bookmarks: {} };
+                    else if (data.name === 'elsewhere') userConfig.elsewhere = {};
+                    else if (data.name === 'hiddenContent') userConfig.hiddenContent = { items: {}, settings: {} };
+                    else userConfig[data.name] = {};
+                } else {
+                    if (data.name === 'shortcuts') userConfig.shortcuts = { Shortcuts: [] };
+                    else if (data.name === 'bookmark') userConfig.bookmark = { bookmarks: {} };
+                    else if (data.name === 'elsewhere') userConfig.elsewhere = {};
+                    else if (data.name === 'hiddenContent') userConfig.hiddenContent = { items: {}, settings: {} };
+                    else userConfig[data.name] = {};
+                }
+            } else {
+                const name = result.value?.name || result.reason?.name || '';
+                if (name === 'shortcuts') userConfig.shortcuts = { Shortcuts: [] };
+                else if (name === 'bookmark') userConfig.bookmark = { bookmarks: {} };
+                else if (name === 'elsewhere') userConfig.elsewhere = {};
+                else if (name === 'hiddenContent') userConfig.hiddenContent = { items: {}, settings: {} };
+                else if (name) userConfig[name] = {};
+            }
+        });
+        return userConfig;
+    }
+
+    /**
+     * Seeds the admin's default display language into the per-user
+     * `${userId}-language` key — only when the user has no language set yet,
+     * so a user's own choice is never overwritten.
+     * @param {string} userId
+     */
+    function seedDisplayLanguage(userId) {
+        if (!userId) return;
+        const languageKey = `${userId}-language`;
+        // Only seed the admin's default language if the user has no language set yet.
+        // This prevents overwriting the user's own language choice on every page load.
+        if (localStorage.getItem(languageKey) === null) {
+            const desiredLanguage = (JE.currentSettings?.displayLanguage || '').trim();
+            if (desiredLanguage) {
+                const normalizeLangCode = (code) => {
+                    if (!code) return '';
+                    const parts = code.split('-');
+                    if (parts.length === 1) return parts[0].toLowerCase();
+                    if (parts.length === 2) return `${parts[0].toLowerCase()}-${parts[1].toUpperCase()}`;
+                    return code;
+                };
+                localStorage.setItem(languageKey, normalizeLangCode(desiredLanguage));
+            }
+        }
+    }
+
+    /**
+     * Wires the plugin's own state into the identity-session machinery
+     * (js/core/session.js): clears the boot-time per-user globals on any
+     * identity transition, and re-loads them for the incoming user after a
+     * switch — the SPA never reloads index.html on logout/login, so without
+     * this every module keeps serving the previous user's data.
+     * Called once, right after the component scripts (including session.js)
+     * have loaded.
+     */
+    function registerSessionIntegration() {
+        if (!JE.session) {
+            console.error('🪼 Jellyfin Enhanced: session.js missing — user-switch handling disabled.');
+            return;
+        }
+
+        // Synchronous reset: wipe every boot-time global the moment the
+        // identity changes, so nothing can read user A's data under user B.
+        JE.session.onUserChange('plugin-globals', () => {
+            JE.userConfig = { settings: {}, shortcuts: { Shortcuts: [] }, bookmark: { bookmarks: {} }, elsewhere: {}, hiddenContent: { items: {}, settings: {} } };
+            JE.currentUser = null;
+            JE.currentSettings = {};
+            // Cleared (not merged over) so user A's extra shortcuts don't
+            // survive into user B's session — initializeShortcuts() merges.
+            JE.state.activeShortcuts = {};
+        });
+
+        // Async re-bootstrap: after a switch to a signed-in user, reload that
+        // user's config and re-derive settings/shortcuts/translations.
+        document.addEventListener('je:user-changed', (e) => {
+            const detail = /** @type {CustomEvent} */ (e).detail || {};
+            const { userId, epoch } = detail;
+            if (!userId) return; // logged out — stay reset until the next sign-in
+            // Defer one macrotask: the transition fires from inside the
+            // setAuthenticationInfo wrapper BEFORE the host installs the new
+            // token; the fetches below need that token in place.
+            setTimeout(async () => {
+                if (!JE.session.isCurrent(epoch)) return; // switched again already
+                try {
+                    const userConfig = await fetchUserScopedConfig(userId);
+                    if (!JE.session.isCurrent(epoch)) return; // stale result — drop it
+                    JE.userConfig = userConfig;
+
+                    // Refresh the cached full user object (admin checks etc.).
+                    try {
+                        const user = await ApiClient.getCurrentUser();
+                        if (JE.session.isCurrent(epoch)) JE.currentUser = user;
+                    } catch (_) { /* non-fatal — consumers null-check */ }
+                    if (!JE.session.isCurrent(epoch)) return;
+
+                    JE.currentSettings = JE.loadSettings();
+                    JE.initializeShortcuts();
+                    seedDisplayLanguage(userId);
+
+                    // Translations follow the per-user language choice.
+                    try {
+                        const translations = await loadTranslations();
+                        if (!JE.session.isCurrent(epoch)) return;
+                        if (translations) JE.translations = translations;
+                    } catch (_) { /* keep previous translations */ }
+
+                    // Announce that the new user's data is live so views
+                    // (bookmarks, hidden content, …) can re-render from it.
+                    document.dispatchEvent(new CustomEvent('je:user-data-loaded', { detail }));
+                    console.log('🪼 Jellyfin Enhanced: Reloaded user-scoped data after user switch.');
+                } catch (err) {
+                    console.error('🪼 Jellyfin Enhanced: Failed to reload user data after user switch:', err);
+                }
+            }, 0);
+        });
+    }
+
+    /**
      * Main initialization function.
      */
     async function initialize() {
@@ -527,60 +689,7 @@
             // Fire-and-forget alongside stage-2 network calls; result available as JE.currentUser
             ApiClient.getCurrentUser().then(u => { JE.currentUser = u; }).catch(() => {});
 
-            const fetchPromises = [
-                ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinEnhanced/user-settings/${userId}/settings.json?_=${Date.now()}`), dataType: 'json' })
-                         .then(data => ({ name: 'settings', status: 'fulfilled', value: data }))
-                         .catch(e => ({ name: 'settings', status: 'rejected', reason: e })),
-                ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinEnhanced/user-settings/${userId}/shortcuts.json?_=${Date.now()}`), dataType: 'json' })
-                         .then(data => ({ name: 'shortcuts', status: 'fulfilled', value: data }))
-                         .catch(e => ({ name: 'shortcuts', status: 'rejected', reason: e })),
-                ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinEnhanced/user-settings/${userId}/bookmark.json?_=${Date.now()}`), dataType: 'json' })
-                         .then(data => ({ name: 'bookmark', status: 'fulfilled', value: data }))
-                         .catch(e => ({ name: 'bookmark', status: 'rejected', reason: e })),
-                ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinEnhanced/user-settings/${userId}/elsewhere.json?_=${Date.now()}`), dataType: 'json' })
-                         .then(data => ({ name: 'elsewhere', status: 'fulfilled', value: data }))
-                         .catch(e => ({ name: 'elsewhere', status: 'rejected', reason: e })),
-                ApiClient.ajax({ type: 'GET', url: ApiClient.getUrl(`/JellyfinEnhanced/user-settings/${userId}/hidden-content.json?_=${Date.now()}`), dataType: 'json' })
-                         .then(data => ({ name: 'hiddenContent', status: 'fulfilled', value: data }))
-                         .catch(e => ({ name: 'hiddenContent', status: 'rejected', reason: e }))
-            ];
-            // Use allSettled to get results even if some fetches fail
-            const results = await Promise.allSettled(fetchPromises);
-
-            JE.userConfig = { settings: {}, shortcuts: { Shortcuts: [] }, bookmark: { bookmarks: {} }, elsewhere: {}, hiddenContent: { items: {}, settings: {} } };
-            results.forEach(result => {
-                if (result.status === 'fulfilled' && result.value) {
-                    const data = result.value;
-                    if (data.status === 'fulfilled' && data.value && typeof data.value === 'object') {
-                        // *** CONVERT PASCALCASE TO CAMELCASE ***
-                        if (data.name === 'settings' || data.name === 'bookmark' || data.name === 'hiddenContent') {
-                            JE.userConfig[data.name] = toCamelCase(data.value);
-                        } else {
-                            JE.userConfig[data.name] = data.value;
-                        }
-                    } else if (data.status === 'rejected') {
-                        if (data.name === 'shortcuts') JE.userConfig.shortcuts = { Shortcuts: [] };
-                        else if (data.name === 'bookmark') JE.userConfig.bookmark = { bookmarks: {} };
-                        else if (data.name === 'elsewhere') JE.userConfig.elsewhere = {};
-                        else if (data.name === 'hiddenContent') JE.userConfig.hiddenContent = { items: {}, settings: {} };
-                        else JE.userConfig[data.name] = {};
-                    } else {
-                        if (data.name === 'shortcuts') JE.userConfig.shortcuts = { Shortcuts: [] };
-                        else if (data.name === 'bookmark') JE.userConfig.bookmark = { bookmarks: {} };
-                        else if (data.name === 'elsewhere') JE.userConfig.elsewhere = {};
-                        else if (data.name === 'hiddenContent') JE.userConfig.hiddenContent = { items: {}, settings: {} };
-                        else JE.userConfig[data.name] = {};
-                    }
-                } else {
-                    const name = result.value?.name || result.reason?.name || '';
-                    if (name === 'shortcuts') JE.userConfig.shortcuts = { Shortcuts: [] };
-                    else if (name === 'bookmark') JE.userConfig.bookmark = { bookmarks: {} };
-                    else if (name === 'elsewhere') JE.userConfig.elsewhere = {};
-                    else if (name === 'hiddenContent') JE.userConfig.hiddenContent = { items: {}, settings: {} };
-                    else if (name) JE.userConfig[name] = {};
-                }
-            });
-
+            JE.userConfig = await fetchUserScopedConfig(userId);
 
             // Initialize splash screen
             if (typeof JE.initializeSplashScreen === 'function') {
@@ -594,6 +703,9 @@
                 // lifecycle registry, the shared body observer, the fetch
                 // layer and base UI primitives that everything else builds on.
                 'core/navigation.js',
+                // session.js must load before every module that registers a
+                // per-user reset handler (JE.session.onUserChange) at eval time.
+                'core/session.js',
                 'core/lifecycle.js',
                 'core/dom-observer.js',
                 'core/ui-kit.js',
@@ -782,6 +894,10 @@
             await loadScripts(allComponentScripts, basePath);
             console.log('🪼 Jellyfin Enhanced: All component scripts loaded.');
 
+            // Wire user-switch detection → global reset → re-bootstrap.
+            // Must happen after loadScripts so JE.session exists.
+            registerSessionIntegration();
+
             // Stage 4: Initialize core settings/shortcuts using potentially defined functions
             if (typeof JE.loadSettings === 'function' && typeof JE.initializeShortcuts === 'function') {
                 JE.currentSettings = JE.loadSettings(); // This happens AFTER config.js is loaded
@@ -792,24 +908,7 @@
                  return;
             }
 
-            if (userId) {
-                const languageKey = `${userId}-language`;
-                // Only seed the admin's default language if the user has no language set yet.
-                // This prevents overwriting the user's own language choice on every page load.
-                if (localStorage.getItem(languageKey) === null) {
-                    const desiredLanguage = (JE.currentSettings?.displayLanguage || '').trim();
-                    if (desiredLanguage) {
-                        const normalizeLangCode = (code) => {
-                            if (!code) return '';
-                            const parts = code.split('-');
-                            if (parts.length === 1) return parts[0].toLowerCase();
-                            if (parts.length === 2) return `${parts[0].toLowerCase()}-${parts[1].toUpperCase()}`;
-                            return code;
-                        };
-                        localStorage.setItem(languageKey, normalizeLangCode(desiredLanguage));
-                    }
-                }
-            }
+            seedDisplayLanguage(userId);
 
             // Stage 5: Initialize theme system first
             if (typeof JE.themer?.init === 'function') {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/plugin.js
@@ -263,6 +263,12 @@
         return Promise.all([configPromise, versionPromise]);
     }
 
+    // Keys merged into JE.pluginConfig from /private-config. Tracked so the
+    // user-switch reset can strip them again: the endpoint is admin-gated, so
+    // an admin's private config (arr instance URLs etc.) must not survive
+    // into a non-admin's session.
+    let privateConfigKeys = [];
+
     /**
      * Fetches sensitive configuration from the authenticated endpoint.
      * @returns {Promise<void>}
@@ -275,6 +281,7 @@
                 dataType: 'json'
             });
             // Merge the sensitive keys into the main config object
+            privateConfigKeys = Object.keys(privateConfig && typeof privateConfig === 'object' ? privateConfig : {});
             Object.assign(JE.pluginConfig, privateConfig);
         } catch (error) {
             console.warn('🪼 Jellyfin Enhanced: Could not load private configuration. Some features may be limited.', error);
@@ -545,6 +552,10 @@
             // Cleared (not merged over) so user A's extra shortcuts don't
             // survive into user B's session — initializeShortcuts() merges.
             JE.state.activeShortcuts = {};
+            // Strip the admin-only private config; re-fetched (admins only)
+            // during the re-bootstrap below.
+            for (const key of privateConfigKeys) delete JE.pluginConfig[key];
+            privateConfigKeys = [];
         });
 
         // Async re-bootstrap: after a switch to a signed-in user, reload that
@@ -570,9 +581,28 @@
                     } catch (_) { /* non-fatal — consumers null-check */ }
                     if (!JE.session.isCurrent(epoch)) return;
 
+                    // Re-fetch the admin-only private config for the incoming
+                    // user (the reset stripped the previous user's copy; the
+                    // server rejects non-admins, leaving the keys absent).
+                    await loadPrivateConfig();
+                    if (!JE.session.isCurrent(epoch)) return;
+
                     JE.currentSettings = JE.loadSettings();
                     JE.initializeShortcuts();
                     seedDisplayLanguage(userId);
+
+                    // Per-user tag toggles can differ between users, and the
+                    // boot-time conditional initialization only ran for the
+                    // first user. The four base-renderer initializers are
+                    // idempotent by design (they re-register with fresh
+                    // settings), so re-run whichever the incoming user has
+                    // enabled; renderers whose toggle is now off stop via
+                    // their isEnabled gate and the pipeline invalidation
+                    // removes stale overlays.
+                    if (JE.currentSettings?.qualityTagsEnabled && typeof JE.initializeQualityTags === 'function') JE.initializeQualityTags();
+                    if (JE.currentSettings?.genreTagsEnabled && typeof JE.initializeGenreTags === 'function') JE.initializeGenreTags();
+                    if (JE.currentSettings?.ratingTagsEnabled && typeof JE.initializeRatingTags === 'function') JE.initializeRatingTags();
+                    if (JE.currentSettings?.languageTagsEnabled && typeof JE.initializeLanguageTags === 'function') JE.initializeLanguageTags();
 
                     // Translations follow the per-user language choice.
                     try {
@@ -683,11 +713,15 @@
             }
 
             // Stage 2: Fetch user-specific settings
-            const userId = ApiClient.getCurrentUserId();
+            let userId = ApiClient.getCurrentUserId();
 
             // Prefetch full user object once (needed for admin check in arr-links etc.)
-            // Fire-and-forget alongside stage-2 network calls; result available as JE.currentUser
-            ApiClient.getCurrentUser().then(u => { JE.currentUser = u; }).catch(() => {});
+            // Fire-and-forget alongside stage-2 network calls; result available as
+            // JE.currentUser. Guarded so a resolution landing after a mid-boot user
+            // switch can't overwrite the new user's object.
+            ApiClient.getCurrentUser().then(u => {
+                if (u?.Id === ApiClient.getCurrentUserId()) JE.currentUser = u;
+            }).catch(() => {});
 
             JE.userConfig = await fetchUserScopedConfig(userId);
 
@@ -897,6 +931,17 @@
             // Wire user-switch detection → global reset → re-bootstrap.
             // Must happen after loadScripts so JE.session exists.
             registerSessionIntegration();
+
+            // A user switch during the stage-2 fetches happens BEFORE the
+            // session module exists, so it was adopted silently with no reset
+            // — the config fetched above belongs to the previous user.
+            // Re-fetch for whoever is actually signed in now.
+            const liveUserId = ApiClient.getCurrentUserId();
+            if (liveUserId && liveUserId !== userId) {
+                console.warn('🪼 Jellyfin Enhanced: User changed during boot — reloading user-scoped data.');
+                userId = liveUserId;
+                JE.userConfig = await fetchUserScopedConfig(liveUserId);
+            }
 
             // Stage 4: Initialize core settings/shortcuts using potentially defined functions
             if (typeof JE.loadSettings === 'function' && typeof JE.initializeShortcuts === 'function') {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/peopletags.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/peopletags.js
@@ -235,7 +235,9 @@
                     url: url,
                     dataType: 'json'
                 });
-                if (JE.session && !JE.session.isCurrent(requestEpoch)) return data || null;
+                // Return null (not the data): the caller would render it
+                // onto a card in the NEW user's session.
+                if (JE.session && !JE.session.isCurrent(requestEpoch)) return null;
 
                 if (data) {
                     // Cache it

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/peopletags.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/peopletags.js
@@ -227,11 +227,15 @@
             try {
                 const queryString = itemId ? `?itemId=${itemId}` : '';
                 const url = ApiClient.getUrl(`/JellyfinEnhanced/person/${personId}${queryString}`);
+                // A response resolving after a user switch must not be written
+                // under the NEW user's identity-owner sentinel.
+                const requestEpoch = JE.session ? JE.session.getEpoch() : 0;
                 const data = await ApiClient.ajax({
                     type: 'GET',
                     url: url,
                     dataType: 'json'
                 });
+                if (JE.session && !JE.session.isCurrent(requestEpoch)) return data || null;
 
                 if (data) {
                     // Cache it

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/peopletags.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/peopletags.js
@@ -69,10 +69,42 @@
             'Papua New Guinea': 'PG', 'Fiji': 'FJ', 'Samoa': 'WS', 'Tonga': 'TO'
         };
 
+        // People metadata is fetched with the signed-in user's library access.
+        // The cache key names are frozen, so ownership is tracked via a
+        // sibling sentinel (same pattern as core/tag-renderer-base.js): a
+        // payload written by a different server:user — or a legacy payload
+        // with no sentinel — is dropped instead of being served cross-user.
+        const OWNER_KEY = `${CACHE_KEY}IdentityOwner`;
+        try {
+            const owner = `${JE.session?.getServerId() || ''}:${JE.session?.getUserId() || ApiClient.getCurrentUserId() || ''}`;
+            if (localStorage.getItem(OWNER_KEY) !== owner) {
+                localStorage.removeItem(CACHE_KEY);
+                localStorage.removeItem(CACHE_TIMESTAMP_KEY);
+                localStorage.setItem(OWNER_KEY, owner);
+            }
+        } catch (e) {
+            console.warn(`${logPrefix} cache ownership check failed`, e);
+        }
+
         let peopleCache = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
         let peopleCacheTimestamp = JSON.parse(localStorage.getItem(CACHE_TIMESTAMP_KEY) || '{}');
         const Hot = (JE._hotCache = JE._hotCache || { ttl: CACHE_TTL });
         Hot.peopleTags = Hot.peopleTags || new Map();
+
+        // Full wipe on user switch; the new owner is stamped immediately so
+        // the next boot doesn't wipe the new user's cache a second time.
+        JE.session?.onUserChange('people-tags', (change) => {
+            peopleCache = {};
+            peopleCacheTimestamp = {};
+            Hot.peopleTags.clear();
+            try {
+                localStorage.removeItem(CACHE_KEY);
+                localStorage.removeItem(CACHE_TIMESTAMP_KEY);
+                localStorage.setItem(OWNER_KEY, `${change.serverId || ''}:${change.userId || ''}`);
+            } catch (e) {
+                console.warn(`${logPrefix} cache clear on user switch failed`, e);
+            }
+        });
 
         let processedCastMembers = new WeakSet();
         let processedPersonIds = new Set();

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/tag-pipeline.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/tag-pipeline.js
@@ -610,6 +610,7 @@
 
                     const firstEpisode = (item.Type === 'Series' || item.Type === 'Season')
                         ? await getFirstEpisode(userId, item.Id) : null;
+                    if (generation !== batchGeneration) break; // switched during the awaits above
                     const extras = { firstEpisode, parentSeries: null, ratingParentSeries: null, renderTarget };
 
                     for (const [, renderer] of renderers) {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/tag-pipeline.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/tag-pipeline.js
@@ -808,6 +808,21 @@
         scheduleScan,
     };
 
+    // The server tag cache is fetched per user (spoiler-stripped for that
+    // user), so it must not survive a user switch. Reset synchronously here;
+    // the full invalidate-and-reload (which also strips stale DOM overlays)
+    // runs once the new user's data is live — reloading at reset time would
+    // race the credential swap.
+    JE.session?.onUserChange('tag-pipeline', () => {
+        serverCache = null;
+        serverCacheVersion = 0;
+        serverCacheTimestamp = 0;
+        JE.tagPipeline.clearProcessed();
+    });
+    document.addEventListener('je:user-data-loaded', () => {
+        JE.tagPipeline.invalidateServerCache().catch(() => {});
+    });
+
     console.log(`${logPrefix} Module loaded`);
 
 })(window.JellyfinEnhanced);

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/tag-pipeline.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/tag-pipeline.js
@@ -536,6 +536,10 @@
             // This way a slow first-episode lookup doesn't block everything else.
 
             const renderItem = (item, firstEpisode) => {
+                // Re-check per render: first-episode/parent-series awaits can
+                // span a navigation OR a user switch (clearProcessed bumps the
+                // generation) — stale data must not be rendered or persisted.
+                if (generation !== batchGeneration) return;
                 const itemId = item.Id.toString().replace(/-/g, '').toLowerCase();
                 const batchEntries = elMap.get(itemId);
                 if (!batchEntries || batchEntries.length === 0) return;
@@ -597,6 +601,7 @@
             console.warn(`${logPrefix} Batch fetch failed, falling back to individual fetches:`, err);
             // Fallback: process items individually
             for (const { renderTarget, itemId } of batch) {
+                if (generation !== batchGeneration) break; // navigation or user switch
                 try {
                     const item = JE.helpers?.getItemCached
                         ? await JE.helpers.getItemCached(itemId, { userId })

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/tag-pipeline.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/tag-pipeline.js
@@ -168,11 +168,15 @@
             const userId = ApiClient.getCurrentUserId();
             if (!userId) return;
 
+            // The response is spoiler-stripped for THIS user — drop it if the
+            // signed-in user changed while the request was in flight.
+            const requestEpoch = JE.session ? JE.session.getEpoch() : 0;
             const resp = await ApiClient.ajax({
                 type: 'GET',
                 url: ApiClient.getUrl(`/JellyfinEnhanced/tag-cache/${userId}`),
                 dataType: 'json'
             });
+            if (JE.session && !JE.session.isCurrent(requestEpoch)) return;
 
             if (resp && resp.items && resp.count > 0) {
                 serverCache = new Map(Object.entries(resp.items));
@@ -208,11 +212,15 @@
             const userId = ApiClient.getCurrentUserId();
             if (!userId) return;
 
+            // Same identity guard as loadServerCache: incremental entries are
+            // spoiler-stripped for the user that requested them.
+            const requestEpoch = JE.session ? JE.session.getEpoch() : 0;
             const resp = await ApiClient.ajax({
                 type: 'GET',
                 url: ApiClient.getUrl(`/JellyfinEnhanced/tag-cache/${userId}?since=${serverCacheTimestamp}`),
                 dataType: 'json'
             });
+            if (JE.session && !JE.session.isCurrent(requestEpoch)) return;
 
             if (resp && resp.items) {
                 const newEntries = Object.entries(resp.items);

--- a/docs/advanced/project-structure.md
+++ b/docs/advanced/project-structure.md
@@ -53,6 +53,7 @@ Jellyfin.Plugin.JellyfinEnhanced/
     │   ├── dom-observer.js
     │   ├── lifecycle.js
     │   ├── navigation.js
+    │   ├── session.js
     │   ├── tag-renderer-base.js
     │   └── ui-kit.js
     ├── enhanced/
@@ -194,6 +195,7 @@ Directory names avoid hyphens (`settingspanel`, not `settings-panel`). Embedded-
     * **`dom-observer.js`**: Multiplexed `MutationObserver` management — one shared body observer with named subscribers, plus dedicated observers and `waitForElement`.
     * **`lifecycle.js`**: Per-feature registration of observers, timers and listeners so they can be torn down together on navigation.
     * **`navigation.js`**: One deduped SPA navigation dispatcher (`onNavigate`, `onViewPage`), replacing the ad-hoc `hashchange`/`viewshow` listeners that previously double-fired on hash navigation and missed `pushState` navigation.
+    * **`session.js`**: Identity-epoch tracker for SPA user switches. Logging out and back in as a different user never reloads the page, so this module detects the transition (an `ApiClient.setAuthenticationInfo` hook plus navigation/storage fallbacks), runs every registered per-feature reset handler (`JE.session.onUserChange`), and emits `je:user-changed`; `plugin.js` then re-fetches the incoming user's data and emits `je:user-data-loaded`. Async loaders capture `JE.session.getEpoch()` and drop stale results after a switch.
     * **`tag-renderer-base.js`**: The shared poster-tag engine — overlay creation, positioning, tagged-card deduplication, caching and reinitialisation. The four poster-overlay renderers (genre, language, quality, rating) supply a spec; `peopletags.js` and `userreviewtags.js` do not use it.
     * **`ui-kit.js`**: `escapeHtml`, `toast`, deduped CSS injection, and scroll-friendly tap detection (`addTouchTapListener`).
 


### PR DESCRIPTION
## Fix stale per-user data after switching users in the same browser

Fixes the cache/user-switch problem behind the *"My Bookmarks page is viewable to all users"* discussion, the *"Radarr/Sonarr/Bazarr buttons can appear for non admin users"* bug report, and completes the cache fix that came out of *"Jellyfin enhanced settings common to all users"* (the earlier cache-busting fix covered the HTTP layer but not the in-memory state). Issue links to follow when this is ready for review.

### Problem

Jellyfin's web client is an SPA — logging out and back in as a different user never reloads `index.html`. Jellyfin Enhanced bootstraps once per page load and snapshots the signed-in user into module-level state (`JE.userConfig`, `JE.currentUser`, `JE.currentSettings`, plus ~25 per-feature caches). After a user switch, all of it still belongs to the previous user until a hard reload (Shift+F5). The most visible symptom was the Bookmarks page via Custom Tabs showing the previous user's bookmarks, but the same staleness affected Seerr identity/permissions, Spoiler Guard state, hidden content, watch progress, tag caches, admin-gated UI (arr links, active streams), the pause screen's captured token, and several localStorage keys.

### Fix

**New `js/core/session.js`** — an identity-epoch tracker:
- Wraps `ApiClient.setAuthenticationInfo` (prototype-chain walk, idempotent, only reacts to the active client) so the transition runs the moment credentials change; the shared `je:navigate` pipeline and a slow reconcile interval are belt-and-braces fallbacks.
- Every transition bumps a monotonic **epoch** and synchronously runs registered reset handlers (`JE.session.onUserChange(name, fn)`), then emits `je:user-changed`.
- Async loaders capture the epoch before awaiting and drop results if the user changed mid-flight (`JE.session.isCurrent(epoch)`), closing the "user A's slow response lands in user B's session" race.

**`plugin.js` re-bootstrap** — on a switch, the per-user globals are wiped, then the incoming user's five config files, user object, admin-only private config, settings, shortcuts and translations are re-fetched (epoch-guarded), and `je:user-data-loaded` re-renders per-user views (bookmarks, hidden content, tags, arr links, active streams) without a reload. A switch that happens mid-boot (before session.js loads) is also detected and repaired.

**Per-feature reset handlers** across every module that holds per-user state, plus epoch guards on every fetch continuation that writes a cache — including debounced/retry save timers (hidden content) that could otherwise erase the incoming user's server-side file.

**Storage hygiene**
- The frozen tag-cache localStorage key NAMES are preserved; a sibling `…:identity-owner` sentinel records which server:user wrote the payload and drops it on mismatch.
- `je_hide_confirm_suppressed_until` and `je.calendar.showUnmonitored` are now per-user (calendar's legacy value is adopted once).
- The `je-spoiler-uid` cookie is rewritten/cleared on every switch.
- Server: `Cache-Control: no-store` on all identity-varying GET endpoints (`user-settings/*`, `tag-cache`, `private-config`, `jellyseerr/user-status`, `spoiler-blur/series`, `arr/requests`).

### Compatibility

Works on Jellyfin 10.11.x and 12 — the mechanism relies only on `ApiClient.setAuthenticationInfo`, the existing `je:navigate` pipeline and plain property reads, no web-client internals.

### Testing

- Automated single-document account-switch E2E (Playwright) on fresh Jellyfin **10.11.11** and **12 (unstable)** containers: login A → UI logout → login B with reload banned (verified via a window marker + `performance.timeOrigin`). Asserts: A's bookmarks wiped at logout, B's bookmarks (and only B's) loaded after switch, `JE.currentUser`/session epoch/spoiler cookie all track the switch. Both pass.
- `node --check` on all changed JS; jf10 (net9.0) and jf12 (net10.0) builds clean; translation validation passes (no new strings); `mkdocs build --strict` passes.
- Three adversarial review rounds (multi-agent + independent model); all confirmed findings fixed — largely in-flight-response races where a fetch spanning the switch could repopulate a freshly cleared cache.

### Notes

- No new settings; no i18n changes. Docs: `project-structure.md` documents the new core module.
- Known limitation: per-user *feature toggles* that gate non-idempotent initializers (people tags, user review tags) still need a reload to newly *enable* for the incoming user; the four base tag renderers re-initialize automatically. Data correctness (no cross-user leakage) is complete regardless.
- On upgrade, the tag/people caches are wiped once when the ownership sentinel is first stamped (they rebuild automatically).

---
*This PR was developed with AI assistance (Claude Code); the implementation has been reviewed, tested end-to-end on both supported Jellyfin versions, and I can explain any part of it.*
