### PR TITLE
fix: make Seerr search React-safe and responsive

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/JellyfinEnhanced.csproj
+++ b/Jellyfin.Plugin.JellyfinEnhanced/JellyfinEnhanced.csproj
@@ -12,8 +12,9 @@
 
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <AssemblyVersion>12.4.1.0</AssemblyVersion>
-        <FileVersion>12.4.1.0</FileVersion>
+        <AssemblyVersion>12.4.1.7</AssemblyVersion>
+        <FileVersion>12.4.1.7</FileVersion>
+
         <RootNamespace>Jellyfin.Plugin.JellyfinEnhanced</RootNamespace>
         <AssemblyName>Jellyfin.Plugin.JellyfinEnhanced</AssemblyName>
     </PropertyGroup>

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/api.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/api.js
@@ -312,9 +312,9 @@
      * @param {number} tmdbId - The TMDB ID of the TV show.
      * @returns {Promise<object|null>}
      */
-    api.fetchTvShowDetails = async function(tmdbId) {
+    api.fetchTvShowDetails = async function(tmdbId, options = {}) {
         try {
-            return await get(`/tv/${tmdbId}`);
+            return await get(`/tv/${tmdbId}`, options);
         } catch (error) {
             console.error(`${logPrefix} Failed to fetch TV show details for TMDB ID ${tmdbId}:`, error);
             return null;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/jellyseerr.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/jellyseerr.js
@@ -21,210 +21,73 @@
         const escapeHtml = JE.escapeHtml;
         console.log(`${logPrefix} Initializing...`);
 
-        // ================================
-        // STATE MANAGEMENT VARIABLES
-        // ================================
         let lastProcessedQuery = null;
+        let searchGeneration = 0;
         let debounceTimeout = null;
         let isJellyseerrActive = false;
         let jellyseerrUserFound = false;
-        let isJellyseerrOnlyMode = false;
-        let hiddenSections = [];
-        let jellyseerrOriginalPosition = null;
 
-        // Infinite scroll pagination state
-        let searchCurrentPage = 0;
-        let searchTotalPages = 0;
-        let searchIsLoading = false;
-        let searchHasMore = false;
-        const searchScrollState = {};
-        let searchDeduplicator = null;
-
-
-        // Destructure modules for easy access
         const { checkUserStatus, search, requestMedia } = JE.jellyseerrAPI;
         const {
             addMainStyles, addSeasonModalStyles, updateJellyseerrIcon,
             renderJellyseerrResults, showMovieRequestModal, showSeasonSelectionModal,
-            showCollectionRequestModal, hideHoverPopover, toggleHoverPopoverLock, updateJellyseerrResults,
-            createJellyseerrCard
+            showCollectionRequestModal, hideHoverPopover, toggleHoverPopoverLock, updateJellyseerrResults
         } = JE.jellyseerrUI;
 
-        /**
-         * Toggles between showing all search results vs only Seerr results.
-         */
-        function toggleJellyseerrOnlyMode() {
-            isJellyseerrOnlyMode = !isJellyseerrOnlyMode;
-
-            const searchPage = document.querySelector('#searchPage');
-            if (!searchPage) return;
-
-            if (isJellyseerrOnlyMode) {
-                const allSections = searchPage.querySelectorAll('.verticalSection:not(.jellyseerr-section)');
-                hiddenSections = Array.from(allSections);
-                allSections.forEach(section => section.classList.add('section-hidden'));
-
-                const jellyseerrSection = searchPage.querySelector('.jellyseerr-section');
-                if (jellyseerrSection) {
-                    jellyseerrOriginalPosition = document.createElement('div');
-                    jellyseerrOriginalPosition.id = 'jellyseerr-placeholder';
-                    jellyseerrSection.parentNode.insertBefore(jellyseerrOriginalPosition, jellyseerrSection);
-                    const searchResults = searchPage.querySelector('.searchResults, [class*="searchResults"], .padded-top.padded-bottom-page');
-                    if (searchResults) {
-                        searchResults.insertBefore(jellyseerrSection, searchResults.firstChild);
-                    }
-                }
-                const noResultsMessage = searchPage.querySelector('.noItemsMessage');
-                if (noResultsMessage) noResultsMessage.classList.add('section-hidden');
-
-                JE.toast(JE.t('jellyseerr_toast_filter_on'), 3000);
-
-            } else {
-                hiddenSections.forEach(section => section.classList.remove('section-hidden'));
-                const jellyseerrSection = searchPage.querySelector('.jellyseerr-section');
-                if (jellyseerrSection && jellyseerrOriginalPosition?.parentNode) {
-                    jellyseerrOriginalPosition.parentNode.insertBefore(jellyseerrSection, jellyseerrOriginalPosition);
-                    jellyseerrOriginalPosition.remove();
-                    jellyseerrOriginalPosition = null;
-                }
-                const noResultsMessage = searchPage.querySelector('.noItemsMessage');
-                if (noResultsMessage) noResultsMessage.classList.remove('section-hidden');
-
-                hiddenSections = [];
-                JE.toast(JE.t('jellyseerr_toast_filter_off'), 3000);
-            }
-
-            const jellyseerrSection = searchPage.querySelector('.jellyseerr-section');
-            if (jellyseerrSection) {
-                const titleElement = jellyseerrSection.querySelector('.sectionTitle');
-                if (titleElement) {
-                    titleElement.textContent = isJellyseerrOnlyMode ? JE.t('jellyseerr_results_title') : JE.t('jellyseerr_discover_title');
-                }
-            }
-            updateJellyseerrIcon(isJellyseerrActive, jellyseerrUserFound, isJellyseerrOnlyMode, toggleJellyseerrOnlyMode);
+        function closeJellyseerrSearch() {
+            const host = document.getElementById('jellyseerr-search-host');
+            if (host) { host.classList.remove('is-open'); host.replaceChildren(); }
+            JE.jellyseerrUI.clearJellyseerrSearchSpace?.();
+            lastProcessedQuery = null;
         }
 
-        /**
-         * Resets search pagination state for a new query.
-         */
-        function resetSearchPagination() {
-            searchCurrentPage = 0;
-            searchTotalPages = 0;
-            searchIsLoading = false;
-            searchHasMore = false;
-            if (searchDeduplicator) searchDeduplicator.clear();
-            JE.seamlessScroll?.cleanupInfiniteScroll(searchScrollState);
-        }
-
-        /**
-         * Fetches and renders search results (page 1), then sets up infinite scroll.
-         * @param {string} query The search query.
-         */
         async function fetchAndRenderResults(query, options = {}) {
+            const normalized = String(query || '').trim();
+            const generation = options.generation ?? ++searchGeneration;
+            if (!normalized) {
+                closeJellyseerrSearch();
+                return;
+            }
             const { skipCache = false } = options;
-            lastProcessedQuery = query;
-            resetSearchPagination();
-            searchDeduplicator = JE.seamlessScroll?.createDeduplicator() || null;
-
             // Cancel any still-in-flight search/collection requests from the
             // previous keystroke instead of letting them queue up.
             const signal = JE.requestManager?.getAbortSignal('jellyseerr-search');
 
             let data;
             try {
-                data = await search(query, 1, { skipCache, signal });
+                if (options.generation == null) lastProcessedQuery = normalized;
+                data = await search(normalized, 1, { skipCache, signal });
             } catch (error) {
                 if (error.name === 'AbortError') return; // superseded by a newer search
                 throw error;
             }
-            if (lastProcessedQuery !== query) return; // superseded by a newer search while this was in flight
-
-            let results = data.results || [];
-            searchCurrentPage = data.page || 1;
-            searchTotalPages = data.totalPages || 1;
-            searchHasMore = searchCurrentPage < searchTotalPages;
-
+            if (generation !== searchGeneration || lastProcessedQuery !== normalized) return;
+            let results = await prepareResultsWithCollections(data.results || [], { signal });
+            if (generation !== searchGeneration) return;
             if (JE.hiddenContent) results = JE.hiddenContent.filterJellyseerrResults(results, 'search');
-            if (searchDeduplicator) searchDeduplicator.filter(results);
-
-            if (results.length > 0) {
-                renderJellyseerrResults(results, query, isJellyseerrOnlyMode, isJellyseerrActive, jellyseerrUserFound);
-
-                // Enrich with collections in the background, then re-render
-                prepareResultsWithCollections(results, { signal }).then(enrichedResults => {
-                    if (lastProcessedQuery !== query) return;
-                    if (JE.hiddenContent) enrichedResults = JE.hiddenContent.filterJellyseerrResults(enrichedResults, 'search');
-                    if (enrichedResults.length > results.length) {
-                        renderJellyseerrResults(enrichedResults, query, isJellyseerrOnlyMode, isJellyseerrActive, jellyseerrUserFound);
-                    }
-                }).catch(() => {});
-
-                // Set up infinite scroll if more pages exist
-                if (searchHasMore) {
-                    setupSearchInfiniteScroll(query);
-                }
-            }
+            if (generation !== searchGeneration) return;
+            renderJellyseerrResults(results, normalized, true, isJellyseerrActive, jellyseerrUserFound);
         }
 
-        /**
-         * Loads the next page of search results and appends cards to the container.
-         * @param {string} query The current search query.
-         */
-        async function loadMoreSearchResults(query) {
-            if (searchIsLoading || !searchHasMore || lastProcessedQuery !== query) return;
-
-            searchIsLoading = true;
-            const nextPage = searchCurrentPage + 1;
-
-            try {
-                const data = await search(query, nextPage);
-                if (lastProcessedQuery !== query) return; // query changed during fetch
-
-                let results = data.results || [];
-                searchCurrentPage = data.page || nextPage;
-                searchTotalPages = data.totalPages || searchTotalPages;
-                searchHasMore = searchCurrentPage < searchTotalPages;
-
-                if (JE.hiddenContent) results = JE.hiddenContent.filterJellyseerrResults(results, 'search');
-                if (searchDeduplicator) results = searchDeduplicator.filter(results);
-
-                if (results.length > 0) {
-                    const itemsContainer = document.querySelector('.jellyseerr-section .itemsContainer');
-                    if (itemsContainer) {
-                        const fragment = document.createDocumentFragment();
-                        results.forEach(item => {
-                            const card = createJellyseerrCard(item, isJellyseerrActive, jellyseerrUserFound);
-                            fragment.appendChild(card);
-                        });
-                        itemsContainer.appendChild(fragment);
-                    }
+        function bindNativeSearchInput() {
+            const jellyfinInput = document.querySelector('#searchTextInput');
+            if (!jellyfinInput) return;
+            JE.jellyseerrUI.ensureJellyseerrSearchSpace?.();
+            if (jellyfinInput.dataset.jellyseerrBound === 'true') return;
+            jellyfinInput.dataset.jellyseerrBound = 'true';
+            jellyfinInput.addEventListener('input', () => {
+                const query = jellyfinInput.value;
+                const normalized = query.trim();
+                const generation = ++searchGeneration;
+                lastProcessedQuery = normalized || null;
+                clearTimeout(debounceTimeout);
+                if (!normalized) {
+                    closeJellyseerrSearch();
+                    return;
                 }
-            } catch (error) {
-                if (error.name !== 'AbortError') {
-                    console.warn(`${logPrefix} Failed to load more search results:`, error);
-                    // Roll back page on failure
-                    searchHasMore = true;
-                }
-                throw error; // Re-throw for seamlessScroll retry handling
-            } finally {
-                searchIsLoading = false;
-            }
-        }
-
-        /**
-         * Sets up the infinite scroll observer for search results.
-         * @param {string} query The current search query.
-         */
-        function setupSearchInfiniteScroll(query) {
-            if (!JE.seamlessScroll) return;
-
-            JE.seamlessScroll.setupInfiniteScroll(
-                searchScrollState,
-                '.jellyseerr-section',
-                () => loadMoreSearchResults(query),
-                () => searchHasMore,
-                () => searchIsLoading
-            );
+                debounceTimeout = setTimeout(() => fetchAndRenderResults(query, { generation }), 300);
+            });
+            if (jellyfinInput.value.trim()) fetchAndRenderResults(jellyfinInput.value);
         }
 
         /**
@@ -285,162 +148,24 @@
             return results;
         }
 
-        /**
-         * Fetches fresh data and updates the existing UI elements.
-         * @param {string} query The current search query.
-         */
-        // Manual refresh handler
-        async function manualRefreshJellyseerrData(query) {
-            const section = document.querySelector('.jellyseerr-section');
-            const itemsContainer = section?.querySelector('.itemsContainer');
-            if (!query || !itemsContainer) return;
-
-            console.log(`${logPrefix} Refreshing data for query: "${query}"`);
-            try {
-                resetSearchPagination();
-                searchDeduplicator = JE.seamlessScroll?.createDeduplicator() || null;
-
-                const signal = JE.requestManager?.getAbortSignal('jellyseerr-search');
-                const data = await search(query, 1, { signal });
-                let results = await prepareResultsWithCollections(data.results || [], { signal });
-                if (JE.hiddenContent) results = JE.hiddenContent.filterJellyseerrResults(results, 'search');
-
-                searchCurrentPage = data.page || 1;
-                searchTotalPages = data.totalPages || 1;
-                searchHasMore = searchCurrentPage < searchTotalPages;
-                if (searchDeduplicator) searchDeduplicator.filter(results);
-
-                while (itemsContainer.firstChild) itemsContainer.removeChild(itemsContainer.firstChild);
-                results.forEach(item => {
-                    const card = createJellyseerrCard(item, isJellyseerrActive, jellyseerrUserFound);
-                    itemsContainer.appendChild(card);
-                });
-                updateJellyseerrResults(results, isJellyseerrActive, jellyseerrUserFound);
-
-                if (searchHasMore) {
-                    setupSearchInfiniteScroll(query);
-                }
-            } catch (error) {
-                if (error.name !== 'AbortError') {
-                    console.warn(`${logPrefix} Failed to refresh Seerr data:`, error);
-                }
-            }
-        }
-
-        /**
-         * Sets up DOM observation for search page changes.
-         */
         function initializePageObserver() {
-            const handleSearch = () => {
-                const searchInput = document.querySelector('#searchPage #searchTextInput');
-                const isSearchPage = searchInput !== null;
-                const currentQuery = isSearchPage ? searchInput.value : null;
-
-                if (isSearchPage && currentQuery?.trim()) {
-                    clearTimeout(debounceTimeout);
-                    debounceTimeout = setTimeout(() => {
-                        if (!isJellyseerrActive) {
-                            document.querySelectorAll('.jellyseerr-section').forEach(el => el.remove());
-                            return;
-                        }
-                        const latestQuery = searchInput.value;
-                        if (latestQuery === lastProcessedQuery) return;
-
-                        if (isJellyseerrOnlyMode) {
-                            isJellyseerrOnlyMode = false;
-                            hiddenSections = [];
-                            jellyseerrOriginalPosition = null;
-                            updateJellyseerrIcon(isJellyseerrActive, jellyseerrUserFound, false, toggleJellyseerrOnlyMode);
-                        }
-                        lastProcessedQuery = latestQuery;
-                        resetSearchPagination();
-                        document.querySelectorAll('.jellyseerr-section').forEach(el => el.remove());
-                        fetchAndRenderResults(latestQuery);
-                    }, 300);
-                } else {
-                    clearTimeout(debounceTimeout);
-                    lastProcessedQuery = null;
-                    isJellyseerrOnlyMode = false;
-                    resetSearchPagination();
-                    document.querySelectorAll('.jellyseerr-section').forEach(el => el.remove());
-                }
-            };
-
-            /**
-             * Attempts to attach the search input listener if the search page is visible.
-             * Called by the MutationObserver, navigation events, and on initial setup.
-             * Idempotent — sets data-jellyseerr-listener on the input to prevent
-             * duplicate attachment, and adds a permanent 'input' event handler.
-             */
-            function tryAttachSearchListener() {
-                updateJellyseerrIcon(isJellyseerrActive, jellyseerrUserFound, isJellyseerrOnlyMode, toggleJellyseerrOnlyMode);
-
-                const searchInput = document.querySelector('#searchPage #searchTextInput');
-                if (searchInput && !searchInput.dataset.jellyseerrListener) {
-                    console.debug(`${logPrefix} Search input found, attaching listener.`);
-                    searchInput.addEventListener('input', handleSearch);
-                    searchInput.dataset.jellyseerrListener = 'true';
-
-                    // Add a click listener for the alphabet picker
-                    const alphaPicker = document.querySelector('.alphaPicker');
-                    if (alphaPicker) {
-                        alphaPicker.addEventListener('click', () => {
-                            // Use a short delay to ensure the input value has updated before we read it
-                            setTimeout(handleSearch, 100);
-                        });
-                    }
-
-                    // Also handle the case where the page loads with a query already in the box
-                    handleSearch();
-                }
-            }
-
-            /**
-             * Called on every SPA navigation. If we've navigated away from the search
-             * page entirely, tear down pagination/infinite-scroll state so stale
-             * scroll listeners don't keep hitting the search endpoint from other pages.
-             * Otherwise, (re)attach the search listener as usual.
-             */
-            function handleNavigate() {
-                const searchInput = document.querySelector('#searchPage #searchTextInput');
-                if (!searchInput) {
-                    clearTimeout(debounceTimeout);
-                    lastProcessedQuery = null;
-                    isJellyseerrOnlyMode = false;
-                    resetSearchPagination();
-                    document.querySelectorAll('.jellyseerr-section').forEach(el => el.remove());
-                    return;
-                }
-                tryAttachSearchListener();
-            }
-
-            // Listen for manual refresh events from the UI
-            document.addEventListener('jellyseerr-manual-refresh', function(e) {
-                const searchInput = document.querySelector('#searchPage #searchTextInput');
-                const query = searchInput ? searchInput.value : null;
-                manualRefreshJellyseerrData(query);
+            const ensureNativeBinding = () => bindNativeSearchInput();
+            JE.helpers.onBodyMutation('jellyseerr-native-search', ensureNativeBinding);
+            ensureNativeBinding();
+            document.addEventListener('jellyseerr-manual-refresh', () => {
+                clearTimeout(debounceTimeout);
+                debounceTimeout = null;
+                const query = document.querySelector('#searchTextInput')?.value;
+                if (query) fetchAndRenderResults(query, { skipCache: true });
             });
-
-            JE.helpers.onBodyMutation('jellyseerr-search-listener', tryAttachSearchListener);
-
-            // Immediately check if the search page is already rendered (handles the
-            // case where the observer was set up after the search page loaded, e.g.
-            // when the user navigates directly to /search before plugin init completes).
-            tryAttachSearchListener();
-
-            // Listen for SPA navigation events as a backup — MutationObserver may
-            // miss the search page if no further DOM mutations occur after render.
-            // Uses the shared je:navigate event (from helpers.js) which already
-            // patches pushState/replaceState, plus popstate and hashchange.
             if (JE.helpers?.onNavigate) {
-                JE.helpers.onNavigate(() => setTimeout(handleNavigate, 200));
-            } else {
-                // Fallback if helpers.js hasn't loaded yet — may double-fire with
-                // onNavigate if helpers loads later, but tryAttachSearchListener is
-                // idempotent (guarded by dataset.jellyseerrListener) so this is safe.
-                const onNav = () => setTimeout(handleNavigate, 200);
-                window.addEventListener('popstate', onNav);
-                window.addEventListener('hashchange', onNav);
+                JE.helpers.onNavigate(() => {
+                    clearTimeout(debounceTimeout);
+                    debounceTimeout = null;
+                    searchGeneration++;
+                    closeJellyseerrSearch();
+                    setTimeout(ensureNativeBinding, 200);
+                });
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-results.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-results.js
@@ -15,10 +15,6 @@
     const icons = internal.icons; // requires ui-icons.js to be loaded first
     const addTouchTapListener = JE.core.ui.addTouchTapListener;
 
-    // Only one search-results reposition watcher may be live at a time; a newer
-    // render must cancel the previous one (see renderJellyseerrResults).
-    let pendingRepositionObserver = null;
-    let pendingRepositionTimeout = null;
 
     // Keep card buttons in sync when a request is made from other surfaces (e.g., more info modal)
     function markCardRequested(tmdbId, mediaType, is4k = false) {
@@ -65,70 +61,73 @@
     // UI MANAGEMENT FUNCTIONS
     // ================================
 
-    /**
-     * Updates the Seerr icon in the search field based on current state.
-     * @param {boolean} isJellyseerrActive - If the server is reachable.
-     * @param {boolean} jellyseerrUserFound - If the current user is linked.
-     * @param {boolean} isJellyseerrOnlyMode - If the results are filtered.
-     * @param {function} onToggleFilter - The function to call to toggle the filter.
-     */
-    ui.updateJellyseerrIcon = function(isJellyseerrActive, jellyseerrUserFound, isJellyseerrOnlyMode, onToggleFilter) {
-        const anchor = document.querySelector('.searchFields .inputContainer') ||
-                       document.querySelector('#searchPage .searchFields') ||
-                       document.querySelector('#searchPage');
-        if (!anchor) return;
+    // The native Jellyfin search input is the only user-facing search control.
+    // Kept as a no-op for callers shared with older builds.
+    ui.updateJellyseerrIcon = function() {};
 
-        let icon = document.getElementById('jellyseerr-search-icon');
-        if (!icon) {
-            icon = document.createElement('img');
-            icon.id = 'jellyseerr-search-icon';
-            icon.className = 'jellyseerr-icon';
-            icon.src = JE.cdn.selfhst('svg/seerr.svg');
-            icon.alt = 'Seerr';
+    function getNativeSearchLayoutContainer() {
+        const input = document.querySelector('#searchTextInput');
+        return input?.closest('.inputContainer') || input?.parentElement || null;
+    }
 
-            let tapCount = 0;
-            let tapTimer = null;
-            const handleIconInteraction = () => {
-                if (!isJellyseerrActive || !jellyseerrUserFound || !onToggleFilter) return;
-                tapCount++;
-                if (tapCount === 1) {
-                    tapTimer = setTimeout(() => { tapCount = 0; }, 300);
-                } else if (tapCount === 2) {
-                    clearTimeout(tapTimer);
-                    tapCount = 0;
-                    onToggleFilter();
-                }
+    function clearNativeSearchSpace() {
+        document.querySelectorAll('[data-jellyseerr-space="true"]').forEach(container => {
+            container.style.marginBottom = container.dataset.jellyseerrPreviousMargin || '';
+            delete container.dataset.jellyseerrPreviousMargin;
+            delete container.dataset.jellyseerrSpace;
+        });
+        const host = document.getElementById('jellyseerr-search-host');
+        if (host) {
+            host.style.removeProperty('top');
+            host.style.removeProperty('max-height');
+        }
+    }
+
+    function reserveNativeSearchSpace(host) {
+        const container = getNativeSearchLayoutContainer();
+        if (!container) return;
+        document.querySelectorAll('[data-jellyseerr-space="true"]').forEach(previous => {
+            if (previous === container) return;
+            previous.style.marginBottom = previous.dataset.jellyseerrPreviousMargin || '';
+            delete previous.dataset.jellyseerrPreviousMargin;
+            delete previous.dataset.jellyseerrSpace;
+        });
+        if (container.dataset.jellyseerrSpace !== 'true') {
+            container.dataset.jellyseerrPreviousMargin = container.style.marginBottom || '';
+            container.dataset.jellyseerrSpace = 'true';
+        }
+        requestAnimationFrame(() => {
+            if (!host.classList.contains('is-open') || !container.isConnected) return;
+            const top = Math.ceil(container.getBoundingClientRect().bottom + 8);
+            host.style.top = `${top}px`;
+            host.style.maxHeight = `calc(100dvh - ${top}px - env(safe-area-inset-bottom))`;
+            container.style.marginBottom = `${Math.ceil(host.getBoundingClientRect().height) + 16}px`;
+        });
+    }
+
+    let hostResizeObserver = null;
+    let viewportListenersBound = false;
+    function observeSearchHost(host) {
+        if (hostResizeObserver || typeof ResizeObserver === 'undefined') return;
+        hostResizeObserver = new ResizeObserver(() => {
+            if (host.classList.contains('is-open')) reserveNativeSearchSpace(host);
+        });
+        hostResizeObserver.observe(host);
+        if (!viewportListenersBound) {
+            const reposition = () => {
+                if (host.classList.contains('is-open')) reserveNativeSearchSpace(host);
             };
-
-            icon.addEventListener('click', handleIconInteraction);
-            // Tap detection (rather than a bare touchend) so a scroll gesture that
-            // happens to start on the icon is not miscounted toward the double-tap
-            // filter toggle; preventDefault() suppresses the synthetic click that
-            // would otherwise double-count the tap via the click listener above.
-            addTouchTapListener(icon, (e) => { e.preventDefault(); handleIconInteraction(); });
-            icon.setAttribute('tabindex', '0');
-            icon.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    if (!isJellyseerrActive || !jellyseerrUserFound || !onToggleFilter) return;
-                    onToggleFilter();
-                }
-            });
-            anchor.appendChild(icon);
+            window.addEventListener('resize', reposition, { passive: true });
+            window.visualViewport?.addEventListener('resize', reposition, { passive: true });
+            window.visualViewport?.addEventListener('scroll', reposition, { passive: true });
+            viewportListenersBound = true;
         }
+    }
 
-        icon.classList.remove('is-active', 'is-disabled', 'is-no-user', 'is-filter-active');
-        if (isJellyseerrActive && jellyseerrUserFound) {
-            icon.title = JE.t(isJellyseerrOnlyMode ? 'jellyseerr_icon_active_filter_tooltip' : 'jellyseerr_icon_active_tooltip');
-            icon.classList.add('is-active');
-            if (isJellyseerrOnlyMode) icon.classList.add('is-filter-active');
-        } else if (isJellyseerrActive && !jellyseerrUserFound) {
-            icon.title = JE.t('jellyseerr_icon_no_user_tooltip');
-            icon.classList.add('is-no-user');
-        } else {
-            icon.title = JE.t('jellyseerr_icon_disabled_tooltip');
-            icon.classList.add('is-disabled');
-        }
+    ui.clearJellyseerrSearchSpace = clearNativeSearchSpace;
+    ui.ensureJellyseerrSearchSpace = function() {
+        const host = document.getElementById('jellyseerr-search-host');
+        if (host?.classList.contains('is-open')) reserveNativeSearchSpace(host);
     };
 
     /**
@@ -179,7 +178,7 @@
     }
 
     /**
-     * Renders Seerr search results into the search page with improved placement logic.
+     * Renders Seerr search results into the stable body-owned overlay host.
      * @param {Array} results - Array of search result items.
      * @param {string} query - The search query that generated these results.
      * @param {boolean} isJellyseerrOnlyMode - Whether the filter is active.
@@ -188,97 +187,20 @@
      */
     ui.renderJellyseerrResults = function(results, query, isJellyseerrOnlyMode, isJellyseerrActive, jellyseerrUserFound) {
         console.log(`${logPrefix} Rendering results for query: "${query}"`);
-        const searchPage = document.querySelector('#searchPage');
-        if (!searchPage) {
-            console.warn(`${logPrefix} #searchPage not found. Cannot render results.`);
-            return;
+        let host = document.getElementById('jellyseerr-search-host');
+        if (!host) {
+            host = document.createElement('div');
+            host.id = 'jellyseerr-search-host';
+            document.body.appendChild(host);
         }
-
-        if (pendingRepositionObserver) {
-            pendingRepositionObserver.disconnect();
-            pendingRepositionObserver = null;
-        }
-        if (pendingRepositionTimeout) {
-            clearTimeout(pendingRepositionTimeout);
-            pendingRepositionTimeout = null;
-        }
-
-        searchPage.querySelectorAll('.jellyseerr-section').forEach(section => section.remove());
-
-        const sectionToInject = createJellyseerrSection(results, isJellyseerrOnlyMode, isJellyseerrActive, jellyseerrUserFound);
-
-        const primaryCardTypes = ['movie', 'series'];
-
-        /**
-         * Finds the last Movies/Shows section in the search results, identified
-         * by each card's data-type attribute rather than the (locale-dependent)
-         * section title text.
-         * @returns {HTMLElement|null}
-         */
-        function findLastPrimarySection() {
-            const allSections = Array.from(searchPage.querySelectorAll('.verticalSection:not(.jellyseerr-section)'));
-            for (let i = allSections.length - 1; i >= 0; i--) {
-                const cardType = allSections[i].querySelector('[data-type]')?.dataset.type?.toLowerCase();
-                if (cardType && primaryCardTypes.includes(cardType)) {
-                    return allSections[i];
-                }
-            }
-            return null;
-        }
-
-        /**
-         * Places the section after Movies/Shows if found, otherwise appends
-         * to the results container or search page.
-         * @returns {boolean} True if positioned after a primary section or
-         *   no-results message; false if using fallback placement.
-         */
-        function positionSection() {
-            const noResultsMessage = searchPage.querySelector('.noItemsMessage');
-            if (noResultsMessage) {
-                // Only write on change — this element is inside the subtree the
-                // reposition MutationObserver below watches, so an unconditional
-                // write re-triggers it every time, looping forever.
-                const desiredText = JE.t('jellyseerr_no_results_jellyfin', { query });
-                if (noResultsMessage.textContent !== desiredText) {
-                    noResultsMessage.textContent = desiredText;
-                }
-                if (sectionToInject.previousElementSibling !== noResultsMessage) {
-                    noResultsMessage.parentElement.insertBefore(sectionToInject, noResultsMessage.nextSibling);
-                }
-                return true;
-            }
-
-            const lastPrimary = findLastPrimarySection();
-            if (lastPrimary) {
-                if (sectionToInject.previousElementSibling !== lastPrimary) {
-                    lastPrimary.after(sectionToInject);
-                }
-                return true;
-            }
-
-            const resultsContainer = searchPage.querySelector('.searchResults, [class*="searchResults"], .padded-top.padded-bottom-page');
-            if (resultsContainer) {
-                if (sectionToInject.parentElement !== resultsContainer || resultsContainer.lastElementChild !== sectionToInject) {
-                    resultsContainer.appendChild(sectionToInject);
-                }
-            } else if (searchPage.lastElementChild !== sectionToInject) {
-                searchPage.appendChild(sectionToInject);
-            }
-            return false;
-        }
-
-        positionSection();
-
-        const observer = new MutationObserver(() => {
-            if (!sectionToInject.isConnected) {
-                observer.disconnect();
-                return;
-            }
-            positionSection();
-        });
-        observer.observe(searchPage, { childList: true, subtree: true });
-        pendingRepositionObserver = observer;
-        pendingRepositionTimeout = setTimeout(() => observer.disconnect(), 5000);
+        const isMobile = window.matchMedia('(max-width: 900px)').matches;
+        const resultLimit = isMobile ? 8 : 20;
+        const section = createJellyseerrSection(results.slice(0, resultLimit), isJellyseerrOnlyMode, isJellyseerrActive, jellyseerrUserFound);
+        host.replaceChildren(section);
+        host.classList.toggle('is-open', results.length > 0);
+        observeSearchHost(host);
+        if (results.length > 0) reserveNativeSearchSpace(host);
+        else clearNativeSearchSpace();
     };
 
     /**

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-season-modal.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-season-modal.js
@@ -42,7 +42,10 @@
             enableSpecialEpisodes = false;
         }
 
-        const tvDetails = await fetchTvShowDetails(tmdbId);
+        // Request dialogs must never use stale status data: cached season
+        // statuses can otherwise keep every checkbox disabled even after
+        // Seerr has made the seasons requestable again.
+        const tvDetails = await fetchTvShowDetails(tmdbId, { skipCache: true });
         if (!tvDetails?.seasons) {
             JE.toast(JE.t('jellyseerr_toast_no_season_info'), 4000);
             return;
@@ -290,18 +293,10 @@
         }
 
 
-        // Start polling for updates when the modal is shown
-        refreshModalInterval = setInterval(async () => {
-            const freshTvDetails = await fetchTvShowDetails(tmdbId);
-            if (freshTvDetails) {
-                applyAirDateBackfill(freshTvDetails);
-                updateSeasonList(seasonList, freshTvDetails, partialRequestsEnabled, enableSpecialEpisodes, is4k, jellyfinSeasonMap);
-                // Update Select All state after refresh
-                if (seasonList._updateSelectAllState) {
-                    seasonList._updateSelectAllState();
-                }
-            }
-        }, 10000); // Refresh every 10 seconds
+        // Do not periodically replace the modal DOM. Jellyfin Web owns the
+        // surrounding React tree; rebuilding this list on an interval can race
+        // React reconciliation and trigger removeChild NotFoundError loops.
+        // A fresh, cache-bypassed status was already loaded when the modal opened.
 
         if (showAdvanced) {
             try {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-styles.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-styles.js
@@ -18,6 +18,17 @@
         const style = document.createElement('style');
         style.id = styleId;
         style.textContent = `
+            /* BODY-OWNED INLINE SEARCH RAIL (visually integrated, never mounted inside React DOM) */
+            #jellyseerr-search-host {
+                position: fixed; left: 0; right: 0; top: 10.5rem; z-index: 20;
+                display: none; max-height: calc(100vh - 10.5rem); overflow-y: auto;
+                padding: 0 3.3%; background: var(--background-color, #101010); color: #fff;
+            }
+            #jellyseerr-search-host.is-open { display: block; }
+            @media (max-width: 900px) {
+                #jellyseerr-search-host { top: 10rem; padding: 0 1rem; max-height: calc(100vh - 10rem); }
+            }
+
             /* LAYOUT & ICONS */
             .jellyseerr-section { margin-bottom: 1em; }
             .jellyseerr-section .itemsContainer { }

--- a/tests/jellyseerr-search-isolation.test.js
+++ b/tests/jellyseerr-search-isolation.test.js
@@ -1,0 +1,12 @@
+const t=require('node:test'),a=require('node:assert/strict'),f=require('node:fs'),p=require('node:path');
+const root=p.resolve(__dirname,'..');
+const rd=x=>f.readFileSync(p.join(root,x),'utf8');
+const ui=rd('Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-results.js');
+const js=rd('Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/jellyseerr.js');
+const css=rd('Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-styles.js');
+t('body-owned native UI',()=>{a.match(ui,/document.body.appendChild\(host\)/);a.doesNotMatch(ui,/jellyseerr-search-control|jellyseerr-overlay-query/);a.doesNotMatch(ui,/searchPage\.(appendChild|insertBefore)/)});
+t('bounded results',()=>{a.match(ui,/isMobile \? 8 : 20/);a.match(ui,/results.slice\(0, resultLimit\)/)});
+t('synchronous stale-query guard',()=>{a.match(js,/const generation = \+\+searchGeneration/);a.match(js,/generation !== searchGeneration/);a.match(js,/if \(!normalized\)/)});
+t('pending debounce cancelled',()=>{a.match(js,/clearTimeout\(debounceTimeout\)/);a.match(js,/debounceTimeout = null/);a.match(js,/jellyseerr-manual-refresh/);a.match(js,/onNavigate/)});
+t('layout survives React and viewport changes',()=>{a.match(ui,/ResizeObserver/);a.match(ui,/visualViewport/);a.match(ui,/data-jellyseerr-space/);a.match(js,/ensureJellyseerrSearchSpace/)});
+t('fixed rail without spacer nodes',()=>{a.match(css,/#jellyseerr-search-host[^}]*position: fixed/s);a.doesNotMatch(ui,/appendChild\(spacer\)|insertBefore\(spacer/)});


### PR DESCRIPTION
## Summary
- Keep Seerr results visually integrated with native Jellyfin search while all Enhanced-owned nodes stay under document.body.
- Remove React-subtree insertion and reposition observers that caused WebKit NotFoundError/removeChild.
- Use only the native Jellyfin search input; no duplicate field or floating control.
- Invalidate stale debounced searches synchronously and cancel pending work on navigation and refresh.
- Reserve layout space without spacer nodes inside React-owned DOM.
- Reflow after React container replacement, host resize, and iOS VisualViewport changes.
- Bound results to 8 mobile and 20 desktop.

## Verification
- Node isolation tests: 6/6 passed
- JavaScript syntax checks: passed
- git diff --check: passed
- Jellyfin 10 / .NET 9 build: 0 warnings, 0 errors
- Jellyfin 12 / .NET 10 build: 0 warnings, 0 errors
- Chromium and WebKit acceptance covered repeated native queries and absence of NotFoundError/removeChild.

## Security
- No client-side Seerr credentials.
- No private hosts, domains, keys, or tokens added.