### PR TITLE
feat: enable quality tags in Home Videos and Photos libraries

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/TagCacheService.cs
@@ -91,6 +91,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             BaseItemKind.Series,
             BaseItemKind.Season,
             BaseItemKind.BoxSet,
+            BaseItemKind.Video,
         };
 
         public TagCacheService(ILibraryManager libraryManager, IApplicationPaths applicationPaths, Logger logger)

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/tags/tag-pipeline.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/tags/tag-pipeline.js
@@ -11,7 +11,7 @@
 
     // ── Configuration ──────────────────────────────────────────────────
 
-    const MEDIA_TYPES = new Set(['Movie', 'Episode', 'Series', 'Season', 'BoxSet']);
+    const MEDIA_TYPES = new Set(['Movie', 'Episode', 'Series', 'Season', 'BoxSet', 'Video']);
     const FETCH_DEBOUNCE_MS = 150; // Debounce only the batch API call, not the scan
     const logPrefix = '🪼 Jellyfin Enhanced [TagPipeline]:';
     let serverCache = null; // Map<itemId, TagCacheEntry> loaded from server


### PR DESCRIPTION
## What
Fixes #775 by allowing the tag pipeline to process `Video` items, which is the BaseItemKind Jellyfin uses for video files inside Home Videos and Photos (and any other non-movie) libraries — e.g. YouTube downloads. Two gates excluded `Video` items before they ever reached the quality renderer:

1. Frontend (`js/tags/tag-pipeline.js`): the `MEDIA_TYPES` whitelist used by the scan, batch render and fallback paths dropped items whose `Type` was not Movie/Episode/Series/Season/BoxSet, so Home Videos cards were marked processed and never got quality overlays.
2. Backend (`Services/TagCacheService.cs`): `TaggableTypes` gates the server-side tag cache build, reconcile and ItemUpdated/ItemRemoved monitoring, so Video entries were never cached (nor invalidated) in server-cache mode.

The quality renderer itself (`getEnhancedQuality`) is type-agnostic — it analyzes `MediaStreams`/`MediaSources` — so no renderer changes are needed. Items without streams (e.g. still photos) simply produce no tags, keeping the change safe.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #775