### PR TITLE
fix: honour "Remove from Continue Watching" on Home Screen Sections rows

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/PluginServiceRegistrator.cs
@@ -68,8 +68,9 @@ namespace Jellyfin.Plugin.JellyfinEnhanced
             serviceCollection.AddTransient<ClearTranslationCacheTask>();
 
             // Hidden Content: server-side filter for every native Jellyfin endpoint that surfaces user-facing item lists
-            // (Resume, Items, Latest, NextUp, Upcoming, Suggestions, SearchHints). Same filter handles "Remove from
-            // Continue Watching" via HideScope=continuewatching in hidden-content.json.
+            // (Resume, Items, Latest, NextUp, Upcoming, Suggestions, SearchHints), plus the Home Screen Sections
+            // plugin's own section-content endpoint, which replaces those native lists on an HSS home screen. Same
+            // filter handles "Remove from Continue Watching" via HideScope=continuewatching in hidden-content.json.
             serviceCollection.AddSingleton<MaintenanceModeService>();
             serviceCollection.AddSingleton<HiddenContentResponseFilter>();
             serviceCollection.AddScoped<IEventConsumer<PlaybackStartEventArgs>, ContinueWatchingPlaybackConsumer>();

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/HiddenContentResponseFilter.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/HiddenContentResponseFilter.cs
@@ -35,20 +35,67 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                 _hcCache.TryRemove(userId, out _);
         }
 
-        private static readonly Dictionary<(string, string), (string Surface, ResponseHandler Handler)> _routes
+        // Shared immutable surface sets. Kept as statics so neither route matching nor per-request
+        // surface resolution allocates.
+        private static readonly string[] ContinueWatchingSurface = { "continuewatching" };
+        private static readonly string[] LibrarySurface = { "library" };
+        private static readonly string[] NextUpSurface = { "nextup" };
+        private static readonly string[] UpcomingSurface = { "upcoming" };
+        private static readonly string[] RecommendationsSurface = { "recommendations" };
+        private static readonly string[] SearchSurface = { "search" };
+
+        // A route whose Surfaces is null resolves its surface(s) per request - see ResolveSurfaces.
+        private static readonly Dictionary<(string, string), (string[]? Surfaces, ResponseHandler Handler)> _routes
             = new(KeyComparer.Instance)
         {
-            { ("Items", "GetResumeItems"),         ("continuewatching", FilterQueryResult) },
-            { ("Items", "GetResumeItemsLegacy"),   ("continuewatching", FilterQueryResult) },
-            { ("Items", "GetItems"),               ("library",          FilterQueryResult) },
-            { ("Items", "GetItemsByUserIdLegacy"), ("library",          FilterQueryResult) },
-            { ("UserLibrary", "GetLatestMedia"),       ("library", FilterEnumerable) },
-            { ("UserLibrary", "GetLatestMediaLegacy"), ("library", FilterEnumerable) },
-            { ("TvShows", "GetNextUp"),                ("nextup",          FilterQueryResult) },
-            { ("TvShows", "GetUpcomingEpisodes"),      ("upcoming",        FilterQueryResult) },
-            { ("Suggestions", "GetSuggestions"),       ("recommendations", FilterQueryResult) },
-            { ("Suggestions", "GetSuggestionsLegacy"), ("recommendations", FilterQueryResult) },
-            { ("Search", "GetSearchHints"),            ("search",          FilterSearchHints) },
+            { ("Items", "GetResumeItems"),         (ContinueWatchingSurface, FilterQueryResult) },
+            { ("Items", "GetResumeItemsLegacy"),   (ContinueWatchingSurface, FilterQueryResult) },
+            { ("Items", "GetItems"),               (LibrarySurface,          FilterQueryResult) },
+            { ("Items", "GetItemsByUserIdLegacy"), (LibrarySurface,          FilterQueryResult) },
+            { ("UserLibrary", "GetLatestMedia"),       (LibrarySurface, FilterEnumerable) },
+            { ("UserLibrary", "GetLatestMediaLegacy"), (LibrarySurface, FilterEnumerable) },
+            { ("TvShows", "GetNextUp"),                (NextUpSurface,          FilterQueryResult) },
+            { ("TvShows", "GetUpcomingEpisodes"),      (UpcomingSurface,        FilterQueryResult) },
+            { ("Suggestions", "GetSuggestions"),       (RecommendationsSurface, FilterQueryResult) },
+            { ("Suggestions", "GetSuggestionsLegacy"), (RecommendationsSurface, FilterQueryResult) },
+            { ("Search", "GetSearchHints"),            (SearchSurface,          FilterSearchHints) },
+
+            // Home Screen Sections (IAmParadox27/jellyfin-plugin-home-sections) builds the home rows from
+            // its OWN endpoint instead of Jellyfin's native ones, so on an HSS home screen a "Remove from
+            // Continue Watching" hide that /UserItems/Resume honours came straight back on the next refresh.
+            // Its response is a plain BaseItemDtoQueryResult, so the native handler fits as-is. The surface
+            // is not fixed per route (it depends on which section was asked for), so it is left null here
+            // and resolved from the {sectionType} route value per request. Matching on controller/action
+            // name alone means no compile-time or runtime dependency on the plugin: with HSS absent the
+            // route simply never matches and nothing here runs.
+            { ("HomeScreen", "GetSectionContent"),     (null, FilterQueryResult) },
+        };
+
+        /// <summary>
+        /// Maps a Home Screen Sections section id (its `{sectionType}` route value) to the hide surface(s)
+        /// that row represents. Only the rows that mirror a scoped JE surface are listed; every other
+        /// section falls back to "library" (see <see cref="ResolveSurfaces"/>).
+        /// </summary>
+        /// <remarks>
+        /// Deliberately not listed, and why the "library" fallback is the right answer for each:
+        /// HSS's Upcoming rows are Sonarr/Radarr/Lidarr/Readarr calendar data as synthetic DTOs with a fresh
+        /// Guid per item per request, and its Discover rows are Seerr results with no Jellyfin id at all, so
+        /// no hide entry can ever match either of them whatever surface they are given. Its MyRequests row is
+        /// different — it resolves each request to a real library item, so entries DO match there and the
+        /// fallback means a global hide is honoured (gated by the Library filter toggle rather than the
+        /// Requests one). Mapping that row to "requests" instead is arguable; it is left alone because the
+        /// behaviour could not be verified against a live Seerr-backed install.
+        /// </remarks>
+        private static readonly Dictionary<string, string[]> _homeScreenSectionSurfaces
+            = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "ContinueWatching", ContinueWatchingSurface },
+            { "NextUp",           NextUpSurface },
+            // One row rendering resume items and next-up items together. Both surfaces are in play, but they
+            // are NOT applied to the whole list: each item is judged against the surface it is actually
+            // appearing as (see FilterMixedHomeRow), so a Next-Up hide cannot suppress an episode that is
+            // now in the row as a resume item, and vice versa.
+            { "ContinueWatchingNextUp", new[] { "continuewatching", "nextup" } },
         };
 
         private delegate void ResponseHandler(ActionExecutedContext executed, HideContext hide, string surface, Logger logger);
@@ -91,15 +138,20 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             var hcEnabled = JellyfinEnhanced.Instance?.Configuration?.HiddenContentEnabled == true;
             var rcwEnabled = JellyfinEnhanced.Instance?.Configuration?.RemoveContinueWatchingEnabled == true;
 
-            // /Items doubles as library list + search results — searchTerm wins, then fall back to library.
-            var surface = (route.Surface == "library" && HasSearchTerm(context))
-                ? "search"
-                : route.Surface;
+            var surfaces = ResolveSurfaces(context, route.Surfaces);
 
             // RemoveContinueWatchingEnabled keeps the home-section Remove surfaces (Continue
             // Watching + Next Up) filtering on even when HC's master switch is off.
-            var isRemoveSurface = string.Equals(surface, "continuewatching", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(surface, "nextup", StringComparison.OrdinalIgnoreCase);
+            var isRemoveSurface = false;
+            foreach (var s in surfaces)
+            {
+                if (string.Equals(s, "continuewatching", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(s, "nextup", StringComparison.OrdinalIgnoreCase))
+                {
+                    isRemoveSurface = true;
+                    break;
+                }
+            }
             if (!hcEnabled && !(rcwEnabled && isRemoveSurface))
             {
                 await next().ConfigureAwait(false);
@@ -121,21 +173,111 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             }
 
             // Pure metadata-resolver Ids calls bypass — JE's batchCheckParentSeries cascade caches missing IDs as deleted forever.
-            if (surface == "library" && IsMetadataResolverIdsCall(context))
+            if (surfaces.Length == 1 && surfaces[0] == "library" && IsMetadataResolverIdsCall(context))
             {
                 await next().ConfigureAwait(false);
                 return;
             }
 
             var executed = await next().ConfigureAwait(false);
+
+            // The action threw, so there is no response to filter and no shape to diagnose. Without this
+            // the handler would read a null Result and log a shape-mismatch warning blaming a Jellyfin
+            // upgrade — wrong, and it would burn that surface's hourly warn slot ahead of a genuine one.
+            // Reachable through any endpoint that can fault, including plugin sections doing network I/O.
+            if (executed.Exception is not null && !executed.ExceptionHandled)
+            {
+                return;
+            }
+
             try
             {
-                route.Handler(executed, hide, surface, _logger);
+                if (surfaces.Length > 1)
+                {
+                    FilterMixedHomeRow(executed, hide, _logger);
+                }
+                else
+                {
+                    route.Handler(executed, hide, surfaces[0], _logger);
+                }
             }
             catch (Exception ex)
             {
-                _logger.Error($"HC response filter handler failed for surface '{route.Surface}' — entries will pass through unfiltered for this request: {ex.Message}");
+                _logger.Error($"HC response filter handler failed for surface '{string.Join("+", surfaces)}' — entries will pass through unfiltered for this request: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Filters a home row that renders resume items and next-up items in one list — Home Screen Sections'
+        /// combined "Continue Watching / Next Up" section.
+        /// </summary>
+        /// <remarks>
+        /// Each item is judged against the surface it is actually appearing as rather than against both
+        /// scopes at once: only a resume item carries a playback position. Applying the union to the whole
+        /// list would mean a Next-Up-scoped hide also suppressed that episode once the user had started
+        /// watching it and it had become a Continue Watching entry — invisible on every other surface, since
+        /// the native resume row and HSS's separate Continue Watching row would both still show it. This
+        /// mirrors what the client-side row detector does per card, so the two halves agree.
+        /// </remarks>
+        private static void FilterMixedHomeRow(ActionExecutedContext executed, HideContext hide, Logger logger)
+        {
+            if (executed.Result is not ObjectResult or || or.Value is not QueryResult<BaseItemDto> qr)
+            {
+                WarnShapeMismatchOnce(logger, "continuewatching+nextup", nameof(FilterMixedHomeRow), executed.Result);
+                return;
+            }
+            var items = qr.Items;
+            if (items is null || items.Count == 0) return;
+
+            var kept = new List<BaseItemDto>(items.Count);
+            var dropped = 0;
+            foreach (var item in items)
+            {
+                var surface = (item.UserData?.PlaybackPositionTicks ?? 0) > 0 ? "continuewatching" : "nextup";
+                if (IsHidden(item, hide, surface)) { dropped++; continue; }
+                kept.Add(item);
+            }
+            if (dropped == 0) return;
+
+            or.Value = new QueryResult<BaseItemDto>(
+                qr.StartIndex,
+                Math.Max(0, qr.TotalRecordCount - dropped),
+                kept);
+        }
+
+        /// <summary>
+        /// Resolves the hide surface(s) a request should be filtered against.
+        /// </summary>
+        /// <param name="context">The executing action, for route values and query string.</param>
+        /// <param name="routeSurfaces">The route's fixed surfaces, or null when they are request-dependent.</param>
+        /// <returns>One or more surface names; never empty.</returns>
+        private static string[] ResolveSurfaces(ActionExecutingContext context, string[]? routeSurfaces)
+        {
+            // Home Screen Sections: the row's surface is whichever section was requested.
+            if (routeSurfaces is null)
+            {
+                var sectionType = context.RouteData?.Values is { } rv
+                    && rv.TryGetValue("sectionType", out var rawSection)
+                        ? rawSection as string
+                        : null;
+
+                // Unmapped, unknown and plugin-registered section types fall back to "library" — the same
+                // treatment a native library list gets, so only a global hide reaches them (no scope is
+                // ever stored as "library"). Conservative by design: a future HSS section keeps working
+                // without a JE update, and a row-scoped hide can never over-hide somewhere it shouldn't.
+                return !string.IsNullOrEmpty(sectionType)
+                    && _homeScreenSectionSurfaces.TryGetValue(sectionType, out var sectionSurfaces)
+                        ? sectionSurfaces
+                        : LibrarySurface;
+            }
+
+            // /Items doubles as library list + search results — searchTerm wins, then fall back to library.
+            if (routeSurfaces.Length == 1 && routeSurfaces[0] == "library" && HasSearchTerm(context))
+            {
+                return SearchSurface;
+            }
+
+            return routeSurfaces;
         }
 
         private static bool HasSearchTerm(ActionExecutingContext context)
@@ -161,7 +303,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         private static bool IsRecursiveTrue(IQueryCollection q, string key)
             => q.TryGetValue(key, out var v) && string.Equals(v.ToString().Trim(), "true", StringComparison.OrdinalIgnoreCase);
 
-        private static bool TryGetRoute(ActionExecutingContext context, out (string Surface, ResponseHandler Handler) route)
+        private static bool TryGetRoute(ActionExecutingContext context, out (string[]? Surfaces, ResponseHandler Handler) route)
         {
             route = default;
             var rv = context.RouteData?.Values;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-data.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-data.js
@@ -30,6 +30,22 @@
     // ============================================================
 
     /**
+     * Canonicalises a Jellyfin item ID for comparison.
+     *
+     * Item IDs reach this module in two shapes: the server writes GUIDs dashed
+     * ("N" vs "D" format) into hidden-content.json, while cards carry them
+     * undashed in `data-id`. Comparing the raw strings silently never matches,
+     * so every lookup key and every ID read off the DOM goes through here.
+     * @param {*} id Raw ID from the store, an API payload, or a DOM attribute.
+     * @returns {string} Lowercase, dash-free ID, or '' when there is nothing usable.
+     */
+    function normalizeId(id) {
+        if (!id) return '';
+        if (typeof id !== 'string' && typeof id !== 'number' && typeof id !== 'bigint') return '';
+        return String(id).replace(/-/g, '').toLowerCase();
+    }
+
+    /**
      * Returns the in-memory hidden-content data object, lazily initialised
      * from `JE.userConfig.hiddenContent`.
      * @returns {{ items: Object, settings: Object }}
@@ -82,7 +98,7 @@
             const item = items[key];
             const scope = item.hideScope || 'global';
             if (scope !== 'global') continue;
-            if (item.itemId) hiddenIdSet.add(item.itemId);
+            if (item.itemId) hiddenIdSet.add(normalizeId(item.itemId));
             if (item.tmdbId) hiddenTmdbIdSet.add(String(item.tmdbId));
         }
     }
@@ -238,7 +254,7 @@
         if (!jellyfinItemId) return false;
         const settings = getSettings();
         if (!settings.enabled) return false;
-        return hiddenIdSet.has(jellyfinItemId);
+        return hiddenIdSet.has(normalizeId(jellyfinItemId));
     }
 
     /**
@@ -313,8 +329,15 @@
             restoredJellyfinId = newItems[itemId].itemId || '';
             delete newItems[itemId];
         } else {
-            // Fallback: itemId might be a Jellyfin ID — find the matching storage key
-            const matchingKey = Object.keys(newItems).find(k => newItems[k].itemId === itemId);
+            // Fallback: itemId might be a Jellyfin ID — find the matching storage key.
+            // Compared canonically: the caller usually has an undashed ID off a card, while a
+            // server-written entry stores it dashed, and a raw comparison would silently no-op.
+            // Guarded against an empty/unusable argument, which would otherwise normalise to ''
+            // and match the first TMDB-only entry (those carry no itemId).
+            const wanted = normalizeId(itemId);
+            const matchingKey = wanted
+                ? Object.keys(newItems).find(k => normalizeId(newItems[k].itemId) === wanted)
+                : undefined;
             if (matchingKey) {
                 restoredJellyfinId = newItems[matchingKey].itemId || itemId || '';
                 delete newItems[matchingKey];
@@ -412,7 +435,7 @@
 
         return events.filter((event) => {
             if (event.tmdbId && hiddenTmdbIdSet.has(String(event.tmdbId))) return false;
-            if (event.itemId && hiddenIdSet.has(event.itemId)) return false;
+            if (event.itemId && hiddenIdSet.has(normalizeId(event.itemId))) return false;
             if (event.title && hiddenNames.has(event.title.toLowerCase())) return false;
             return true;
         });
@@ -429,7 +452,7 @@
         return items.filter((item) => {
             const tmdbId = item.tmdbId || item.id;
             if (tmdbId && hiddenTmdbIdSet.has(String(tmdbId))) return false;
-            if (item.jellyfinMediaId && hiddenIdSet.has(item.jellyfinMediaId)) return false;
+            if (item.jellyfinMediaId && hiddenIdSet.has(normalizeId(item.jellyfinMediaId))) return false;
             return true;
         });
     }
@@ -478,6 +501,7 @@
 
     Object.assign(internal, {
         hiddenIdSet,
+        normalizeId,
         getHiddenData,
         getSettings,
         rebuildSets,

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-filter.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-filter.js
@@ -13,7 +13,7 @@
     JE.internals = JE.internals || {};
     const internal = JE.internals.hiddenContent = JE.internals.hiddenContent || {};
 
-    const { hiddenIdSet, getSettings, shouldFilterSurface, getHiddenData, getHiddenCount } = internal;
+    const { hiddenIdSet, normalizeId, getSettings, shouldFilterSurface, getHiddenData, getHiddenCount } = internal;
     // Late-bound cross-module reference (defined in hidden-content-buttons.js).
     const addLibraryHideButtons = (...args) => internal.addLibraryHideButtons(...args);
 
@@ -100,11 +100,21 @@
     // ============================================================
 
     /**
-     * Detects the surface context of a card by checking parent section headers.
+     * Detects which home surface a card is displayed on.
+     *
+     * Delegates to the Remove feature's row detector, so a card is classified the same way
+     * when it is hidden and when it is filtered back out. The two used to disagree: this one
+     * matched only the English headings "Next Up" / "Continue Watching", so on a translated
+     * client it classified nothing and scope-hidden items came back on the next render.
+     * Note this is the strict, row-gated detector — a Continue Watching hide must not blank
+     * the same item where it also appears in, say, a Recently Added row.
      * @param {HTMLElement} card The card element to check.
      * @returns {'nextup'|'continuewatching'|null} The detected surface or null.
      */
     function getCardSurface(card) {
+        if (typeof JE.detectCardRowSurface === 'function') return JE.detectCardRowSurface(card);
+
+        // Fallback for the (unsupported) case of the Remove module not being loaded.
         const section = card.closest('.section, .verticalSection, .homeSection');
         if (!section) return null;
         if (sectionSurfaceCache.has(section)) return sectionSurfaceCache.get(section);
@@ -133,10 +143,11 @@
 
         const data = getHiddenData();
         const items = data.items || {};
+        const wanted = normalizeId(itemId);
 
         for (const key of Object.keys(items)) {
             const item = items[key];
-            if (item.itemId !== itemId) continue;
+            if (normalizeId(item.itemId) !== wanted) continue;
             const scope = item.hideScope || 'global';
             if (scope === 'global') return true;
             if (scope === surface) return true;
@@ -155,8 +166,10 @@
      * @returns {string|null} The item ID, or null if not found.
      */
     function getCardItemId(el) {
-        if (el.dataset && el.dataset.id) return el.dataset.id;
-        if (el.dataset && el.dataset.itemid) return el.dataset.itemid;
+        // Normalised so it can be compared against store keys directly — the store
+        // holds dashed GUIDs when the server wrote the entry, undashed when the client did.
+        if (el.dataset && el.dataset.id) return normalizeId(el.dataset.id);
+        if (el.dataset && el.dataset.itemid) return normalizeId(el.dataset.itemid);
         return null;
     }
 
@@ -300,15 +313,23 @@
      */
     function restoreNativeCardsForIds(idsToRestore) {
         if (!idsToRestore || idsToRestore.size === 0) return;
+        // Callers pass IDs straight from the store or from an unhide argument, so they may be
+        // dashed; the IDs they are matched against here are not. Canonicalise once, up front.
+        const wanted = new Set();
+        idsToRestore.forEach((id) => {
+            const norm = normalizeId(id);
+            if (norm) wanted.add(norm);
+        });
+        if (wanted.size === 0) return;
         document.querySelectorAll(CARD_SEL).forEach((card) => {
             card.removeAttribute(PROCESSED_ATTR);
             const cardId = getCardItemId(card);
-            const hiddenBySeriesId = card.getAttribute(HIDDEN_PARENT_ATTR);
-            if (hiddenBySeriesId && idsToRestore.has(hiddenBySeriesId) && card.classList.contains('je-hidden')) {
+            const hiddenBySeriesId = normalizeId(card.getAttribute(HIDDEN_PARENT_ATTR));
+            if (hiddenBySeriesId && wanted.has(hiddenBySeriesId) && card.classList.contains('je-hidden')) {
                 card.classList.remove('je-hidden');
                 card.removeAttribute(HIDDEN_PARENT_ATTR);
                 card.removeAttribute(HIDDEN_DIRECT_ATTR);
-            } else if ((cardId && idsToRestore.has(cardId)) || card.getAttribute(HIDDEN_DIRECT_ATTR) === '1') {
+            } else if ((cardId && wanted.has(cardId)) || card.getAttribute(HIDDEN_DIRECT_ATTR) === '1') {
                 card.classList.remove('je-hidden');
                 card.removeAttribute(HIDDEN_DIRECT_ATTR);
             }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/homeremoval/features-remove-home.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/homeremoval/features-remove-home.js
@@ -113,38 +113,231 @@
     // ~150ms of a menu opening; this bounds how stale a context can be before we ignore it.
     const REMOVE_CONTEXT_TTL_MS = 5000;
 
+    // Section-level surface verdict, cached per section element so a full-page card scan does
+    // not re-query the same row's title/link once per card. Keyed weakly, so a re-rendered
+    // section is re-evaluated rather than keeping a stale entry alive. Replaced wholesale when the
+    // home-section configuration arrives, since verdicts reached without it may have been guesses.
+    let sectionSurfaceCache = new WeakMap();
+
+    // Home Screen Sections stamps its section id onto the row element as a class, which is a
+    // locale-independent identifier for the rows JE cares about. 'both' means the row renders
+    // resume items and next-up items together, so only the card itself can say which it is.
+    const HSS_ROW_CLASS_SURFACE = {
+        continuewatching: 'continuewatching',
+        nextup: 'nextup',
+        continuewatchingnextup: 'both',
+    };
+
+    // jellyfin-web builds the home screen by reading the user's own `homesection{N}` preferences and
+    // rendering one `sectionN` slot per entry, so that config states outright what each row is. Mirrors
+    // homesections.js: the same defaults, the same 'folders' alias, and the same TV-layout behaviour of
+    // prepending a library row (which shifts every index) when none is configured.
+    const HOME_SECTION_DEFAULTS = Object.freeze([
+        'smalllibrarytiles', 'resume', 'resumeaudio', 'resumebook',
+        'livetv', 'nextup', 'latestmedia', 'none',
+    ]);
+    const HOME_SECTION_SLOTS = 10;
+    // Video, audio and book resume rows are all "continue" rows and all carry playback positions.
+    const RESUME_SECTION_TYPES = new Set(['resume', 'resumeaudio', 'resumebook']);
+
+    /** CustomPrefs of the current user's `usersettings` display preferences, or null until fetched. */
+    let homeSectionPrefs = null;
+    /** User the snapshot belongs to, so a user switch cannot be answered from the previous user's config. */
+    let homeSectionPrefsUserId = null;
+    let homeSectionPrefsInFlight = false;
+    /** Per-container memo of the resolved slot list, rebuilt whenever the snapshot changes. */
+    let configuredSectionsCache = new WeakMap();
+
     /**
-     * Determines which home-screen surface a card belongs to, using locale-independent
-     * signals so detection survives translated section titles and custom themes:
-     *   • Next Up — the section title is a link to the Next Up list (`?type=nextup`).
-     *   • Continue Watching — resume cards carry a `data-positionticks` playback position.
-     * A localized section-title text check is kept as a last-resort fallback.
+     * Fetches the current user's home-section configuration once, in the background.
+     *
+     * Deliberately fire-and-forget: until it lands, classifyRow falls through to the markup signals,
+     * which are correct on their own — this only replaces inference with the actual configuration.
+     * A failed fetch is not retried; the fallbacks stay in charge.
+     */
+    function primeHomeSectionPrefs() {
+        let userId = null;
+        try { userId = window.ApiClient?.getCurrentUserId?.() || null; } catch (e) { return; }
+        if (!userId) return;
+        if (homeSectionPrefsUserId === userId && (homeSectionPrefs || homeSectionPrefsInFlight)) return;
+
+        homeSectionPrefsUserId = userId;
+        homeSectionPrefs = null;
+        homeSectionPrefsInFlight = true;
+        configuredSectionsCache = new WeakMap();
+
+        Promise.resolve()
+            .then(() => window.ApiClient.getDisplayPreferences('usersettings', userId, 'emby'))
+            .then((prefs) => {
+                if (homeSectionPrefsUserId !== userId) return;
+                homeSectionPrefs = prefs?.CustomPrefs || {};
+                // Verdicts cached from the fallback path were reached without this config — drop them
+                // so every row is re-read against it.
+                configuredSectionsCache = new WeakMap();
+                sectionSurfaceCache = new WeakMap();
+            })
+            .catch((e) => {
+                console.warn('🪼 Jellyfin Enhanced: home-section preferences unavailable, falling back to row markup', e);
+            })
+            .then(() => {
+                if (homeSectionPrefsUserId === userId) homeSectionPrefsInFlight = false;
+            });
+    }
+
+    /** The `N` of a `sectionN` class, or null when the element carries none. */
+    function sectionSlotIndex(section) {
+        for (const cls of section.classList) {
+            const match = /^section(\d+)$/.exec(cls);
+            if (match) return Number.parseInt(match[1], 10);
+        }
+        return null;
+    }
+
+    /** Resolves the container's slot list from the user's config, memoised per container element. */
+    function configuredSectionTypes(container) {
+        if (!homeSectionPrefs) return null;
+        const cached = configuredSectionsCache.get(container);
+        if (cached) return cached;
+
+        const types = [];
+        for (let i = 0; i < HOME_SECTION_SLOTS; i++) {
+            let type = homeSectionPrefs[`homesection${i}`] || HOME_SECTION_DEFAULTS[i] || '';
+            if (type === 'folders') type = HOME_SECTION_DEFAULTS[0];
+            types.push(String(type).toLowerCase());
+        }
+        // An 11th slot only exists on the TV layout, where a library row was prepended.
+        if (container.querySelector(':scope > .section10')
+            && !types.includes('smalllibrarytiles') && !types.includes('librarybuttons')) {
+            types.unshift('smalllibrarytiles');
+        }
+
+        const frozen = Object.freeze(types);
+        configuredSectionsCache.set(container, frozen);
+        return frozen;
+    }
+
+    /**
+     * Identifies a native home row from the user's home-section configuration.
+     * @param {Element} section The row element.
+     * @returns {'continuewatching'|'nextup'|'other'|null} 'other' means the config positively says this
+     *   slot is something else; null means the config cannot answer and the caller should fall back.
+     */
+    function nativeRowKindFromPreferences(section) {
+        const container = section.closest('.homeSectionsContainer');
+        if (!container) return null;
+        const index = sectionSlotIndex(section);
+        if (index === null) return null;
+
+        primeHomeSectionPrefs();
+        const types = configuredSectionTypes(container);
+        const type = types ? types[index] : null;
+        if (!type || type === 'none') return null;
+
+        if (RESUME_SECTION_TYPES.has(type)) return 'continuewatching';
+        if (type === 'nextup') return 'nextup';
+        return 'other';
+    }
+
+    /**
+     * Classifies a home row as Continue Watching, Next Up, both, or neither — using the row's
+     * own markup rather than its (translated) heading wherever possible.
+     * @param {Element} section A `.section` / `.verticalSection` / `.homeSection` element.
+     * @returns {'continuewatching'|'nextup'|'both'|null}
+     */
+    function classifyRow(section) {
+        for (const cls of section.classList) {
+            const hit = HSS_ROW_CLASS_SURFACE[cls.toLowerCase()];
+            if (hit) return hit;
+        }
+
+        // A Home Screen Sections row is fully described by the class checked above, and it is
+        // the ONLY thing that describes it: HSS stamps jellyfin-web's playback-monitor marker
+        // onto every row it renders, including Recently Added, so the native test below would
+        // read those as resume rows. Its rows are identifiable by the page index it tags them
+        // with, so stop here rather than fall through to a marker it overloads.
+        if (section.hasAttribute('data-page')) return null;
+
+        // What the user actually configured this slot to be. Exact when available, and authoritative
+        // in both directions: 'other' ends the search rather than letting a weaker signal override it.
+        const configured = nativeRowKindFromPreferences(section);
+        if (configured === 'continuewatching' || configured === 'nextup') return configured;
+        if (configured === 'other') return null;
+
+        // Native Next Up: its heading links to the Next Up list. Absent on the TV layout,
+        // which renders a bare <h2> — that case is caught by the data-monitor test below.
+        if (section.querySelector('a[href*="type=nextup"]')) return 'nextup';
+
+        // Resume and Next Up are the only home rows jellyfin-web asks to re-render on playback
+        // events, so a monitored row is one of the two. Both carry the same marker, so the
+        // caller's per-card playback position decides which.
+        const monitored = section.querySelector('.itemsContainer[data-monitor]');
+        if (monitored && /playback/i.test(monitored.getAttribute('data-monitor') || '')) return 'both';
+
+        // Last resort for themes/markup with none of the above: the (English) heading text.
+        const title = (section.querySelector('.sectionTitle, h2, .headerText, .sectionTitle-sectionTitle')?.textContent || '')
+            .toLowerCase().trim();
+        if (title.includes('next up')) return 'nextup';
+        if (title.includes('continue watching')) return 'continuewatching';
+        return null;
+    }
+
+    /**
+     * Determines the home surface a card is being *displayed on*, or null when it is not in a
+     * Continue Watching / Next Up row at all.
+     *
+     * Strict by design: a resume item also appears in rows like "Recently Added", and those
+     * cards carry a playback position too, so treating the position alone as proof of surface
+     * would let a Continue-Watching-scoped hide blank the item everywhere it shows up. The row
+     * decides the kind; the card's playback position only disambiguates a combined row (Home
+     * Screen Sections renders one "Continue Watching / Next Up" section holding both).
      * @param {Element} el A `.card` element, or any element inside/representing one.
      * @returns {'continuewatching'|'nextup'|null}
      */
-    JE.detectCardSurface = function(el) {
+    JE.detectCardRowSurface = function(el) {
         if (!el) return null;
         const card = (typeof el.closest === 'function' ? el.closest('.card') : null) || el;
         const section = typeof card.closest === 'function'
             ? card.closest('.section, .verticalSection, .homeSection')
             : null;
+        if (!section) return null;
 
-        // Next Up: the section title links to the Next Up list — present regardless of locale.
-        if (section && section.querySelector('a[href*="type=nextup"]')) return 'nextup';
+        // Only the row-level verdict is cached — the per-card test below always runs, so a
+        // resume card in a combined row is never served a stale "nextup".
+        let kind;
+        if (sectionSurfaceCache.has(section)) {
+            kind = sectionSurfaceCache.get(section);
+        } else {
+            kind = classifyRow(section);
+            sectionSurfaceCache.set(section, kind);
+        }
+        if (!kind) return null;
+        if (kind !== 'both') return kind;
 
-        // Continue Watching: only resume cards expose a playback position.
         const ticks = (card.getAttribute && card.getAttribute('data-positionticks'))
             || (el.getAttribute && el.getAttribute('data-positionticks'));
-        if (ticks) return 'continuewatching';
+        return ticks ? 'continuewatching' : 'nextup';
+    };
 
-        // Fallback for markup/themes without the link or ticks: localized section title text.
-        if (section) {
-            const title = (section.querySelector('.sectionTitle, h2, .headerText, .sectionTitle-sectionTitle')?.textContent || '')
-                .toLowerCase().trim();
-            if (title.includes('next up')) return 'nextup';
-            if (title.includes('continue watching')) return 'continuewatching';
-        }
-        return null;
+    /**
+     * Which surface a Remove action on this card should be scoped to.
+     *
+     * Deliberately more generous than {@link JE.detectCardRowSurface}: when the row cannot be
+     * identified (a custom theme, an unrecognised layout) a card that carries a playback
+     * position is still a Continue Watching item, and offering Remove there is useful — the
+     * worst case is writing a scope for a surface the user was not looking at, which hides
+     * nothing extra. Filtering cannot afford the same guess, which is why it is a separate call.
+     * @param {Element} el A `.card` element, or any element inside/representing one.
+     * @returns {'continuewatching'|'nextup'|null}
+     */
+    JE.detectCardSurface = function(el) {
+        if (!el) return null;
+        const row = JE.detectCardRowSurface(el);
+        if (row) return row;
+
+        const card = (typeof el.closest === 'function' ? el.closest('.card') : null) || el;
+        const ticks = (card.getAttribute && card.getAttribute('data-positionticks'))
+            || (el.getAttribute && el.getAttribute('data-positionticks'));
+        return ticks ? 'continuewatching' : null;
     };
 
     /**

--- a/docs/enhanced/enhanced-features.md
+++ b/docs/enhanced/enhanced-features.md
@@ -102,6 +102,7 @@ A lightweight, **non-destructive** way to tidy the home screen. It adds a **Remo
 - Hidden state is stored **server-side, per-user**, so it applies across all your devices and survives reloads
 - **Undoable:** removed items appear in the **Hidden Content** management page with an "Add back" button, and simply resuming a hidden item unhides it automatically
 - Works on its own — it does not require the full Hidden Content feature to be enabled
+- Also applies to home screens rendered by the [Home Screen Sections](https://github.com/IAmParadox27/jellyfin-plugin-home-sections) plugin, including its combined *Continue Watching / Next Up* row
 
 ![Bulk removal confirmation listing each item and its row](../images/remove-confirm.png)
 

--- a/docs/faq-support/faq.md
+++ b/docs/faq-support/faq.md
@@ -298,6 +298,7 @@ This is usually due to TMDB API access issues.
 - Adds a **Remove** option to an item's "⋯" menu (and to the long-press / multi-select menu on touch devices) for Continue Watching and Next Up items
 - Hides the item from that row only — your progress is **not** reset and the item is **not** marked played
 - The hidden state is stored server-side per-user, so it applies across all your devices
+- It is enforced server-side, so the row stays tidy on every client — including home screens built by the [Home Screen Sections](https://github.com/IAmParadox27/jellyfin-plugin-home-sections) plugin
 
 **Can it be undone?**
 


### PR DESCRIPTION
## Description

Fixes "Remove from Continue Watching" not sticking: the item disappears, but comes back on the next refresh.

Closes #750

There turned out to be two independent reasons an item can come back, so this is two commits. The first is
what the reporter hit; the second is why nothing caught it.

### 1. Home Screen Sections rows were never filtered

Remove-from-Continue-Watching is enforced **server-side**: the hide is written to `hidden-content.json` and
`HiddenContentResponseFilter` strips the item from the list endpoints that render the row. That filter's route
table only knew about Jellyfin's own controllers (`Items.GetResumeItems`, `TvShows.GetNextUp`, …).

The [Home Screen Sections](https://github.com/IAmParadox27/jellyfin-plugin-home-sections) plugin doesn't use
those endpoints — it builds **every** home row from its own `GET /HomeScreen/Section/{sectionType}`. That
endpoint was never filtered, so on an HSS home screen the card vanished optimistically, the hide was written
correctly, and then it came straight back.

Reproduced on a clean 10.11.11 container (JE 12.2.0.0 + File Transformation 2.5.11.0 + HSS 2.5.11.0):

```
after "Remove from Continue Watching":
  /UserItems/Resume                    -> Alpha Movie, Test Show S01E01           (filtered, correct)
  /HomeScreen/Section/ContinueWatching -> Beta Movie, Alpha Movie, Test Show ...  (unfiltered, item is back)
```

Two details made this more than a one-line table entry:

* **The surface isn't fixed per route** — it depends on which section was requested. That entry's surfaces are
  `null` and `ResolveSurfaces` derives them per request from the `{sectionType}` route value:
  `ContinueWatching` → `continuewatching`, `NextUp` → `nextup`, everything else → `library`, so unknown and
  future section types still get global hides applied and no JE update is needed when HSS adds one.
* **HSS has a combined `ContinueWatchingNextUp` row** that renders resume items and next-up items in one
  list. Both scopes are in play there, but they are applied *per item* rather than to the whole list: only a
  resume item carries a playback position, so that is what decides which surface each item is appearing as.
  Applying the union to the entire row would mean a Next-Up hide also suppressed that episode once the user
  started watching it and it became a Continue Watching entry — invisible everywhere else, since the native
  resume row and HSS's separate Continue Watching row would both still show it. This matches what the
  client-side detector does per card, so the two halves agree.

Matching is by controller/action name only, so there is **no compile-time or runtime dependency on the
plugin**: with HSS absent the route never matches and nothing runs. Behaviour of every existing native route
is unchanged, including the `/Items` + `searchTerm` → `search` special case and the metadata-resolver `Ids`
bypass.

### 2. The client-side filter could never match anything

JE also filters cards in the DOM, which is what should have made the gap above invisible to users. It was
broken in two ways, so it had been doing nothing for scoped hides:

* **ID format.** The server writes GUIDs dashed into `hidden-content.json`; card `data-id` attributes are
  undashed. They were compared raw, so a server-written entry never matched a card. A `normalizeId` helper now
  sits on every store/DOM comparison. The same mismatch also made `unhideItem`'s fallback lookup miss, so
  un-hiding such an entry from a details page or a card button silently did nothing.
* **Row identification by heading text.** A card's row was identified by matching the English strings
  `"continue watching"` / `"next up"` in the heading, so on a translated client nothing was ever classified.
  A native row is now read from the user's own `homesection{N}` settings — the same configuration
  jellyfin-web itself builds the home screen from, and which states outright what each `sectionN` slot is —
  so the answer is exact rather than inferred, in any language. That config is fetched once per user in the
  background; until it arrives, and for rows it cannot describe (HSS rows, and the per-library sub-rows
  inside the Latest Media slot), detection falls back to markup: HSS's section-id class, jellyfin-web's Next
  Up link, and the `data-monitor` marker it sets only on its resume and next-up rows, with the heading last.
  A row holding both kinds at once is resolved per card by its playback position.

Detection is deliberately **split in two**, because the two callers are asking different questions.
Filtering and the library hide button need the strict row test: a resume item also appears in rows like
Recently Added and those cards carry a playback position too, so treating the position alone as proof of
surface would blank the item wherever it appears. Choosing the scope to *write* for a Remove action stays
generous and keeps its previous behaviour.

## Implementation Notes

This PR was developed with AI assistance (Claude). I have reviewed and tested all changes and understand the
implementation.

## Testing

Verified on a purpose-built Jellyfin **10.11.11** container (JE 12.2.0.0, File Transformation 2.5.11.0, Home
Screen Sections 2.5.11.0) with a generated library, driven through the real web UI with Playwright as both an
admin and a non-admin account. Native-surface regressions were re-checked separately against a 10.11 server
with a real library.

- [x] Tested on Jellyfin 10.11
- [x] Verified no basic errors

**The reported bug**

- [x] Remove from Continue Watching on an HSS home screen → item stays gone after a full page reload
- [x] Same item also gone from HSS's combined *Continue Watching / Next Up* row
- [x] `/HomeScreen/Section/ContinueWatching` now matches `/UserItems/Resume` exactly
- [x] `/HomeScreen/Section/NextUp` honours a Next-Up-scoped hide; native `/Shows/NextUp` agrees
- [x] Combined row drops both a CW-scoped and a Next-Up-scoped hide, keeps everything else
- [x] Combined row resolves scope per item: an episode hidden from Next Up is dropped while it *is* a Next Up
      item, and comes back once it has a playback position and belongs in Continue Watching — matching the
      native resume row and HSS's separate Continue Watching row
- [x] An action that throws (a plugin section doing network I/O to a service that is down) is left alone
      rather than being reported as a response-shape change

**No over-hiding**

- [x] A Continue Watching hide does **not** remove the item from `/Items`, Recently Added, or any library row
- [x] Unmapped HSS section (`RecentlyAddedMovies`) drops a *global* hide but not a scoped one
- [x] Per-user isolation through HSS's section cache: two users with different hides each see only their own

**Client-side filter**

- [x] With the server-side half deliberately absent, the DOM filter alone keeps the item hidden after reload —
      i.e. it now works as the backstop it was meant to be
- [x] On an Italian client: "Continua a guardare" → `continuewatching`, combined row → per card,
      "Film aggiunti di recente" → `null`, native Next Up row → `nextup`
- [x] Row identity follows the user's configuration, not the markup: with Continue Watching moved to a
      different `homesection` slot it is still resolved correctly, and a row relabelled into a slot the user
      configured as Next Up resolves as `nextup` even though its markup and card playback positions say
      resume — i.e. the configuration is authoritative where the two disagree
- [x] Falls back cleanly when the configuration has not loaded yet or cannot describe a row
- [x] Hide/unhide round-trips with both dashed and undashed IDs, including removing the store entry
- [x] Library hide button still writes a *global* hide outside a Continue Watching / Next Up row

**Build**

- [x] Compiles clean for both targets (net9.0 / 10.11 and net10.0 / 12), no new warnings
- [x] `validate-translations.js validate` passes (no new keys)
- [x] `mkdocs build --strict` passes

No new settings, no new translation keys, no UI changes — so no screenshots. Docs updated in
`enhanced-features.md` and `faq.md` to say the removal is honoured on HSS home screens.

## Not included

While tracking this down I found a third, unrelated way to get the same symptom, with no other plugin
involved: the "Remove from Continue Watching" toggle in the user settings panel is per-user, but the
server-side filter is gated on the admin-level `RemoveContinueWatchingEnabled` / `HiddenContentEnabled`
config, both of which default to `false`. A user who enables the toggle themselves on a server where the admin
never did gets the menu item, a successful hide, and no filtering — so the item returns on every client, and
the workaround is for the admin to enable it in the plugin config.

That looked like a deliberate design decision rather than a bug, so I've left it alone. Happy to open it as a
separate issue or PR if you'd like it changed.
