### PR TITLE
Fix German FSK rating colors

### DIFF
--- a/css/ratings.css
+++ b/css/ratings.css
@@ -444,6 +444,48 @@
     border-color: #C2185B !important;
 }
 
+/* === GERMANY: Official FSK color scheme === */
+
+/* FSK 0 — White */
+.mediaInfoOfficialRating[rating='FSK-0'] {
+    background-color: #FFFFFF !important;
+    border-color: #BDBDBD !important;
+    color: #000000 !important;
+    text-shadow: none !important;
+}
+
+/* FSK 6 — Yellow */
+.mediaInfoOfficialRating[rating='FSK-6'] {
+    background-color: #FFEB00 !important;
+    border-color: #D6C600 !important;
+    color: #000000 !important;
+    text-shadow: none !important;
+}
+
+/* FSK 12 — Green */
+.mediaInfoOfficialRating[rating='FSK-12'] {
+    background-color: #12B53F !important;
+    border-color: #07912E !important;
+    color: #000000 !important;
+    text-shadow: none !important;
+}
+
+/* FSK 16 — Blue */
+.mediaInfoOfficialRating[rating='FSK-16'] {
+    background-color: #1597D4 !important;
+    border-color: #0875AB !important;
+    color: #000000 !important;
+    text-shadow: none !important;
+}
+
+/* FSK 18 — Red */
+.mediaInfoOfficialRating[rating='FSK-18'] {
+    background-color: #ED0016 !important;
+    border-color: #B90011 !important;
+    color: #000000 !important;
+    text-shadow: none !important;
+}
+
 /* === BLACK: Refused Classification / Banned === */
 .mediaInfoOfficialRating[rating='AU-RC'],                  /* 🇦🇺 Australia — Refused Classification */
 .mediaInfoOfficialRating[rating='RC'] {                    /* 🇦🇺 Australia — RC (bare label) */


### PR DESCRIPTION
Follow-up to #748.

The German FSK normalization was merged successfully, but the dedicated FSK color overrides were not included in the final merge commit.

This restores the intended official German FSK color scheme:

- FSK-0: white
- FSK-6: yellow
- FSK-12: green
- FSK-16: blue
- FSK-18: red

All FSK labels use black text for readability and to match the official FSK design.