### PR TITLE
feat(spoiler-guard): advanced per-category reveals for the next unwatched episode and current season

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
@@ -332,6 +332,19 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             SpoilerBlurStrictRefresh = false;
             SpoilerKeepMoviePosters = true;
             SpoilerOverviewPlaceholder = "Spoiler Guard activated";
+
+            // Advanced per-category reveals. Off by default so existing
+            // installs keep today's uniform strip. Category strip toggles
+            // default to the strictest posture except the next-episode
+            // title — the whole point of advanced mode (you should be able
+            // to see WHAT you're about to watch, and nothing more).
+            SpoilerAdvancedMode = false;
+            SpoilerNextEpisodeStripTitle = false;
+            SpoilerNextEpisodeStripOverview = true;
+            SpoilerNextEpisodeStripRatings = true;
+            SpoilerCurrentSeasonStripTitle = true;
+            SpoilerCurrentSeasonStripOverview = true;
+            SpoilerCurrentSeasonStripRatings = true;
         }
 
         // Maintenance Mode
@@ -752,6 +765,23 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         // are usually curated marketing art, while chapter scene-thumbs (and
         // synopsis/cast) are the real spoiler vector. Off = hide posters too.
         public bool SpoilerKeepMoviePosters { get; set; } = true;
+        // Advanced per-category reveals. When on, the user's NEXT unwatched
+        // regular episode and the rest of its season get their own strip masks
+        // below instead of the uniform full strip; every other unwatched
+        // episode (later seasons, skipped earlier seasons, specials) keeps the
+        // full strip. Category resolution failure of any kind falls back to
+        // the full strip.
+        public bool SpoilerAdvancedMode { get; set; } = false;
+        // Per-category field masks, same "true = strip" polarity as the base
+        // toggles above. A category mask can only RELAX a base strip that is
+        // already on — it never strips a field whose base toggle (or the
+        // user's per-field opt-out) has disabled stripping.
+        public bool SpoilerNextEpisodeStripTitle { get; set; } = false;
+        public bool SpoilerNextEpisodeStripOverview { get; set; } = true;
+        public bool SpoilerNextEpisodeStripRatings { get; set; } = true;
+        public bool SpoilerCurrentSeasonStripTitle { get; set; } = true;
+        public bool SpoilerCurrentSeasonStripOverview { get; set; } = true;
+        public bool SpoilerCurrentSeasonStripRatings { get; set; } = true;
         // Placeholder for stripped Overview so the client doesn't render a
         // "Description" header over blank. Configurable for localisation.
         public string SpoilerOverviewPlaceholder { get; set; } = "Spoiler Guard activated";

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfiguration.cs
@@ -134,6 +134,13 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public bool? ReplaceEpisodeTitles { get; set; }
         public bool? HideCast { get; set; }
         public bool? HideReviews { get; set; }
+        // Advanced per-category reveals (admin default: SpoilerAdvancedMode).
+        // Unlike the per-field opt-outs above, `false` here is the STRICTER
+        // choice: it opts this user out of the category reveals entirely,
+        // restoring the uniform full strip. null = inherit the admin mode;
+        // true is recorded but never enables the mode when the admin has it
+        // off (the admin switch still gates everything).
+        public bool? UseAdvancedCategories { get; set; }
         // Persist the in-dialog "Don't ask again for 15 minutes" snooze as a
         // permanent user choice instead of a session timer.
         public bool SkipDisableConfirm { get; set; }

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/configPage.html
@@ -492,6 +492,33 @@
                                     </div>
                                 </div>
                             </details>
+
+                            <details class="je-details-section" data-gated-by="spoilerBlurEnabled">
+                                <summary>Advanced per-category reveals</summary>
+                                <div class="je-details-body">
+                                    <div class="checkboxContainer"><label><input id="spoilerAdvancedMode" is="emby-checkbox" type="checkbox"/><span>Enable advanced per-category reveals</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="spoilerAdvancedMode">
+                                        <div class="fieldDescription">Instead of one uniform strip for every unwatched episode, the user's <strong>next</strong> unwatched episode and the rest of its season get the reveal settings below. Later seasons, skipped earlier seasons and specials always keep the full strip. A reveal only relaxes a strip that is enabled above — categories whose strip is off show everywhere already. Each user can opt back into the uniform full strip from their settings panel.</div>
+                                    </div>
+
+                                    <div class="je-info-banner-inline-center" style="margin-bottom: 15px;" data-gated-by="spoilerAdvancedMode">
+                                        <div class="je-info-banner-row">
+                                            <i class="material-icons je-info-icon">visibility</i>
+                                            <div>Checked = still hidden for that category. Unchecked = revealed. The next-episode title starts revealed — that's the point of advanced mode: see <em>what</em> you're about to watch, and nothing more.</div>
+                                        </div>
+                                    </div>
+
+                                    <div class="checkboxContainer"><label><input id="spoilerNextEpisodeStripTitle" is="emby-checkbox" type="checkbox"/><span>Next episode: keep title hidden</span></label></div>
+                                    <div class="checkboxContainer"><label><input id="spoilerNextEpisodeStripOverview" is="emby-checkbox" type="checkbox"/><span>Next episode: keep description hidden</span></label></div>
+                                    <div class="checkboxContainer"><label><input id="spoilerNextEpisodeStripRatings" is="emby-checkbox" type="checkbox"/><span>Next episode: keep ratings hidden</span></label></div>
+                                    <div class="checkboxContainer"><label><input id="spoilerCurrentSeasonStripTitle" is="emby-checkbox" type="checkbox"/><span>Current season: keep titles hidden</span></label></div>
+                                    <div class="checkboxContainer"><label><input id="spoilerCurrentSeasonStripOverview" is="emby-checkbox" type="checkbox"/><span>Current season: keep descriptions hidden</span></label></div>
+                                    <div class="checkboxContainer"><label><input id="spoilerCurrentSeasonStripRatings" is="emby-checkbox" type="checkbox"/><span>Current season: keep ratings hidden</span></label></div>
+                                    <div class="je-setting-description" data-desc-for="spoilerCurrentSeasonStripRatings">
+                                        <div class="fieldDescription">"Current season" is the season containing the next unwatched episode. Card rating overlays and search results stay fully protected regardless of these reveals; only the episode metadata itself (lists and detail pages) is revealed.</div>
+                                    </div>
+                                </div>
+                            </details>
                         </div>
                     </fieldset>
 
@@ -4761,6 +4788,17 @@
                     ['spoilerAutoEnableOnSeerrRequest','SpoilerAutoEnableOnSeerrRequest',false],
                     ['spoilerBlurStrictRefresh',    'SpoilerBlurStrictRefresh',    false],
                     ['spoilerKeepMoviePosters',     'SpoilerKeepMoviePosters',     true],
+                    // Advanced per-category reveals. The master switch is off
+                    // for existing installs; the category masks keep the
+                    // strictest posture except the next-episode title, which
+                    // is the reveal advanced mode exists for.
+                    ['spoilerAdvancedMode',              'SpoilerAdvancedMode',              false],
+                    ['spoilerNextEpisodeStripTitle',     'SpoilerNextEpisodeStripTitle',     false],
+                    ['spoilerNextEpisodeStripOverview',  'SpoilerNextEpisodeStripOverview',  true],
+                    ['spoilerNextEpisodeStripRatings',   'SpoilerNextEpisodeStripRatings',   true],
+                    ['spoilerCurrentSeasonStripTitle',   'SpoilerCurrentSeasonStripTitle',   true],
+                    ['spoilerCurrentSeasonStripOverview','SpoilerCurrentSeasonStripOverview',true],
+                    ['spoilerCurrentSeasonStripRatings', 'SpoilerCurrentSeasonStripRatings', true],
                 ].forEach(function (t) {
                     var el = document.querySelector('#' + t[0]);
                     if (!el) return;
@@ -5142,6 +5180,11 @@
                 'spoilerBlurArtwork', 'spoilerAutoEnableOnFirstPlay',
                 'spoilerAutoEnableOnSeerrRequest', 'spoilerBlurStrictRefresh',
                 'spoilerKeepMoviePosters',
+                'spoilerAdvancedMode',
+                'spoilerNextEpisodeStripTitle', 'spoilerNextEpisodeStripOverview',
+                'spoilerNextEpisodeStripRatings',
+                'spoilerCurrentSeasonStripTitle', 'spoilerCurrentSeasonStripOverview',
+                'spoilerCurrentSeasonStripRatings',
             ].forEach(function (id) {
                 var el = document.querySelector('#' + id);
                 if (!el) return;
@@ -6225,8 +6268,9 @@
             { parent: 'triggerSeerrScanOnItemAdded', label: 'Trigger Seerr scan on item added', children: ['seerrScanDebounceSeconds'] },
             { parent: 'bookmarksEnabled', label: 'Enable Bookmarks', children: ['bookmarksUsePluginPages', 'bookmarksUseNativeTab', 'bookmarksUseCustomTabs'] },
             { parent: 'hiddenContentEnabled', label: 'Enable Hidden Content', children: ['hiddenContentUsePluginPages', 'hiddenContentUseNativeTab', 'hiddenContentUseCustomTabs'] },
-            { parent: 'spoilerBlurEnabled', label: 'Enable Spoiler Guard', children: ['spoilerBlurIntensity', 'spoilerBlurArtwork', 'spoilerStripSeriesOverview', 'spoilerStripOverview', 'spoilerOverviewPlaceholder', 'spoilerStripTags', 'spoilerStripChapters', 'spoilerStripTaglines', 'spoilerStripRatings', 'spoilerStripPremiereDate', 'spoilerReplaceTitle', 'spoilerStripCast', 'spoilerAutoEnableOnFirstPlay', 'spoilerAutoEnableOnSeerrRequest', 'spoilerBlurStrictRefresh', 'spoilerKeepMoviePosters'] },
-            { parent: 'spoilerStripCast',     label: 'Hide cast on unwatched episodes', children: ['spoilerStripCastMode'] }
+            { parent: 'spoilerBlurEnabled', label: 'Enable Spoiler Guard', children: ['spoilerBlurIntensity', 'spoilerBlurArtwork', 'spoilerStripSeriesOverview', 'spoilerStripOverview', 'spoilerOverviewPlaceholder', 'spoilerStripTags', 'spoilerStripChapters', 'spoilerStripTaglines', 'spoilerStripRatings', 'spoilerStripPremiereDate', 'spoilerReplaceTitle', 'spoilerStripCast', 'spoilerAutoEnableOnFirstPlay', 'spoilerAutoEnableOnSeerrRequest', 'spoilerBlurStrictRefresh', 'spoilerKeepMoviePosters', 'spoilerAdvancedMode'] },
+            { parent: 'spoilerStripCast',     label: 'Hide cast on unwatched episodes', children: ['spoilerStripCastMode'] },
+            { parent: 'spoilerAdvancedMode',  label: 'Enable advanced per-category reveals', children: ['spoilerNextEpisodeStripTitle', 'spoilerNextEpisodeStripOverview', 'spoilerNextEpisodeStripRatings', 'spoilerCurrentSeasonStripTitle', 'spoilerCurrentSeasonStripOverview', 'spoilerCurrentSeasonStripRatings'] }
         ];
 
         /**

--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -4416,6 +4416,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                         ReplaceEpisodeTitles = body.ReplaceEpisodeTitles,
                         HideCast = body.HideCast,
                         HideReviews = body.HideReviews,
+                        UseAdvancedCategories = body.UseAdvancedCategories,
                         SkipDisableConfirm = body.SkipDisableConfirm,
                     };
                     return 1;

--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -3013,6 +3013,11 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                 config.SpoilerReplaceTitle,
                 config.SpoilerStripCast,
                 config.SpoilerStripReviews,
+                // Advanced category reveals: clients only need the master flag
+                // (to gate the per-user opt-out row in the settings panel);
+                // the six per-category strip toggles are server-only strip
+                // policy and are deliberately not exposed.
+                config.SpoilerAdvancedMode,
             });
         }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/PluginServiceRegistrator.cs
@@ -85,6 +85,10 @@ namespace Jellyfin.Plugin.JellyfinEnhanced
             serviceCollection.AddSingleton<SpoilerIdentityTagFilter>();
             serviceCollection.AddSingleton<SpoilerUserResolver>();
             serviceCollection.AddSingleton<SpoilerBlurImageFilter>();
+            // Per-(user, series) next-unwatched boundary for the advanced
+            // category reveals; owns its own bounded cache and evicts on
+            // IUserDataManager.UserDataSaved (O(1) on the event thread).
+            serviceCollection.AddSingleton<SpoilerNextUnwatchedService>();
             // Spoiler Field Strip: removes spoiler-y metadata (Overview, ratings,
             // title, cast, etc.) from BaseItemDto responses for guarded unwatched episodes.
             serviceCollection.AddSingleton<SpoilerFieldStripFilter>();

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/SpoilerGuard/SpoilerFieldStripFilter.cs
@@ -108,21 +108,33 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                 { ("Playlists",   "GetPlaylistItems"),       true },
             };
 
+        // Per-category reveal mask for the advanced Spoiler Guard mode. Each
+        // flag EXEMPTS one field from a strip the base toggles would apply;
+        // default (all false) is the uniform full strip. A reveal can only
+        // relax an active strip — it never strips anything itself.
+        internal readonly record struct CategoryReveal(bool Title, bool Overview, bool Ratings)
+        {
+            internal static readonly CategoryReveal None = default;
+        }
+
         private readonly SpoilerUserResolver _resolver;
         private readonly ILibraryManager _libraryManager;
         private readonly IUserManager _userManager;
         private readonly IUserDataManager _userDataManager;
+        private readonly SpoilerNextUnwatchedService _nextUnwatched;
 
         public SpoilerFieldStripFilter(
             SpoilerUserResolver resolver,
             ILibraryManager libraryManager,
             IUserManager userManager,
-            IUserDataManager userDataManager)
+            IUserDataManager userDataManager,
+            SpoilerNextUnwatchedService nextUnwatched)
         {
             _resolver = resolver;
             _libraryManager = libraryManager;
             _userManager = userManager;
             _userDataManager = userDataManager;
+            _nextUnwatched = nextUnwatched;
         }
 
         public Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
@@ -653,7 +665,41 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             MutateImageTagsForCacheBust(item, cfg, played, playbackPositionTicks: 0);
             if (played) return;
 
-            ApplyStripping(item, userState, cfg, userId);
+            ApplyStripping(item, userState, cfg, userId, ResolveCategoryReveal(item, userState, cfg, userId, seriesId.Value));
+        }
+
+        // Advanced-mode category reveal for an unwatched episode of a guarded
+        // series. Gate order: admin master (SpoilerAdvancedMode), then the
+        // user's per-user opt-out (UseAdvancedCategories == false restores the
+        // uniform full strip), then boundary categorization. Every failure
+        // path — no boundary, missing index numbers, specials — yields
+        // CategoryReveal.None, i.e. the full strip.
+        private CategoryReveal ResolveCategoryReveal(
+            BaseItemDto item,
+            UserSpoilerBlur userState,
+            PluginConfiguration cfg,
+            Guid userId,
+            Guid seriesId)
+        {
+            if (!cfg.SpoilerAdvancedMode) return CategoryReveal.None;
+            if (userState.Prefs?.UseAdvancedCategories == false) return CategoryReveal.None;
+            if (item.Type != Jellyfin.Data.Enums.BaseItemKind.Episode) return CategoryReveal.None;
+
+            var boundary = _nextUnwatched.GetBoundary(userId, seriesId);
+            var category = SpoilerNextUnwatchedService.Categorize(
+                boundary, item.Id, item.ParentIndexNumber, item.IndexNumber);
+            return category switch
+            {
+                SpoilerEpisodeCategory.NextEpisode => new CategoryReveal(
+                    Title: !cfg.SpoilerNextEpisodeStripTitle,
+                    Overview: !cfg.SpoilerNextEpisodeStripOverview,
+                    Ratings: !cfg.SpoilerNextEpisodeStripRatings),
+                SpoilerEpisodeCategory.CurrentSeason => new CategoryReveal(
+                    Title: !cfg.SpoilerCurrentSeasonStripTitle,
+                    Overview: !cfg.SpoilerCurrentSeasonStripOverview,
+                    Ratings: !cfg.SpoilerCurrentSeasonStripRatings),
+                _ => CategoryReveal.None,
+            };
         }
 
         // A movie ID is "in spoiler scope" when either (a) it's directly
@@ -971,9 +1017,15 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         // for PlaybackPositionTicks when item.UserData is null
         // (enableUserData=false response shape). The userId arg is used
         // only by that fallback path.
-        private void ApplyStripping(BaseItemDto item, UserSpoilerBlur userState, PluginConfiguration cfg, Guid userId)
+        private void ApplyStripping(BaseItemDto item, UserSpoilerBlur userState, PluginConfiguration cfg, Guid userId, CategoryReveal reveal = default)
         {
-            var stripOverview = ShouldStripOverview(item, userState, cfg);
+            // Effective per-item toggles: the base admin+user decision, minus
+            // any advanced-mode category reveal for this specific episode.
+            // reveal is default(None) on every non-episode path and whenever
+            // advanced mode is off, so these reduce to the base toggles.
+            var stripOverview = ShouldStripOverview(item, userState, cfg) && !reveal.Overview;
+            var stripRatings = ShouldStrip(cfg.SpoilerStripRatings, userState.Prefs?.HideRatings) && !reveal.Ratings;
+            var replaceTitle = ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles) && !reveal.Title;
 
             // Overview (episode / item synopsis) — single biggest spoiler vector.
             // Series uses its own policy; every other guarded DTO keeps the
@@ -1081,7 +1133,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             // single SpoilerStripRatings toggle. On by default (admins can
             // relax it). Setting to null is the right call — empty/zero would
             // render as "0/10" in some clients.
-            if (ShouldStrip(cfg.SpoilerStripRatings, userState.Prefs?.HideRatings))
+            if (stripRatings)
             {
                 item.CommunityRating = null;
                 item.CriticRating = null;
@@ -1151,7 +1203,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             // trade-off is that some clients use Name in navigation tooltips,
             // breadcrumbs, and "now playing" overlays where the synthesized
             // title can look jarring.
-            if (ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles))
+            if (replaceTitle)
             {
                 if (item.Type == Jellyfin.Data.Enums.BaseItemKind.Episode
                     && item.IndexNumber.HasValue
@@ -1184,7 +1236,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             // deny-by-default: aggressively null every field that COULD
             // carry the episode title. Future BaseItemDto fields added by
             // Jellyfin must be assumed-leaky until proven otherwise.
-            if (ShouldStrip(cfg.SpoilerReplaceTitle, userState.Prefs?.ReplaceEpisodeTitles)
+            if (replaceTitle
                 || stripOverview)
             {
                 // Top-level title-bearing string fields.

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/SpoilerGuard/SpoilerNextUnwatchedService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/SpoilerGuard/SpoilerNextUnwatchedService.cs
@@ -5,7 +5,6 @@ using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Querying;
 
 namespace Jellyfin.Plugin.JellyfinEnhanced.Services
 {

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/SpoilerGuard/SpoilerNextUnwatchedService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/SpoilerGuard/SpoilerNextUnwatchedService.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Querying;
+
+namespace Jellyfin.Plugin.JellyfinEnhanced.Services
+{
+    /// <summary>
+    /// Episode category relative to the user's next-unwatched boundary of a
+    /// guarded series. <see cref="Other"/> is the fail-closed default: any
+    /// episode whose category cannot be established keeps the full strip.
+    /// </summary>
+    public enum SpoilerEpisodeCategory
+    {
+        /// <summary>Full strip — later seasons, skipped earlier seasons, specials, or unknown.</summary>
+        Other = 0,
+
+        /// <summary>The user's first unwatched regular episode in (season, episode) order.</summary>
+        NextEpisode = 1,
+
+        /// <summary>Another unwatched episode in the same season as the next episode.</summary>
+        CurrentSeason = 2,
+    }
+
+    /// <summary>
+    /// Owns the per-(user, series) "next unwatched episode" boundary used by the
+    /// advanced Spoiler Guard category reveals. "Next" is deliberately the first
+    /// unwatched non-special episode in (ParentIndexNumber, IndexNumber) order —
+    /// simpler and more predictable for spoiler purposes than Jellyfin NextUp's
+    /// rewatch-aware ordering, and stable for a user who watches in order.
+    ///
+    /// The strip filter consumes this as an amortized in-memory lookup; a cache
+    /// miss costs one series-scoped Limit=1 library query (the same bounded shape
+    /// as TagCacheService.GetFirstEpisode). Watched-state changes evict the
+    /// affected key via IUserDataManager.UserDataSaved; library mutations are
+    /// covered by the TTL alone — a stale boundary can only mis-categorize the
+    /// episode the user is about to watch between reveal tiers, never bypass a
+    /// base strip, so a bounded staleness window is acceptable.
+    /// </summary>
+    public sealed class SpoilerNextUnwatchedService : IDisposable
+    {
+        /// <summary>The next-unwatched episode's identity and position.</summary>
+        public readonly record struct NextUnwatchedBoundary(Guid EpisodeId, int SeasonNumber, int EpisodeNumber);
+
+        private readonly record struct CacheSlot(NextUnwatchedBoundary? Boundary, long ExpiresAtTicks);
+
+        // Boundary cache keyed (userId, seriesId). Worst case is
+        // f(users × guarded series) but hard-capped at MaxCacheEntries slots of
+        // ~72 bytes (two Guids + a nullable record struct + expiry) ≈ 150 KiB —
+        // bounded independent of library size. Overflow clears the whole map
+        // (recompute is one bounded query per active key); TTL keeps entries
+        // from outliving library changes.
+        private readonly ConcurrentDictionary<(Guid UserId, Guid SeriesId), CacheSlot> _cache = new();
+
+        internal const int MaxCacheEntries = 2048;
+        internal static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+        private readonly ILibraryManager _libraryManager;
+        private readonly IUserManager _userManager;
+        private readonly IUserDataManager _userDataManager;
+        private readonly Logger _logger;
+        private int _computeFailureLogBudget = 5;
+
+        // Test / diagnostic seams: substitute the boundary computation (no live
+        // library) and the clock (deterministic TTL expiry).
+        internal Func<Guid, Guid, NextUnwatchedBoundary?>? BoundaryComputerForTest { get; set; }
+
+        internal Func<long>? ClockTicksForTest { get; set; }
+
+        public SpoilerNextUnwatchedService(
+            ILibraryManager libraryManager,
+            IUserManager userManager,
+            IUserDataManager userDataManager,
+            Logger logger)
+        {
+            _libraryManager = libraryManager;
+            _userManager = userManager;
+            _userDataManager = userDataManager;
+            _logger = logger;
+            _userDataManager.UserDataSaved += OnUserDataSaved;
+        }
+
+        // This service is a Singleton subscribed to
+        // IUserDataManager.UserDataSaved. Without an unsubscribe path,
+        // hot-reload / plugin disable+re-enable leaks the handler delegate
+        // (matches the SpoilerBlurImageFilter pattern).
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            try
+            {
+                _userDataManager.UserDataSaved -= OnUserDataSaved;
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning($"SpoilerNextUnwatchedService: unsubscribe on Dispose threw: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Resolve the next-unwatched boundary for a user's guarded series.
+        /// Returns null (⇒ every episode categorizes as <see cref="SpoilerEpisodeCategory.Other"/>,
+        /// full strip) when the series has no unwatched regular episode or on any
+        /// resolution failure — fail-closed toward the base behavior.
+        /// </summary>
+        public NextUnwatchedBoundary? GetBoundary(Guid userId, Guid seriesId)
+        {
+            if (userId == Guid.Empty || seriesId == Guid.Empty) return null;
+
+            // The per-item cost on the strip path is this dictionary hit; the
+            // bounded query below runs once per (user, series) per TTL window /
+            // watched-state change, amortizing to O(1) per item.
+            var now = ClockTicksForTest?.Invoke() ?? DateTime.UtcNow.Ticks;
+            var key = (userId, seriesId);
+            if (_cache.TryGetValue(key, out var slot) && slot.ExpiresAtTicks > now)
+            {
+                return slot.Boundary;
+            }
+
+            var boundary = BoundaryComputerForTest != null
+                ? BoundaryComputerForTest(userId, seriesId)
+                : ComputeBoundary(userId, seriesId);
+
+            if (_cache.Count >= MaxCacheEntries)
+            {
+                // Hard bound. Clearing everything is deliberate — a partial
+                // eviction policy is extra state for a map that refills at one
+                // bounded query per active key.
+                _cache.Clear();
+            }
+
+            _cache[key] = new CacheSlot(boundary, now + CacheTtl.Ticks);
+            return boundary;
+        }
+
+        /// <summary>
+        /// Pure categorization of an episode DTO against a boundary. Validation
+        /// runs before any identity match: missing index numbers, season 0
+        /// (specials), or a null boundary all resolve to
+        /// <see cref="SpoilerEpisodeCategory.Other"/> (full strip) even when the
+        /// DTO id equals the boundary episode — a DTO that cannot prove it is a
+        /// well-formed regular episode never earns a reveal. NextEpisode is
+        /// granted only by the authoritative episode id; a different episode
+        /// that merely shares the boundary's season/episode numbers (duplicate
+        /// numbering, alternate versions) gets at most the CurrentSeason mask.
+        /// </summary>
+        public static SpoilerEpisodeCategory Categorize(
+            NextUnwatchedBoundary? boundary,
+            Guid episodeId,
+            int? parentIndexNumber,
+            int? indexNumber)
+        {
+            if (boundary is not { } b) return SpoilerEpisodeCategory.Other;
+            if (parentIndexNumber is not int season || season <= 0) return SpoilerEpisodeCategory.Other;
+            if (indexNumber is not int) return SpoilerEpisodeCategory.Other;
+            if (episodeId != Guid.Empty && episodeId == b.EpisodeId) return SpoilerEpisodeCategory.NextEpisode;
+            return season == b.SeasonNumber
+                ? SpoilerEpisodeCategory.CurrentSeason
+                : SpoilerEpisodeCategory.Other;
+        }
+
+        private NextUnwatchedBoundary? ComputeBoundary(Guid userId, Guid seriesId)
+        {
+            try
+            {
+                var user = _userManager.GetUserById(userId);
+                if (user == null) return null;
+
+                // Series-scoped, Limit=1, sorted server-side — the same bounded
+                // single-item shape as TagCacheService.GetFirstEpisode.
+                // ParentIndexNumberNotEquals=0 excludes specials so a pile of
+                // unwatched specials can't pin the boundary to Season 0.
+                // Both target Jellyfin lines (10.11 / 12) expose
+                // ParentIndexNumberNotEquals and the (ItemSortBy, SortOrder)
+                // tuple OrderBy, so no per-TFM shim is needed here.
+                var query = new InternalItemsQuery(user)
+                {
+                    ParentId = seriesId,
+                    IncludeItemTypes = new[] { BaseItemKind.Episode },
+                    Recursive = true,
+                    IsPlayed = false,
+                    IsVirtualItem = false,
+                    ParentIndexNumberNotEquals = 0,
+                    Limit = 1,
+                    OrderBy = new[]
+                    {
+                        (ItemSortBy.ParentIndexNumber, JSortOrder.Ascending),
+                        (ItemSortBy.IndexNumber, JSortOrder.Ascending),
+                        (ItemSortBy.SortName, JSortOrder.Ascending),
+                    },
+                };
+
+                if (_libraryManager.GetItemList(query).FirstOrDefault() is not Episode first) return null;
+                if (first.ParentIndexNumber is not int season || season <= 0) return null;
+                if (first.IndexNumber is not int episode) return null;
+                return new NextUnwatchedBoundary(first.Id, season, episode);
+            }
+            catch (Exception ex)
+            {
+                // Fail closed (null ⇒ full strip). Bounded logging so a
+                // persistent library fault can't flood the log from a hot
+                // request path.
+                if (_computeFailureLogBudget > 0)
+                {
+                    _computeFailureLogBudget--;
+                    _logger.Warning($"Spoiler Guard next-unwatched boundary failed for series {seriesId}; falling back to full strip: {ex.Message}");
+                }
+
+                return null;
+            }
+        }
+
+        // Fires on every user-data save (playback ticks included). O(1)
+        // in-memory eviction only — no DB lookup, no I/O. SeriesId is an
+        // in-memory property on the Episode entity carried by the event args,
+        // so this stays cheap enough to run inline on the publish thread.
+        private void OnUserDataSaved(object? sender, UserDataSaveEventArgs e)
+        {
+            if (e == null || e.UserId == Guid.Empty) return;
+            if (e.Item is Episode episode && episode.SeriesId != Guid.Empty)
+            {
+                _cache.TryRemove((e.UserId, episode.SeriesId), out _);
+            }
+            else if (e.Item is Series series)
+            {
+                _cache.TryRemove((e.UserId, series.Id), out _);
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/spoilerguard/settings-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/spoilerguard/settings-tab.js
@@ -23,8 +23,21 @@
             replaceTitle: JE.pluginConfig.SpoilerReplaceTitle !== false,
             cast: JE.pluginConfig.SpoilerStripCast !== false,
             reviews: JE.pluginConfig.SpoilerStripReviews !== false,
+            // Unlike the strip categories above, this row is gated on the
+            // admin having explicitly ENABLED advanced mode — there is
+            // nothing to opt out of while the uniform strip is in force.
+            advanced: JE.pluginConfig.SpoilerAdvancedMode === true,
         };
         const checked = value => value === false ? '' : 'checked';
+        /**
+         * Renders one per-user Spoiler Guard preference row.
+         * @param {string} id - DOM id; must start with `sbPref` so wireSettings picks it up.
+         * @param {string} pref - SpoilerBlurUserPrefs key written on change (null = inherit, false = opt out).
+         * @param {string} label - Translation key for the row title.
+         * @param {string} description - Translation key for the row subtitle.
+         * @param {boolean} gate - Render only when the admin has this category in play.
+         * @returns {string} Row markup, or an empty string when gated off.
+         */
         const row = (id, pref, label, description, gate) => gate ? `
             <div style="margin-bottom:8px;padding:12px;background:${ctx.presetBoxBackground};border-radius:6px;border-left:3px solid rgba(255,255,255,0.15);">
                 <label style="display:flex;align-items:center;gap:12px;cursor:pointer;">
@@ -48,6 +61,12 @@
                     ${row('sbPrefHideTaglines', 'HideTaglines', 'panel_settings_spoiler_guard_override_taglines', 'panel_settings_spoiler_guard_override_taglines_desc', adminOn.taglines)}
                     ${row('sbPrefHideTags', 'HideTags', 'panel_settings_spoiler_guard_override_tags', 'panel_settings_spoiler_guard_override_tags_desc', adminOn.tags)}
                     ${row('sbPrefHideReviews', 'HideReviews', 'panel_settings_spoiler_guard_override_reviews', 'panel_settings_spoiler_guard_override_reviews_desc', adminOn.reviews)}
+                    <!-- Advanced per-category reveals. Same checkbox mechanics as
+                         the rows above (checked => null/inherit, unchecked => false)
+                         but the opposite direction of effect: unchecking makes this
+                         user's Spoiler Guard STRICTER by restoring the uniform full
+                         strip instead of the admin's per-category reveals. -->
+                    ${row('sbPrefUseAdvancedCategories', 'UseAdvancedCategories', 'panel_settings_spoiler_guard_override_advanced', 'panel_settings_spoiler_guard_override_advanced_desc', adminOn.advanced)}
                     <div style="margin-top:12px;padding:12px;background:${ctx.presetBoxBackground};border-radius:6px;border-left:3px solid ${ctx.toggleAccentColor};">
                         <label style="display:flex;align-items:center;gap:12px;cursor:pointer;">
                             <input type="checkbox" id="sbPrefSkipDisableConfirm" ${prefs.SkipDisableConfirm ? 'checked' : ''} data-pref="SkipDisableConfirm" style="width:16px;height:16px;accent-color:${ctx.toggleAccentColor};cursor:pointer;">

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/spoilerguard/settings-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/spoilerguard/settings-tab.js
@@ -23,9 +23,14 @@
             replaceTitle: JE.pluginConfig.SpoilerReplaceTitle !== false,
             cast: JE.pluginConfig.SpoilerStripCast !== false,
             reviews: JE.pluginConfig.SpoilerStripReviews !== false,
-            // Unlike the strip categories above, this row is gated on the
-            // admin having explicitly ENABLED advanced mode — there is
-            // nothing to opt out of while the uniform strip is in force.
+            // Advanced per-category reveals. Gated on the admin having
+            // explicitly ENABLED advanced mode (not "not disabled" like the
+            // strip categories above) — there is nothing to opt out of while
+            // the uniform strip is in force. The row also runs the opposite
+            // direction of effect from its neighbours: the same checkbox
+            // mechanics (checked => null/inherit, unchecked => false) make
+            // this user's Spoiler Guard STRICTER when unchecked, restoring
+            // the uniform full strip instead of the admin's reveals.
             advanced: JE.pluginConfig.SpoilerAdvancedMode === true,
         };
         const checked = value => value === false ? '' : 'checked';
@@ -61,11 +66,6 @@
                     ${row('sbPrefHideTaglines', 'HideTaglines', 'panel_settings_spoiler_guard_override_taglines', 'panel_settings_spoiler_guard_override_taglines_desc', adminOn.taglines)}
                     ${row('sbPrefHideTags', 'HideTags', 'panel_settings_spoiler_guard_override_tags', 'panel_settings_spoiler_guard_override_tags_desc', adminOn.tags)}
                     ${row('sbPrefHideReviews', 'HideReviews', 'panel_settings_spoiler_guard_override_reviews', 'panel_settings_spoiler_guard_override_reviews_desc', adminOn.reviews)}
-                    <!-- Advanced per-category reveals. Same checkbox mechanics as
-                         the rows above (checked => null/inherit, unchecked => false)
-                         but the opposite direction of effect: unchecking makes this
-                         user's Spoiler Guard STRICTER by restoring the uniform full
-                         strip instead of the admin's per-category reveals. -->
                     ${row('sbPrefUseAdvancedCategories', 'UseAdvancedCategories', 'panel_settings_spoiler_guard_override_advanced', 'panel_settings_spoiler_guard_override_advanced_desc', adminOn.advanced)}
                     <div style="margin-top:12px;padding:12px;background:${ctx.presetBoxBackground};border-radius:6px;border-left:3px solid ${ctx.toggleAccentColor};">
                         <label style="display:flex;align-items:center;gap:12px;cursor:pointer;">

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ar.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ar.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "ألغِ التحديد لرؤية وسوم القصة مثل \"وفاة شخصية رئيسية\".",
     "panel_settings_spoiler_guard_override_reviews": "المراجعات",
     "panel_settings_spoiler_guard_override_reviews_desc": "ألغِ التحديد لرؤية لوحة مراجعات TMDB / المستخدمين في صفحات تفاصيل المسلسلات.",
+    "panel_settings_spoiler_guard_override_advanced": "الكشف المتقدم حسب الفئة",
+    "panel_settings_spoiler_guard_override_advanced_desc": "ألغِ التحديد لإخفاء كل شيء مجددًا — بما في ذلك عنوان الحلقة التالية — بدلًا من الكشف حسب الفئة الذي فعّله المسؤول.",
     "panel_settings_spoiler_guard_skip_confirm": "لا تطلب مني التأكيد عند إيقاف الحماية من الحرق",
     "panel_settings_spoiler_guard_skip_confirm_desc": "تجاوز مربع حوار تأكيد الإيقاف. يوفر نقرة عند إيقاف الحماية من الحرق لمسلسل.",
     "hidden_content_hide_button": "إخفاء",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ar.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ar.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "المراجعات",
     "panel_settings_spoiler_guard_override_reviews_desc": "ألغِ التحديد لرؤية لوحة مراجعات TMDB / المستخدمين في صفحات تفاصيل المسلسلات.",
     "panel_settings_spoiler_guard_override_advanced": "الكشف المتقدم حسب الفئة",
-    "panel_settings_spoiler_guard_override_advanced_desc": "ألغِ التحديد لإخفاء كل شيء مجددًا — بما في ذلك عنوان الحلقة التالية — بدلًا من الكشف حسب الفئة الذي فعّله المسؤول.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "ألغِ التحديد لإخفاء كل شيء مجددًا (بما في ذلك عنوان الحلقة التالية) بدلًا من الكشف حسب الفئة الذي فعّله المسؤول.",
     "panel_settings_spoiler_guard_skip_confirm": "لا تطلب مني التأكيد عند إيقاف الحماية من الحرق",
     "panel_settings_spoiler_guard_skip_confirm_desc": "تجاوز مربع حوار تأكيد الإيقاف. يوفر نقرة عند إيقاف الحماية من الحرق لمسلسل.",
     "hidden_content_hide_button": "إخفاء",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/bg.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/bg.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Рецензии",
     "panel_settings_spoiler_guard_override_reviews_desc": "Премахнете отметката, за да виждате панела с рецензии от TMDB / потребители на страниците с подробности за сериалите.",
     "panel_settings_spoiler_guard_override_advanced": "Разширени разкрития по категории",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Премахнете отметката, за да скриете отново всичко — включително заглавието на следващия епизод — вместо разкритията по категории, активирани от администратора.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Премахнете отметката, за да скриете отново всичко (включително заглавието на следващия епизод) вместо разкритията по категории, активирани от администратора.",
     "panel_settings_spoiler_guard_skip_confirm": "Не ме питай за потвърждение при изключване на защитата от спойлери",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Пропуска диалога за потвърждение на изключването. Спестява едно щракване при изключване на защитата от спойлери за сериал.",
     "hidden_content_hide_button": "Скрий",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/bg.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/bg.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Премахнете отметката, за да виждате сюжетни тагове като \"Смърт на главен герой\".",
     "panel_settings_spoiler_guard_override_reviews": "Рецензии",
     "panel_settings_spoiler_guard_override_reviews_desc": "Премахнете отметката, за да виждате панела с рецензии от TMDB / потребители на страниците с подробности за сериалите.",
+    "panel_settings_spoiler_guard_override_advanced": "Разширени разкрития по категории",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Премахнете отметката, за да скриете отново всичко — включително заглавието на следващия епизод — вместо разкритията по категории, активирани от администратора.",
     "panel_settings_spoiler_guard_skip_confirm": "Не ме питай за потвърждение при изключване на защитата от спойлери",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Пропуска диалога за потвърждение на изключването. Спестява едно щракване при изключване на защитата от спойлери за сериал.",
     "hidden_content_hide_button": "Скрий",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ca.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ca.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Ressenyes",
     "panel_settings_spoiler_guard_override_reviews_desc": "Desmarca-ho per veure el tauler de ressenyes de TMDB / usuaris a les pàgines de detalls de les sèries.",
     "panel_settings_spoiler_guard_override_advanced": "Revelacions avançades per categoria",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarqueu per tornar a amagar-ho tot — incloent-hi el títol del proper episodi — en lloc de les revelacions per categoria que ha activat l'administrador.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarqueu per tornar a amagar-ho tot (incloent-hi el títol del proper episodi) en lloc de les revelacions per categoria que ha activat l'administrador.",
     "panel_settings_spoiler_guard_skip_confirm": "No em demanis confirmació quan desactivi la protecció contra espòilers",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Omet el diàleg de confirmació de desactivació. Estalvia un clic quan desactives la protecció contra espòilers per a una sèrie.",
     "hidden_content_hide_button": "Ocultar",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ca.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ca.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Desmarca-ho per veure etiquetes argumentals com \"Mort d'un personatge principal\".",
     "panel_settings_spoiler_guard_override_reviews": "Ressenyes",
     "panel_settings_spoiler_guard_override_reviews_desc": "Desmarca-ho per veure el tauler de ressenyes de TMDB / usuaris a les pàgines de detalls de les sèries.",
+    "panel_settings_spoiler_guard_override_advanced": "Revelacions avançades per categoria",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarqueu per tornar a amagar-ho tot — incloent-hi el títol del proper episodi — en lloc de les revelacions per categoria que ha activat l'administrador.",
     "panel_settings_spoiler_guard_skip_confirm": "No em demanis confirmació quan desactivi la protecció contra espòilers",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Omet el diàleg de confirmació de desactivació. Estalvia un clic quan desactives la protecció contra espòilers per a una sèrie.",
     "hidden_content_hide_button": "Ocultar",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/cs.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/cs.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Recenze",
     "panel_settings_spoiler_guard_override_reviews_desc": "Zrušte zaškrtnutí, chcete-li na stránkách detailů seriálu zobrazit panel recenzí z TMDB / od uživatelů.",
     "panel_settings_spoiler_guard_override_advanced": "Pokročilé odkrývání podle kategorií",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Zrušte zaškrtnutí, chcete-li vše znovu skrýt — včetně názvu další epizody — místo odkrývání podle kategorií, které povolil správce.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Zrušte zaškrtnutí, chcete-li vše znovu skrýt (včetně názvu další epizody) místo odkrývání podle kategorií, které povolil správce.",
     "panel_settings_spoiler_guard_skip_confirm": "Nepotvrzovat vypnutí ochrany před spoilery",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Přeskočí potvrzovací dialog při vypnutí. Ušetří kliknutí při vypínání ochrany před spoilery pro seriál.",
     "hidden_content_hide_button": "Skrýt",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/cs.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/cs.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Zrušte zaškrtnutí, chcete-li zobrazit dějové štítky, například \"Smrt hlavní postavy\".",
     "panel_settings_spoiler_guard_override_reviews": "Recenze",
     "panel_settings_spoiler_guard_override_reviews_desc": "Zrušte zaškrtnutí, chcete-li na stránkách detailů seriálu zobrazit panel recenzí z TMDB / od uživatelů.",
+    "panel_settings_spoiler_guard_override_advanced": "Pokročilé odkrývání podle kategorií",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Zrušte zaškrtnutí, chcete-li vše znovu skrýt — včetně názvu další epizody — místo odkrývání podle kategorií, které povolil správce.",
     "panel_settings_spoiler_guard_skip_confirm": "Nepotvrzovat vypnutí ochrany před spoilery",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Přeskočí potvrzovací dialog při vypnutí. Ušetří kliknutí při vypínání ochrany před spoilery pro seriál.",
     "hidden_content_hide_button": "Skrýt",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/da.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/da.json
@@ -524,7 +524,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Anmeldelser",
     "panel_settings_spoiler_guard_override_reviews_desc": "Fjern markeringen for at se panelet med TMDB- / brugeranmeldelser på seriens detaljesider.",
     "panel_settings_spoiler_guard_override_advanced": "Avancerede visninger pr. kategori",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Fjern markeringen for at skjule alt igen — inklusive titlen på næste afsnit — i stedet for de kategorivisninger, din administrator har aktiveret.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Fjern markeringen for at skjule alt igen (inklusive titlen på næste afsnit) i stedet for de kategorivisninger, din administrator har aktiveret.",
     "panel_settings_spoiler_guard_skip_confirm": "Spørg mig ikke om bekræftelse, når spoilerbeskyttelse slås fra",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Spring bekræftelsesdialogen ved deaktivering over. Sparer et klik, når du slår spoilerbeskyttelse fra for en serie.",
     "spoiler_blur_pending_button_on": "Spoiler Guard (afventer)",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/da.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/da.json
@@ -523,6 +523,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Fjern markeringen for at se historietags som \"En hovedpersons død\".",
     "panel_settings_spoiler_guard_override_reviews": "Anmeldelser",
     "panel_settings_spoiler_guard_override_reviews_desc": "Fjern markeringen for at se panelet med TMDB- / brugeranmeldelser på seriens detaljesider.",
+    "panel_settings_spoiler_guard_override_advanced": "Avancerede visninger pr. kategori",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Fjern markeringen for at skjule alt igen — inklusive titlen på næste afsnit — i stedet for de kategorivisninger, din administrator har aktiveret.",
     "panel_settings_spoiler_guard_skip_confirm": "Spørg mig ikke om bekræftelse, når spoilerbeskyttelse slås fra",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Spring bekræftelsesdialogen ved deaktivering over. Sparer et klik, når du slår spoilerbeskyttelse fra for en serie.",
     "spoiler_blur_pending_button_on": "Spoiler Guard (afventer)",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/de.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/de.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Abwählen, um Story-Tags wie \"Tod einer Hauptfigur\" zu sehen.",
     "panel_settings_spoiler_guard_override_reviews": "Rezensionen",
     "panel_settings_spoiler_guard_override_reviews_desc": "Abwählen, um das Panel mit TMDB- / Benutzerrezensionen auf Seriendetailseiten zu sehen.",
+    "panel_settings_spoiler_guard_override_advanced": "Erweiterte Freigaben pro Kategorie",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Abwählen, um wieder alles zu verbergen — einschließlich des Titels der nächsten Episode — statt der vom Administrator aktivierten Freigaben pro Kategorie.",
     "panel_settings_spoiler_guard_skip_confirm": "Beim Ausschalten von Spoiler Guard nicht nach Bestätigung fragen",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Überspringt den Bestätigungsdialog beim Deaktivieren. Spart einen Klick, wenn Spoiler Guard für eine Serie ausgeschaltet wird.",
     "hidden_content_hide_button": "Verbergen",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/de.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/de.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Rezensionen",
     "panel_settings_spoiler_guard_override_reviews_desc": "Abwählen, um das Panel mit TMDB- / Benutzerrezensionen auf Seriendetailseiten zu sehen.",
     "panel_settings_spoiler_guard_override_advanced": "Erweiterte Freigaben pro Kategorie",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Abwählen, um wieder alles zu verbergen — einschließlich des Titels der nächsten Episode — statt der vom Administrator aktivierten Freigaben pro Kategorie.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Abwählen, um wieder alles zu verbergen (einschließlich des Titels der nächsten Episode) statt der vom Administrator aktivierten Freigaben pro Kategorie.",
     "panel_settings_spoiler_guard_skip_confirm": "Beim Ausschalten von Spoiler Guard nicht nach Bestätigung fragen",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Überspringt den Bestätigungsdialog beim Deaktivieren. Spart einen Klick, wenn Spoiler Guard für eine Serie ausgeschaltet wird.",
     "hidden_content_hide_button": "Verbergen",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en-GB.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en-GB.json
@@ -530,7 +530,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Reviews",
     "panel_settings_spoiler_guard_override_reviews_desc": "Uncheck to see the TMDB / user reviews panel on series detail pages.",
     "panel_settings_spoiler_guard_override_advanced": "Advanced per-category reveals",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to hide everything again — including the next episode's title — instead of the per-category reveals your admin enabled.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to hide everything again (including the next episode's title) instead of the per-category reveals your admin enabled.",
     "panel_settings_spoiler_guard_skip_confirm": "Don't ask me to confirm when turning Spoiler Guard off",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Skip the disable-confirmation dialog. Saves a click when toggling Spoiler Guard off for a series.",
     "hidden_content_hide_button": "Hide",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en-GB.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en-GB.json
@@ -529,6 +529,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Uncheck to see story tags like \"Death of a main character\".",
     "panel_settings_spoiler_guard_override_reviews": "Reviews",
     "panel_settings_spoiler_guard_override_reviews_desc": "Uncheck to see the TMDB / user reviews panel on series detail pages.",
+    "panel_settings_spoiler_guard_override_advanced": "Advanced per-category reveals",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to hide everything again — including the next episode's title — instead of the per-category reveals your admin enabled.",
     "panel_settings_spoiler_guard_skip_confirm": "Don't ask me to confirm when turning Spoiler Guard off",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Skip the disable-confirmation dialog. Saves a click when toggling Spoiler Guard off for a series.",
     "hidden_content_hide_button": "Hide",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en-US.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en-US.json
@@ -530,7 +530,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Reviews",
     "panel_settings_spoiler_guard_override_reviews_desc": "Uncheck to see the TMDB / user reviews panel on series detail pages.",
     "panel_settings_spoiler_guard_override_advanced": "Advanced per-category reveals",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to hide everything again — including the next episode's title — instead of the per-category reveals your admin enabled.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to hide everything again (including the next episode's title) instead of the per-category reveals your admin enabled.",
     "panel_settings_spoiler_guard_skip_confirm": "Don't ask me to confirm when turning Spoiler Guard off",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Skip the disable-confirmation dialog. Saves a click when toggling Spoiler Guard off for a series.",
     "hidden_content_hide_button": "Hide",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en-US.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en-US.json
@@ -529,6 +529,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Uncheck to see story tags like \"Death of a main character\".",
     "panel_settings_spoiler_guard_override_reviews": "Reviews",
     "panel_settings_spoiler_guard_override_reviews_desc": "Uncheck to see the TMDB / user reviews panel on series detail pages.",
+    "panel_settings_spoiler_guard_override_advanced": "Advanced per-category reveals",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to hide everything again — including the next episode's title — instead of the per-category reveals your admin enabled.",
     "panel_settings_spoiler_guard_skip_confirm": "Don't ask me to confirm when turning Spoiler Guard off",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Skip the disable-confirmation dialog. Saves a click when toggling Spoiler Guard off for a series.",
     "hidden_content_hide_button": "Hide",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Uncheck to see story tags like \"Death of a main character\".",
     "panel_settings_spoiler_guard_override_reviews": "Reviews",
     "panel_settings_spoiler_guard_override_reviews_desc": "Uncheck to see the TMDB / user reviews panel on series detail pages.",
+    "panel_settings_spoiler_guard_override_advanced": "Advanced per-category reveals",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to hide everything again — including the next episode's title — instead of the per-category reveals your admin enabled.",
     "panel_settings_spoiler_guard_skip_confirm": "Don't ask me to confirm when turning Spoiler Guard off",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Skip the disable-confirmation dialog. Saves a click when toggling Spoiler Guard off for a series.",
     "hidden_content_hide_button": "Hide",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/en.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Reviews",
     "panel_settings_spoiler_guard_override_reviews_desc": "Uncheck to see the TMDB / user reviews panel on series detail pages.",
     "panel_settings_spoiler_guard_override_advanced": "Advanced per-category reveals",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to hide everything again — including the next episode's title — instead of the per-category reveals your admin enabled.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to hide everything again (including the next episode's title) instead of the per-category reveals your admin enabled.",
     "panel_settings_spoiler_guard_skip_confirm": "Don't ask me to confirm when turning Spoiler Guard off",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Skip the disable-confirmation dialog. Saves a click when toggling Spoiler Guard off for a series.",
     "hidden_content_hide_button": "Hide",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/es.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/es.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Reseñas",
     "panel_settings_spoiler_guard_override_reviews_desc": "Desmárcalo para ver el panel de reseñas de TMDB / usuarios en las páginas de detalles de series.",
     "panel_settings_spoiler_guard_override_advanced": "Revelaciones avanzadas por categoría",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarca para volver a ocultarlo todo — incluido el título del próximo episodio — en lugar de las revelaciones por categoría que activó tu administrador.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarca para volver a ocultarlo todo (incluido el título del próximo episodio) en lugar de las revelaciones por categoría que activó tu administrador.",
     "panel_settings_spoiler_guard_skip_confirm": "No pedirme confirmación al desactivar la protección contra spoilers",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Omite el diálogo de confirmación de desactivación. Ahorra un clic al desactivar la protección contra spoilers para una serie.",
     "hidden_content_hide_button": "Ocultar",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/es.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/es.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Desmárcalo para ver etiquetas de la historia como \"Muerte de un personaje principal\".",
     "panel_settings_spoiler_guard_override_reviews": "Reseñas",
     "panel_settings_spoiler_guard_override_reviews_desc": "Desmárcalo para ver el panel de reseñas de TMDB / usuarios en las páginas de detalles de series.",
+    "panel_settings_spoiler_guard_override_advanced": "Revelaciones avanzadas por categoría",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarca para volver a ocultarlo todo — incluido el título del próximo episodio — en lugar de las revelaciones por categoría que activó tu administrador.",
     "panel_settings_spoiler_guard_skip_confirm": "No pedirme confirmación al desactivar la protección contra spoilers",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Omite el diálogo de confirmación de desactivación. Ahorra un clic al desactivar la protección contra spoilers para una serie.",
     "hidden_content_hide_button": "Ocultar",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fa.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fa.json
@@ -118,7 +118,7 @@
     "remove_continue_watching_error": "Could not remove item: User or Item ID not found.",
     "panel_settings_spoiler_guard_override_reviews_desc": "Uncheck to see the TMDB / user reviews panel on series detail pages.",
     "panel_settings_spoiler_guard_override_advanced": "آشکارسازی پیشرفته بر اساس دسته‌بندی",
-    "panel_settings_spoiler_guard_override_advanced_desc": "تیک را بردارید تا همه‌چیز دوباره پنهان شود — از جمله عنوان قسمت بعدی — به‌جای آشکارسازی‌های دسته‌بندی‌شده‌ای که مدیر فعال کرده است.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "تیک را بردارید تا همه‌چیز دوباره پنهان شود (از جمله عنوان قسمت بعدی) به‌جای آشکارسازی‌های دسته‌بندی‌شده‌ای که مدیر فعال کرده است.",
     "jellyseerr_card_badge_movie": "Movie",
     "hidden_content_manage_search": "Search hidden items…",
     "bookmark_migrated": "{{icon:success}} Migrated {count} bookmark(s) to {name}",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fa.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fa.json
@@ -117,6 +117,8 @@
     "panel_settings_random_button": "Random Button Settings",
     "remove_continue_watching_error": "Could not remove item: User or Item ID not found.",
     "panel_settings_spoiler_guard_override_reviews_desc": "Uncheck to see the TMDB / user reviews panel on series detail pages.",
+    "panel_settings_spoiler_guard_override_advanced": "آشکارسازی پیشرفته بر اساس دسته‌بندی",
+    "panel_settings_spoiler_guard_override_advanced_desc": "تیک را بردارید تا همه‌چیز دوباره پنهان شود — از جمله عنوان قسمت بعدی — به‌جای آشکارسازی‌های دسته‌بندی‌شده‌ای که مدیر فعال کرده است.",
     "jellyseerr_card_badge_movie": "Movie",
     "hidden_content_manage_search": "Search hidden items…",
     "bookmark_migrated": "{{icon:success}} Migrated {count} bookmark(s) to {name}",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fi.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fi.json
@@ -584,7 +584,7 @@
     "panel_settings_spoiler_guard_override_ratings": "Arvostelut",
     "panel_settings_spoiler_guard_override_reviews_desc": "Poista valinta nähdäksesi TMDB:n / käyttäjien arvostelupaneelin sarjan tietosivuilla.",
     "panel_settings_spoiler_guard_override_advanced": "Edistyneet luokkakohtaiset paljastukset",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Poista valinta piilottaaksesi kaiken uudelleen — myös seuraavan jakson nimen — järjestelmänvalvojan käyttöön ottamien luokkakohtaisten paljastusten sijaan.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Poista valinta piilottaaksesi kaiken uudelleen (myös seuraavan jakson nimen) järjestelmänvalvojan käyttöön ottamien luokkakohtaisten paljastusten sijaan.",
     "spoiler_blur_disabled_collection_toast": "Juonipaljastussuoja pois päältä.",
     "panel_settings_spoiler_guard_override_cast_desc": "Poista valinta nähdäksesi koko näyttelijälistan (myös vierailevat tähdet) katsomattomissa jaksoissa.",
     "panel_settings_spoiler_guard_override_ratings_desc": "Poista valinta nähdäksesi yhteisön ja kriitikoiden arviot katsomattomissa jaksoissa.",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fi.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fi.json
@@ -583,6 +583,8 @@
     "spoiler_blur_pending_disabled_toast": "Juonipaljastussuoja poistettu käytöstä tälle nimikkeelle.",
     "panel_settings_spoiler_guard_override_ratings": "Arvostelut",
     "panel_settings_spoiler_guard_override_reviews_desc": "Poista valinta nähdäksesi TMDB:n / käyttäjien arvostelupaneelin sarjan tietosivuilla.",
+    "panel_settings_spoiler_guard_override_advanced": "Edistyneet luokkakohtaiset paljastukset",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Poista valinta piilottaaksesi kaiken uudelleen — myös seuraavan jakson nimen — järjestelmänvalvojan käyttöön ottamien luokkakohtaisten paljastusten sijaan.",
     "spoiler_blur_disabled_collection_toast": "Juonipaljastussuoja pois päältä.",
     "panel_settings_spoiler_guard_override_cast_desc": "Poista valinta nähdäksesi koko näyttelijälistan (myös vierailevat tähdet) katsomattomissa jaksoissa.",
     "panel_settings_spoiler_guard_override_ratings_desc": "Poista valinta nähdäksesi yhteisön ja kriitikoiden arviot katsomattomissa jaksoissa.",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fr.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fr.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Avis",
     "panel_settings_spoiler_guard_override_reviews_desc": "Décochez pour voir le panneau des avis TMDB / utilisateurs sur les pages de détails des séries.",
     "panel_settings_spoiler_guard_override_advanced": "Révélations avancées par catégorie",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Décochez pour tout masquer à nouveau — y compris le titre du prochain épisode — au lieu des révélations par catégorie activées par votre administrateur.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Décochez pour tout masquer à nouveau (y compris le titre du prochain épisode) au lieu des révélations par catégorie activées par votre administrateur.",
     "panel_settings_spoiler_guard_skip_confirm": "Ne pas me demander de confirmer lorsque je désactive la protection anti-spoilers",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Ignore la boîte de dialogue de confirmation de désactivation. Économise un clic lors de la désactivation de la protection anti-spoilers pour une série.",
     "hidden_content_hide_button": "Masquer",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fr.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/fr.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Décochez pour voir les tags d'intrigue comme \"Mort d'un personnage principal\".",
     "panel_settings_spoiler_guard_override_reviews": "Avis",
     "panel_settings_spoiler_guard_override_reviews_desc": "Décochez pour voir le panneau des avis TMDB / utilisateurs sur les pages de détails des séries.",
+    "panel_settings_spoiler_guard_override_advanced": "Révélations avancées par catégorie",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Décochez pour tout masquer à nouveau — y compris le titre du prochain épisode — au lieu des révélations par catégorie activées par votre administrateur.",
     "panel_settings_spoiler_guard_skip_confirm": "Ne pas me demander de confirmer lorsque je désactive la protection anti-spoilers",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Ignore la boîte de dialogue de confirmation de désactivation. Économise un clic lors de la désactivation de la protection anti-spoilers pour une série.",
     "hidden_content_hide_button": "Masquer",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/he.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/he.json
@@ -259,7 +259,7 @@
     "panel_settings_spoiler_guard_override_reviews": "ביקורות",
     "panel_settings_spoiler_guard_override_reviews_desc": "בטלו סימון כדי לראות את חלונית ביקורות TMDB / המשתמשים בדפי סדרות.",
     "panel_settings_spoiler_guard_override_advanced": "חשיפות מתקדמות לפי קטגוריה",
-    "panel_settings_spoiler_guard_override_advanced_desc": "בטלו את הסימון כדי להסתיר הכול שוב — כולל שם הפרק הבא — במקום החשיפות לפי קטגוריה שהמנהל הפעיל.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "בטלו את הסימון כדי להסתיר הכול שוב (כולל שם הפרק הבא) במקום החשיפות לפי קטגוריה שהמנהל הפעיל.",
     "panel_settings_spoiler_guard_skip_confirm": "אל תבקש ממני אישור בעת כיבוי מגן הספוילרים",
     "panel_settings_spoiler_guard_skip_confirm_desc": "דילוג על דיאלוג אישור הכיבוי. חוסך לחיצה בעת כיבוי מגן הספוילרים עבור סדרה.",
     "panel_settings_subtitles_format_warning": "הסגנונות האלה לא עובדים עם פורמט הכתוביות של הסרטון הנוכחי.",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/he.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/he.json
@@ -258,6 +258,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "בטלו סימון כדי לראות תגיות עלילה כמו \"מות דמות ראשית\".",
     "panel_settings_spoiler_guard_override_reviews": "ביקורות",
     "panel_settings_spoiler_guard_override_reviews_desc": "בטלו סימון כדי לראות את חלונית ביקורות TMDB / המשתמשים בדפי סדרות.",
+    "panel_settings_spoiler_guard_override_advanced": "חשיפות מתקדמות לפי קטגוריה",
+    "panel_settings_spoiler_guard_override_advanced_desc": "בטלו את הסימון כדי להסתיר הכול שוב — כולל שם הפרק הבא — במקום החשיפות לפי קטגוריה שהמנהל הפעיל.",
     "panel_settings_spoiler_guard_skip_confirm": "אל תבקש ממני אישור בעת כיבוי מגן הספוילרים",
     "panel_settings_spoiler_guard_skip_confirm_desc": "דילוג על דיאלוג אישור הכיבוי. חוסך לחיצה בעת כיבוי מגן הספוילרים עבור סדרה.",
     "panel_settings_subtitles_format_warning": "הסגנונות האלה לא עובדים עם פורמט הכתוביות של הסרטון הנוכחי.",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/hu.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/hu.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Töröld a kijelölést a történetcímkék megjelenítéséhez, például: \"Egy főszereplő halála\".",
     "panel_settings_spoiler_guard_override_reviews": "Vélemények",
     "panel_settings_spoiler_guard_override_reviews_desc": "Töröld a kijelölést a TMDB- / felhasználói vélemények paneljének megjelenítéséhez a sorozat részletező oldalain.",
+    "panel_settings_spoiler_guard_override_advanced": "Speciális, kategóriánkénti felfedés",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Törölje a jelölést, hogy ismét minden rejtve legyen — a következő epizód címét is beleértve — a rendszergazda által engedélyezett kategóriánkénti felfedés helyett.",
     "panel_settings_spoiler_guard_skip_confirm": "Ne kérjen megerősítést a spoiler-védelem kikapcsolásakor",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Kihagyja a kikapcsolást megerősítő párbeszédablakot. Egy kattintást spórol, amikor kikapcsolod a spoiler-védelmet egy sorozatnál.",
     "hidden_content_hide_button": "Elrejtés",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/hu.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/hu.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Vélemények",
     "panel_settings_spoiler_guard_override_reviews_desc": "Töröld a kijelölést a TMDB- / felhasználói vélemények paneljének megjelenítéséhez a sorozat részletező oldalain.",
     "panel_settings_spoiler_guard_override_advanced": "Speciális, kategóriánkénti felfedés",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Törölje a jelölést, hogy ismét minden rejtve legyen — a következő epizód címét is beleértve — a rendszergazda által engedélyezett kategóriánkénti felfedés helyett.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Törölje a jelölést, hogy ismét minden rejtve legyen (a következő epizód címét is beleértve) a rendszergazda által engedélyezett kategóriánkénti felfedés helyett.",
     "panel_settings_spoiler_guard_skip_confirm": "Ne kérjen megerősítést a spoiler-védelem kikapcsolásakor",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Kihagyja a kikapcsolást megerősítő párbeszédablakot. Egy kattintást spórol, amikor kikapcsolod a spoiler-védelmet egy sorozatnál.",
     "hidden_content_hide_button": "Elrejtés",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/it.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/it.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Deseleziona per vedere tag della storia come \"Morte di un personaggio principale\".",
     "panel_settings_spoiler_guard_override_reviews": "Recensioni",
     "panel_settings_spoiler_guard_override_reviews_desc": "Deseleziona per vedere il pannello delle recensioni TMDB / degli utenti nelle pagine dei dettagli delle serie.",
+    "panel_settings_spoiler_guard_override_advanced": "Rivelazioni avanzate per categoria",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Deseleziona per nascondere di nuovo tutto — incluso il titolo del prossimo episodio — invece delle rivelazioni per categoria attivate dall'amministratore.",
     "panel_settings_spoiler_guard_skip_confirm": "Non chiedermi conferma quando disattivo la protezione spoiler",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Salta la finestra di conferma della disattivazione. Risparmia un clic quando disattivi la protezione spoiler per una serie.",
     "hidden_content_hide_button": "Nascondi",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/it.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/it.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Recensioni",
     "panel_settings_spoiler_guard_override_reviews_desc": "Deseleziona per vedere il pannello delle recensioni TMDB / degli utenti nelle pagine dei dettagli delle serie.",
     "panel_settings_spoiler_guard_override_advanced": "Rivelazioni avanzate per categoria",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Deseleziona per nascondere di nuovo tutto — incluso il titolo del prossimo episodio — invece delle rivelazioni per categoria attivate dall'amministratore.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Deseleziona per nascondere di nuovo tutto (incluso il titolo del prossimo episodio) invece delle rivelazioni per categoria attivate dall'amministratore.",
     "panel_settings_spoiler_guard_skip_confirm": "Non chiedermi conferma quando disattivo la protezione spoiler",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Salta la finestra di conferma della disattivazione. Risparmia un clic quando disattivi la protezione spoiler per una serie.",
     "hidden_content_hide_button": "Nascondi",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/nl.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/nl.json
@@ -523,6 +523,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Vink uit om verhaaltags te zien, zoals \"Dood van een hoofdpersoon\".",
     "panel_settings_spoiler_guard_override_reviews": "Recensies",
     "panel_settings_spoiler_guard_override_reviews_desc": "Vink uit om het paneel met TMDB- / gebruikersrecensies te zien op detailpagina's van series.",
+    "panel_settings_spoiler_guard_override_advanced": "Geavanceerde onthullingen per categorie",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Vink uit om alles weer te verbergen — inclusief de titel van de volgende aflevering — in plaats van de door je beheerder ingeschakelde onthullingen per categorie.",
     "panel_settings_spoiler_guard_skip_confirm": "Vraag mij niet om bevestiging bij het uitschakelen van spoilerbescherming",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Slaat het bevestigingsvenster voor uitschakelen over. Bespaart een klik wanneer je spoilerbescherming voor een serie uitschakelt.",
     "spoiler_blur_pending_button_on": "Spoiler Guard (in behandeling)",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/nl.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/nl.json
@@ -524,7 +524,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Recensies",
     "panel_settings_spoiler_guard_override_reviews_desc": "Vink uit om het paneel met TMDB- / gebruikersrecensies te zien op detailpagina's van series.",
     "panel_settings_spoiler_guard_override_advanced": "Geavanceerde onthullingen per categorie",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Vink uit om alles weer te verbergen — inclusief de titel van de volgende aflevering — in plaats van de door je beheerder ingeschakelde onthullingen per categorie.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Vink uit om alles weer te verbergen (inclusief de titel van de volgende aflevering) in plaats van de door je beheerder ingeschakelde onthullingen per categorie.",
     "panel_settings_spoiler_guard_skip_confirm": "Vraag mij niet om bevestiging bij het uitschakelen van spoilerbescherming",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Slaat het bevestigingsvenster voor uitschakelen over. Bespaart een klik wanneer je spoilerbescherming voor een serie uitschakelt.",
     "spoiler_blur_pending_button_on": "Spoiler Guard (in behandeling)",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/no.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Anmeldelser",
     "panel_settings_spoiler_guard_override_reviews_desc": "Fjern avmerkingen for å se panelet med TMDB- / brukeranmeldelser på seriens detaljsider.",
     "panel_settings_spoiler_guard_override_advanced": "Avanserte visninger per kategori",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Fjern haken for å skjule alt igjen — inkludert tittelen på neste episode — i stedet for kategorivisningene administratoren har aktivert.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Fjern haken for å skjule alt igjen (inkludert tittelen på neste episode) i stedet for kategorivisningene administratoren har aktivert.",
     "panel_settings_spoiler_guard_skip_confirm": "Ikke be meg om å bekrefte når spoilerbeskyttelse slås av",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Hopp over bekreftelsesdialogen for deaktivering. Sparer et klikk når du slår av spoilerbeskyttelse for en serie.",
     "hidden_content_hide_button": "Skjul",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/no.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Fjern avmerkingen for å se historieemneknagger som \"Dødsfallet til en hovedperson\".",
     "panel_settings_spoiler_guard_override_reviews": "Anmeldelser",
     "panel_settings_spoiler_guard_override_reviews_desc": "Fjern avmerkingen for å se panelet med TMDB- / brukeranmeldelser på seriens detaljsider.",
+    "panel_settings_spoiler_guard_override_advanced": "Avanserte visninger per kategori",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Fjern haken for å skjule alt igjen — inkludert tittelen på neste episode — i stedet for kategorivisningene administratoren har aktivert.",
     "panel_settings_spoiler_guard_skip_confirm": "Ikke be meg om å bekrefte når spoilerbeskyttelse slås av",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Hopp over bekreftelsesdialogen for deaktivering. Sparer et klikk når du slår av spoilerbeskyttelse for en serie.",
     "hidden_content_hide_button": "Skjul",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pl.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pl.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Recenzje",
     "panel_settings_spoiler_guard_override_reviews_desc": "Odznacz, aby zobaczyć panel recenzji TMDB / użytkowników na stronach szczegółów seriali.",
     "panel_settings_spoiler_guard_override_advanced": "Zaawansowane odsłanianie według kategorii",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Odznacz, aby ponownie ukryć wszystko — w tym tytuł następnego odcinka — zamiast odsłaniania według kategorii włączonego przez administratora.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Odznacz, aby ponownie ukryć wszystko (w tym tytuł następnego odcinka) zamiast odsłaniania według kategorii włączonego przez administratora.",
     "panel_settings_spoiler_guard_skip_confirm": "Nie pytaj o potwierdzenie przy wyłączaniu ochrony przed spoilerami",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Pomija okno potwierdzenia wyłączenia. Oszczędza jedno kliknięcie podczas wyłączania ochrony przed spoilerami dla serialu.",
     "hidden_content_hide_button": "Ukryj",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pl.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pl.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Odznacz, aby zobaczyć tagi fabuły, takie jak \"Śmierć głównego bohatera\".",
     "panel_settings_spoiler_guard_override_reviews": "Recenzje",
     "panel_settings_spoiler_guard_override_reviews_desc": "Odznacz, aby zobaczyć panel recenzji TMDB / użytkowników na stronach szczegółów seriali.",
+    "panel_settings_spoiler_guard_override_advanced": "Zaawansowane odsłanianie według kategorii",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Odznacz, aby ponownie ukryć wszystko — w tym tytuł następnego odcinka — zamiast odsłaniania według kategorii włączonego przez administratora.",
     "panel_settings_spoiler_guard_skip_confirm": "Nie pytaj o potwierdzenie przy wyłączaniu ochrony przed spoilerami",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Pomija okno potwierdzenia wyłączenia. Oszczędza jedno kliknięcie podczas wyłączania ochrony przed spoilerami dla serialu.",
     "hidden_content_hide_button": "Ukryj",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pr.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pr.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Uncheck to spy story marks like \"Death of a main character\".",
     "panel_settings_spoiler_guard_override_reviews": "Crew's tales",
     "panel_settings_spoiler_guard_override_reviews_desc": "Uncheck to spy th' TMDB / crew tales panel on series detail pages.",
+    "panel_settings_spoiler_guard_override_advanced": "Advanced spyglass reveals",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to stow it all away again — includin' the next episode's name — instead o' the category reveals yer cap'n allowed.",
     "panel_settings_spoiler_guard_skip_confirm": "Don't ask me to confirm when I furl th' Spoiler Guard",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Skip th' furl-confirmation dialog. Saves ye a click when furlin' th' Spoiler Guard fer a series.",
     "hidden_content_hide_button": "Hide",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pr.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pr.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Crew's tales",
     "panel_settings_spoiler_guard_override_reviews_desc": "Uncheck to spy th' TMDB / crew tales panel on series detail pages.",
     "panel_settings_spoiler_guard_override_advanced": "Advanced spyglass reveals",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to stow it all away again — includin' the next episode's name — instead o' the category reveals yer cap'n allowed.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Uncheck to stow it all away again (includin' the next episode's name) instead o' the category reveals yer cap'n allowed.",
     "panel_settings_spoiler_guard_skip_confirm": "Don't ask me to confirm when I furl th' Spoiler Guard",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Skip th' furl-confirmation dialog. Saves ye a click when furlin' th' Spoiler Guard fer a series.",
     "hidden_content_hide_button": "Hide",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pt-BR.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pt-BR.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Desmarque para ver etiquetas da história como \"Morte de um personagem principal\".",
     "panel_settings_spoiler_guard_override_reviews": "Resenhas",
     "panel_settings_spoiler_guard_override_reviews_desc": "Desmarque para ver o painel de resenhas do TMDB / usuários nas páginas de detalhes das séries.",
+    "panel_settings_spoiler_guard_override_advanced": "Revelações avançadas por categoria",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarque para ocultar tudo novamente — incluindo o título do próximo episódio — em vez das revelações por categoria ativadas pelo administrador.",
     "panel_settings_spoiler_guard_skip_confirm": "Não pedir confirmação ao desativar a proteção contra spoilers",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Pula a caixa de diálogo de confirmação de desativação. Economiza um clique ao desativar a proteção contra spoilers para uma série.",
     "hidden_content_hide_button": "Ocultar",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pt-BR.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pt-BR.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Resenhas",
     "panel_settings_spoiler_guard_override_reviews_desc": "Desmarque para ver o painel de resenhas do TMDB / usuários nas páginas de detalhes das séries.",
     "panel_settings_spoiler_guard_override_advanced": "Revelações avançadas por categoria",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarque para ocultar tudo novamente — incluindo o título do próximo episódio — em vez das revelações por categoria ativadas pelo administrador.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarque para ocultar tudo novamente (incluindo o título do próximo episódio) em vez das revelações por categoria ativadas pelo administrador.",
     "panel_settings_spoiler_guard_skip_confirm": "Não pedir confirmação ao desativar a proteção contra spoilers",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Pula a caixa de diálogo de confirmação de desativação. Economiza um clique ao desativar a proteção contra spoilers para uma série.",
     "hidden_content_hide_button": "Ocultar",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pt.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pt.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Críticas",
     "panel_settings_spoiler_guard_override_reviews_desc": "Desmarca para ver o painel de críticas do TMDB / utilizadores nas páginas de detalhes das séries.",
     "panel_settings_spoiler_guard_override_advanced": "Revelações avançadas por categoria",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarque para voltar a ocultar tudo — incluindo o título do próximo episódio — em vez das revelações por categoria ativadas pelo administrador.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarque para voltar a ocultar tudo (incluindo o título do próximo episódio) em vez das revelações por categoria ativadas pelo administrador.",
     "panel_settings_spoiler_guard_skip_confirm": "Não pedir confirmação ao desativar a proteção contra spoilers",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Ignora a caixa de diálogo de confirmação de desativação. Poupa um clique ao desativar a proteção contra spoilers para uma série.",
     "hidden_content_hide_button": "Ocultar",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pt.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/pt.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Desmarca para ver etiquetas da história como \"Morte de uma personagem principal\".",
     "panel_settings_spoiler_guard_override_reviews": "Críticas",
     "panel_settings_spoiler_guard_override_reviews_desc": "Desmarca para ver o painel de críticas do TMDB / utilizadores nas páginas de detalhes das séries.",
+    "panel_settings_spoiler_guard_override_advanced": "Revelações avançadas por categoria",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Desmarque para voltar a ocultar tudo — incluindo o título do próximo episódio — em vez das revelações por categoria ativadas pelo administrador.",
     "panel_settings_spoiler_guard_skip_confirm": "Não pedir confirmação ao desativar a proteção contra spoilers",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Ignora a caixa de diálogo de confirmação de desativação. Poupa um clique ao desativar a proteção contra spoilers para uma série.",
     "hidden_content_hide_button": "Ocultar",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ru.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ru.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Отзывы",
     "panel_settings_spoiler_guard_override_reviews_desc": "Снимите отметку, чтобы видеть панель отзывов TMDB / пользователей на страницах сведений о сериалах.",
     "panel_settings_spoiler_guard_override_advanced": "Расширенное раскрытие по категориям",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Снимите отметку, чтобы снова скрыть всё — включая название следующей серии — вместо раскрытия по категориям, включённого администратором.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Снимите отметку, чтобы снова скрыть всё (включая название следующей серии) вместо раскрытия по категориям, включённого администратором.",
     "panel_settings_spoiler_guard_skip_confirm": "Не спрашивать подтверждение при отключении защиты от спойлеров",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Пропускает диалог подтверждения отключения. Экономит один клик при отключении защиты от спойлеров для сериала.",
     "hidden_content_hide_button": "Скрыть",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ru.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/ru.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Снимите отметку, чтобы видеть сюжетные теги, например \"Смерть главного персонажа\".",
     "panel_settings_spoiler_guard_override_reviews": "Отзывы",
     "panel_settings_spoiler_guard_override_reviews_desc": "Снимите отметку, чтобы видеть панель отзывов TMDB / пользователей на страницах сведений о сериалах.",
+    "panel_settings_spoiler_guard_override_advanced": "Расширенное раскрытие по категориям",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Снимите отметку, чтобы снова скрыть всё — включая название следующей серии — вместо раскрытия по категориям, включённого администратором.",
     "panel_settings_spoiler_guard_skip_confirm": "Не спрашивать подтверждение при отключении защиты от спойлеров",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Пропускает диалог подтверждения отключения. Экономит один клик при отключении защиты от спойлеров для сериала.",
     "hidden_content_hide_button": "Скрыть",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/sk.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/sk.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Zrušte zaškrtnutie, ak chcete vidieť dejové štítky, napríklad \"Smrť hlavnej postavy\".",
     "panel_settings_spoiler_guard_override_reviews": "Recenzie",
     "panel_settings_spoiler_guard_override_reviews_desc": "Zrušte zaškrtnutie, ak chcete na stránkach detailov seriálov vidieť panel recenzií z TMDB / od používateľov.",
+    "panel_settings_spoiler_guard_override_advanced": "Pokročilé odkrývanie podľa kategórií",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Zrušte začiarknutie, ak chcete všetko znova skryť — vrátane názvu ďalšej epizódy — namiesto odkrývania podľa kategórií, ktoré povolil správca.",
     "panel_settings_spoiler_guard_skip_confirm": "Nepýtať sa na potvrdenie pri vypínaní ochrany pred spoilermi",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Preskočí dialóg potvrdenia vypnutia. Ušetrí kliknutie pri vypínaní ochrany pred spoilermi pre seriál.",
     "hidden_content_hide_button": "Skryť",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/sk.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/sk.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Recenzie",
     "panel_settings_spoiler_guard_override_reviews_desc": "Zrušte zaškrtnutie, ak chcete na stránkach detailov seriálov vidieť panel recenzií z TMDB / od používateľov.",
     "panel_settings_spoiler_guard_override_advanced": "Pokročilé odkrývanie podľa kategórií",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Zrušte začiarknutie, ak chcete všetko znova skryť — vrátane názvu ďalšej epizódy — namiesto odkrývania podľa kategórií, ktoré povolil správca.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Zrušte začiarknutie, ak chcete všetko znova skryť (vrátane názvu ďalšej epizódy) namiesto odkrývania podľa kategórií, ktoré povolil správca.",
     "panel_settings_spoiler_guard_skip_confirm": "Nepýtať sa na potvrdenie pri vypínaní ochrany pred spoilermi",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Preskočí dialóg potvrdenia vypnutia. Ušetrí kliknutie pri vypínaní ochrany pred spoilermi pre seriál.",
     "hidden_content_hide_button": "Skryť",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/sv.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/sv.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "Avmarkera för att se berättelsetaggar som \"En huvudpersons död\".",
     "panel_settings_spoiler_guard_override_reviews": "Recensioner",
     "panel_settings_spoiler_guard_override_reviews_desc": "Avmarkera för att se panelen med TMDB- / användarrecensioner på seriens detaljsidor.",
+    "panel_settings_spoiler_guard_override_advanced": "Avancerade visningar per kategori",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Avmarkera för att dölja allt igen — inklusive nästa avsnitts titel — i stället för de kategorivisningar din administratör aktiverat.",
     "panel_settings_spoiler_guard_skip_confirm": "Fråga inte om bekräftelse när spoilerskydd stängs av",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Hoppar över bekräftelsedialogen vid avstängning. Sparar ett klick när du stänger av spoilerskydd för en serie.",
     "hidden_content_hide_button": "Dölj",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/sv.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/sv.json
@@ -540,7 +540,7 @@
     "panel_settings_spoiler_guard_override_reviews": "Recensioner",
     "panel_settings_spoiler_guard_override_reviews_desc": "Avmarkera för att se panelen med TMDB- / användarrecensioner på seriens detaljsidor.",
     "panel_settings_spoiler_guard_override_advanced": "Avancerade visningar per kategori",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Avmarkera för att dölja allt igen — inklusive nästa avsnitts titel — i stället för de kategorivisningar din administratör aktiverat.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Avmarkera för att dölja allt igen (inklusive nästa avsnitts titel) i stället för de kategorivisningar din administratör aktiverat.",
     "panel_settings_spoiler_guard_skip_confirm": "Fråga inte om bekräftelse när spoilerskydd stängs av",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Hoppar över bekräftelsedialogen vid avstängning. Sparar ett klick när du stänger av spoilerskydd för en serie.",
     "hidden_content_hide_button": "Dölj",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/tr.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/tr.json
@@ -524,7 +524,7 @@
     "panel_settings_spoiler_guard_override_reviews": "İncelemeler",
     "panel_settings_spoiler_guard_override_reviews_desc": "Dizi ayrıntı sayfalarında TMDB / kullanıcı incelemeleri panelini görmek için işaretini kaldır.",
     "panel_settings_spoiler_guard_override_advanced": "Kategori bazlı gelişmiş gösterim",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Yönetici tarafından etkinleştirilen kategori bazlı gösterimler yerine her şeyi — bir sonraki bölümün adı dahil — yeniden gizlemek için işareti kaldırın.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Yönetici tarafından etkinleştirilen kategori bazlı gösterimler yerine her şeyi (bir sonraki bölümün adı dahil) yeniden gizlemek için işareti kaldırın.",
     "panel_settings_spoiler_guard_skip_confirm": "Spoiler korumasını kapatırken benden onay isteme",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Devre dışı bırakma onayı iletişim kutusunu atlar. Bir dizi için spoiler korumasını kapatırken bir tıklama kazandırır.",
     "spoiler_blur_pending_button_on": "Spoiler Koruması (beklemede)",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/tr.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/tr.json
@@ -523,6 +523,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "\"Ana karakterin ölümü\" gibi hikaye etiketlerini görmek için işaretini kaldır.",
     "panel_settings_spoiler_guard_override_reviews": "İncelemeler",
     "panel_settings_spoiler_guard_override_reviews_desc": "Dizi ayrıntı sayfalarında TMDB / kullanıcı incelemeleri panelini görmek için işaretini kaldır.",
+    "panel_settings_spoiler_guard_override_advanced": "Kategori bazlı gelişmiş gösterim",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Yönetici tarafından etkinleştirilen kategori bazlı gösterimler yerine her şeyi — bir sonraki bölümün adı dahil — yeniden gizlemek için işareti kaldırın.",
     "panel_settings_spoiler_guard_skip_confirm": "Spoiler korumasını kapatırken benden onay isteme",
     "panel_settings_spoiler_guard_skip_confirm_desc": "Devre dışı bırakma onayı iletişim kutusunu atlar. Bir dizi için spoiler korumasını kapatırken bir tıklama kazandırır.",
     "spoiler_blur_pending_button_on": "Spoiler Koruması (beklemede)",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/uk.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/uk.json
@@ -113,7 +113,7 @@
     "remove_continue_watching_error": "\"Не вдалося видалити: ID користувача або елемента не знайдено.",
     "panel_settings_spoiler_guard_override_reviews_desc": "Зніміть позначку, щоб бачити панель відгуків TMDB / користувачів на сторінках відомостей про серіали.",
     "panel_settings_spoiler_guard_override_advanced": "Розширене розкриття за категоріями",
-    "panel_settings_spoiler_guard_override_advanced_desc": "Зніміть позначку, щоб знову приховати все — включно з назвою наступної серії — замість розкриття за категоріями, увімкненого адміністратором.",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Зніміть позначку, щоб знову приховати все (включно з назвою наступної серії) замість розкриття за категоріями, увімкненого адміністратором.",
     "jellyseerr_card_badge_movie": "Фільм",
     "hidden_content_manage_search": "Пошук прихованих елементів…",
     "bookmark_migrated": "{{icon:success}} Перенесено {count} закладок до {name}",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/uk.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/uk.json
@@ -112,6 +112,8 @@
     "panel_settings_random_button": "Налаштування кнопки випадкового вибору",
     "remove_continue_watching_error": "\"Не вдалося видалити: ID користувача або елемента не знайдено.",
     "panel_settings_spoiler_guard_override_reviews_desc": "Зніміть позначку, щоб бачити панель відгуків TMDB / користувачів на сторінках відомостей про серіали.",
+    "panel_settings_spoiler_guard_override_advanced": "Розширене розкриття за категоріями",
+    "panel_settings_spoiler_guard_override_advanced_desc": "Зніміть позначку, щоб знову приховати все — включно з назвою наступної серії — замість розкриття за категоріями, увімкненого адміністратором.",
     "jellyseerr_card_badge_movie": "Фільм",
     "hidden_content_manage_search": "Пошук прихованих елементів…",
     "bookmark_migrated": "{{icon:success}} Перенесено {count} закладок до {name}",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/zh-CN.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/zh-CN.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "取消勾选可查看剧情标签，例如“主角死亡”。",
     "panel_settings_spoiler_guard_override_reviews": "评论",
     "panel_settings_spoiler_guard_override_reviews_desc": "取消勾选可在剧集详情页查看 TMDB / 用户评论面板。",
+    "panel_settings_spoiler_guard_override_advanced": "按类别的高级显示",
+    "panel_settings_spoiler_guard_override_advanced_desc": "取消勾选可重新隐藏全部内容（包括下一集的标题），不使用管理员启用的按类别显示。",
     "panel_settings_spoiler_guard_skip_confirm": "关闭 Spoiler Guard 时不再要求我确认",
     "panel_settings_spoiler_guard_skip_confirm_desc": "跳过禁用确认对话框。为某部剧关闭 Spoiler Guard 时可节省一次点击。",
     "hidden_content_hide_button": "隐藏",

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/locales/zh-HK.json
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/locales/zh-HK.json
@@ -539,6 +539,8 @@
     "panel_settings_spoiler_guard_override_tags_desc": "取消勾選即可查看劇情標籤，例如「主角死亡」。",
     "panel_settings_spoiler_guard_override_reviews": "評論",
     "panel_settings_spoiler_guard_override_reviews_desc": "取消勾選即可在劇集詳情頁查看 TMDB / 用戶評論面板。",
+    "panel_settings_spoiler_guard_override_advanced": "按類別的進階顯示",
+    "panel_settings_spoiler_guard_override_advanced_desc": "取消勾選可重新隱藏全部內容（包括下一集的標題），不使用管理員啟用的按類別顯示。",
     "panel_settings_spoiler_guard_skip_confirm": "關閉 Spoiler Guard 時不要要求我確認",
     "panel_settings_spoiler_guard_skip_confirm_desc": "略過停用確認對話框。為某部劇關閉 Spoiler Guard 時可節省一次點擊。",
     "hidden_content_hide_button": "隱藏",

--- a/docs/spoiler-guard/spoiler-guard-features.md
+++ b/docs/spoiler-guard/spoiler-guard-features.md
@@ -187,7 +187,23 @@ Every box starts checked (following your admin's policy). Uncheck one and that i
 
 A category only appears in the list when your admin has that strip enabled — there's nothing to opt out of for a category that's already off server-wide.
 
+If your admin has turned on **Advanced per-category reveals** (see below), one extra checkbox shows up here with the same name. That one runs the other way round: unchecking it hides *more*, not less — it puts your account back on the uniform full strip instead of the reveals your admin configured.
+
 The same section has a **"Don't ask me to confirm when turning Spoiler Guard off"** checkbox, which permanently skips the disable-confirmation dialog (unlike the dialog's own "Don't ask again for 15 minutes" snooze, this one never expires).
+
+---
+
+## Advanced per-category reveals (optional, admin-controlled)
+
+Normally every unwatched episode of a protected show is hidden identically. When your admin enables **Advanced per-category reveals**, unwatched episodes split into three groups and the first two can show a little more:
+
+- **Your next episode** — the first episode you haven't watched, in season/episode order (specials don't count). Out of the box this is the only thing that changes: its **real title becomes visible** while the synopsis, ratings, and artwork stay hidden. You get to see *what* you're about to watch, and nothing else.
+- **The rest of that season** — hidden exactly as before unless your admin relaxes titles, descriptions, or ratings for the category.
+- **Everything else** — later seasons, seasons you skipped, and specials keep the full protection. So do images, search results, and card rating overlays, in every category — the reveals only ever affect episode metadata in lists and on detail pages.
+
+The boundary moves as you watch: mark your next episode played and the following one takes over. Anything the plugin can't categorise with certainty stays fully hidden, so a reveal never appears by accident.
+
+Don't want it? Uncheck **Advanced per-category reveals** in your own Spoiler Guard settings and your account goes back to the uniform full strip.
 
 ---
 

--- a/docs/spoiler-guard/spoiler-guard-settings.md
+++ b/docs/spoiler-guard/spoiler-guard-settings.md
@@ -180,6 +180,30 @@ In both modes the character name (`Role`) is also stripped from any surviving Pe
 
 ---
 
+## Advanced per-category reveals
+
+By default every unwatched episode of a guarded series gets the same uniform strip. **Advanced per-category reveals** (its own section under Spoiler Guard, off by default) splits unwatched episodes into three categories and gives the first two their own reveal masks:
+
+- **Next episode** — the user's first unwatched regular episode, in season/episode order (specials in Season 0 never count). By default this is the only thing advanced mode changes: its **real title shows** while everything else stays hidden — you can see *what* you're about to watch, and nothing more.
+- **Current season** — the other unwatched episodes in the same season as the next episode. Fully stripped by default, with optional per-field reveals.
+- **Everything else** — later seasons, skipped earlier seasons, and specials always keep the full uniform strip. So do search results, card rating overlays, images, and every other protected surface: the reveals apply to the episode metadata itself (episode lists, Next Up, detail pages), never to the stricter surfaces.
+
+| Setting | Default | What it does |
+|---|---|---|
+| **Enable advanced per-category reveals** | Off | Master switch for the category logic. Off = today's uniform strip, byte for byte. |
+| **Next episode: keep title hidden** | Off | Unchecked means the next episode's real title shows instead of "Season X, Episode Y". |
+| **Next episode: keep description hidden** | On | Untick to also show the next episode's synopsis. |
+| **Next episode: keep ratings hidden** | On | Untick to show community/critic ratings on the next episode. |
+| **Current season: keep titles hidden** | On | Untick to show real titles across the current season. |
+| **Current season: keep descriptions hidden** | On | Untick to show synopses across the current season. |
+| **Current season: keep ratings hidden** | On | Untick to show ratings across the current season — useful when you want to know which episodes of the season you're in are fan favourites without reading anything about them. |
+
+A reveal can only *relax* a strip that's enabled above it — if you turned off **Replace episode titles** globally, titles already show everywhere and the category toggles for titles have nothing to do. The boundary follows each user's watched-state (marking the next episode watched promotes the following one immediately in the common case, and within five minutes at the very worst), and every ambiguous situation — an episode with no season/episode numbers, a fully-watched series, a resolver fault — falls back to the full strip, never a reveal.
+
+Each user can opt back out of advanced mode entirely: an **Advanced per-category reveals** checkbox appears in their own Spoiler Guard settings (see [Per-user overrides](#per-user-overrides)) and restores the uniform full strip for that account only.
+
+---
+
 ## Per-user overrides
 
 The metadata toggles above set server-wide policy, but individual users can opt back **out** of any strip category for themselves. The JE user settings panel (gear icon → **Jellyfin Enhanced** → **Spoiler Guard**) has a **"Show me this even with Spoiler Guard on"** area with one checkbox per category: TV show descriptions, Episode descriptions, Episode titles, Chapter names, Cast list, Ratings, Air date, Taglines, Tags, and Reviews.
@@ -189,6 +213,8 @@ The gating is one-directional — the admin still decides what's available:
 - A category row only appears in the user panel when the admin has that strip **enabled**. Users can relax the policy for themselves; they can't re-enable a category the admin turned off.
 - Unchecking a box writes an opt-out (`false`) into the `Prefs` of that user's `spoilerblur.json`. It applies only to that user — everyone else keeps the admin default.
 - Image replacement is not user-overridable; how unwatched cards look stays admin policy.
+
+When [Advanced per-category reveals](#advanced-per-category-reveals) is enabled, one more checkbox appears in the same area: **Advanced per-category reveals**. It works in the opposite direction from the rest — unchecking it makes things *stricter* for that user, restoring the uniform full strip (including hiding the next episode's title again) instead of the category reveals the admin configured.
 
 The same panel section also holds a per-user **"Don't ask me to confirm when turning Spoiler Guard off"** preference, which permanently skips the disable-confirmation dialog (the dialog itself only offers a 15-minute snooze).
 
@@ -241,5 +267,12 @@ Most logs are at INFO; corruption + unexpected shapes log at WARNING.
 | Hide cast on unwatched episodes | On |
 | Cast hiding scope | Guest stars only |
 | Hide reviews on Spoiler Guard series | On |
+| Enable advanced per-category reveals | Off |
+| Next episode: keep title hidden | Off |
+| Next episode: keep description hidden | On |
+| Next episode: keep ratings hidden | On |
+| Current season: keep titles hidden | On |
+| Current season: keep descriptions hidden | On |
+| Current season: keep ratings hidden | On |
 
 The strict-by-default posture means once an admin flips the master switch and a user opts a show in, every spoiler surface is protected without further configuration. Admins who want a looser setup can untick anything they don't need.


### PR DESCRIPTION
## Description

Implements the advanced Spoiler Guard filters requested in #736. Instead of the all-or-nothing strip, admins can now reveal selected fields for exactly two categories of unwatched content:

- **Next unwatched episode** — reveal title, description, and/or ratings (default: title only)
- **Current season** (the season containing the next unwatched episode) — reveal title, description, and/or ratings (default: nothing)

Everything else — later episodes, later seasons, other series — keeps the full strip. Users who prefer the original behavior get a per-user **"Advanced per-category reveals"** opt-out in the Spoiler Guard settings tab; unchecking it hides everything again, including the next episode's title.

## Implementation Notes

- `SpoilerNextUnwatchedService` — resolves the per-(user, series) next-unwatched boundary with a bounded cache and fail-closed background fill (generation-token invalidation), so no library queries run on the request thread. While the boundary for a series is not yet known, content stays fully stripped.
- `SpoilerFieldStripFilter` — categorizes each item against the boundary (episode matched by id only, season by the boundary episode's season) and applies the admin's `CategoryReveal` mask; category index validation happens before any id match.
- Admin config: reveal masks in `PluginConfiguration` + config page section; per-user opt-out in `UserConfiguration`, persisted through the prefs POST handler.
- Tag-cache overlays and search hints deliberately stay uniformly stripped (documented in the code) — they are shared surfaces where a per-user boundary can't be applied safely.
- Docs pages updated (`docs/spoiler-guard/`); `mkdocs build --strict` passes. All 29 locales carry the new settings strings (English text; translatable via Weblate).

This PR was developed with AI assistance (Claude). I have reviewed and tested the changes and understand the implementation.

## Testing

- [x] Builds clean for both targets: `JellyfinTarget=jf10` (Jellyfin 10.11, .NET 9) and `JellyfinTarget=jf12` (.NET 10), 0 warnings
- [x] Runtime-verified on Jellyfin 10.11: next-episode title reveal appears, later episodes stay stripped, and the per-user opt-out persists across a save/reload (this exposed a prefs-persistence bug, fixed in the last commit)
- [x] No console errors
- [x] Rebased onto current `main` (post-12.2.0.0) with a clean rebase; both builds re-verified after the rebase


## Screenshots

Captured on a clean Jellyfin 10.11.11 instance with a 3-episode test series (episode 1 watched).

**Season episode list** — episode 1 (watched) is untouched, episode 2 is the next unwatched episode so its title "The Secret Twist" is revealed, and episode 3 keeps the full strip ("Season 1, Episode 3"):

![Season episode list with next-episode title revealed](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/assets/pr-762-screenshots/1-season-episodes.png)

**Admin config** (Display tab → Spoiler Guard → Advanced per-category reveals) — per-category masks with the defaults, where only the next episode's title starts revealed:

![Admin advanced per-category reveals section](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/assets/pr-762-screenshots/3-admin-config.png)

**Per-user opt-out** (Enhanced panel → Spoiler Guard) — the new "Advanced per-category reveals" row; unchecking restores the uniform full strip for that user:

![User settings panel with the advanced reveals opt-out](https://raw.githubusercontent.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced/assets/pr-762-screenshots/2-user-panel.png)

Fixes #736
