### PR TITLE
fix: search page removeChild crash — stop mutating React-owned no-results message

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/jellyseerr.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/jellyseerr.js
@@ -47,7 +47,7 @@
             addMainStyles, addSeasonModalStyles, updateJellyseerrIcon,
             renderJellyseerrResults, showMovieRequestModal, showSeasonSelectionModal,
             showCollectionRequestModal, hideHoverPopover, toggleHoverPopoverLock, updateJellyseerrResults,
-            createJellyseerrCard
+            createJellyseerrCard, clearInjectedSearchResults
         } = JE.jellyseerrUI;
 
         /**
@@ -74,8 +74,7 @@
                         searchResults.insertBefore(jellyseerrSection, searchResults.firstChild);
                     }
                 }
-                const noResultsMessage = searchPage.querySelector('.noItemsMessage');
-                if (noResultsMessage) noResultsMessage.classList.add('section-hidden');
+                searchPage.querySelectorAll('.noItemsMessage').forEach(el => el.classList.add('section-hidden'));
 
                 JE.toast(JE.t('jellyseerr_toast_filter_on'), 3000);
 
@@ -87,8 +86,7 @@
                     jellyseerrOriginalPosition.remove();
                     jellyseerrOriginalPosition = null;
                 }
-                const noResultsMessage = searchPage.querySelector('.noItemsMessage');
-                if (noResultsMessage) noResultsMessage.classList.remove('section-hidden');
+                searchPage.querySelectorAll('.noItemsMessage').forEach(el => el.classList.remove('section-hidden'));
 
                 hiddenSections = [];
                 JE.toast(JE.t('jellyseerr_toast_filter_off'), 3000);
@@ -340,7 +338,7 @@
                     clearTimeout(debounceTimeout);
                     debounceTimeout = setTimeout(() => {
                         if (!isJellyseerrActive) {
-                            document.querySelectorAll('.jellyseerr-section').forEach(el => el.remove());
+                            clearInjectedSearchResults();
                             return;
                         }
                         const latestQuery = searchInput.value;
@@ -354,7 +352,7 @@
                         }
                         lastProcessedQuery = latestQuery;
                         resetSearchPagination();
-                        document.querySelectorAll('.jellyseerr-section').forEach(el => el.remove());
+                        clearInjectedSearchResults();
                         fetchAndRenderResults(latestQuery);
                     }, 300);
                 } else {
@@ -362,7 +360,7 @@
                     lastProcessedQuery = null;
                     isJellyseerrOnlyMode = false;
                     resetSearchPagination();
-                    document.querySelectorAll('.jellyseerr-section').forEach(el => el.remove());
+                    clearInjectedSearchResults();
                 }
             };
 
@@ -408,7 +406,7 @@
                     lastProcessedQuery = null;
                     isJellyseerrOnlyMode = false;
                     resetSearchPagination();
-                    document.querySelectorAll('.jellyseerr-section').forEach(el => el.remove());
+                    clearInjectedSearchResults();
                     return;
                 }
                 tryAttachSearchListener();

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-results.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-results.js
@@ -179,6 +179,17 @@
     }
 
     /**
+     * Removes every plugin-owned node injected into the search page (results
+     * section and no-results replacement message) and restores the native
+     * no-results message if positionSection hid it. React-safe: only removes
+     * plugin-owned nodes and toggles a class on native ones.
+     */
+    ui.clearInjectedSearchResults = function() {
+        document.querySelectorAll('.jellyseerr-section, .jellyseerr-no-results-message').forEach(el => el.remove());
+        document.querySelectorAll('.jellyseerr-native-message-hidden').forEach(el => el.classList.remove('jellyseerr-native-message-hidden'));
+    };
+
+    /**
      * Renders Seerr search results into the search page with improved placement logic.
      * @param {Array} results - Array of search result items.
      * @param {string} query - The search query that generated these results.
@@ -233,20 +244,43 @@
          *   no-results message; false if using fallback placement.
          */
         function positionSection() {
-            const noResultsMessage = searchPage.querySelector('.noItemsMessage');
+            const noResultsMessage = searchPage.querySelector('.noItemsMessage:not(.jellyseerr-no-results-message)');
             if (noResultsMessage) {
+                // The no-results message is React-owned, and React reuses the same
+                // DOM node for the results container on a later query (both render
+                // as plain keyless divs, and cached queries swap between them with
+                // no <Loading/> commit in between). Rewriting its textContent here
+                // would replace React's own text node, so the next reconciliation
+                // of that div throws NotFoundError ("Failed to execute
+                // 'removeChild' on 'Node'"). Never mutate its children — hide it
+                // with a class and show a plugin-owned message beside it instead.
+                noResultsMessage.classList.add('jellyseerr-native-message-hidden');
+
+                let message = searchPage.querySelector('.jellyseerr-no-results-message');
+                if (!message) {
+                    message = document.createElement('div');
+                    message.className = 'noItemsMessage centerMessage jellyseerr-no-results-message';
+                }
                 // Only write on change — this element is inside the subtree the
                 // reposition MutationObserver below watches, so an unconditional
                 // write re-triggers it every time, looping forever.
                 const desiredText = JE.t('jellyseerr_no_results_jellyfin', { query });
-                if (noResultsMessage.textContent !== desiredText) {
-                    noResultsMessage.textContent = desiredText;
+                if (message.textContent !== desiredText) {
+                    message.textContent = desiredText;
                 }
-                if (sectionToInject.previousElementSibling !== noResultsMessage) {
-                    noResultsMessage.parentElement.insertBefore(sectionToInject, noResultsMessage.nextSibling);
+                if (message.previousElementSibling !== noResultsMessage) {
+                    noResultsMessage.parentElement.insertBefore(message, noResultsMessage.nextSibling);
+                }
+                if (sectionToInject.previousElementSibling !== message) {
+                    message.parentElement.insertBefore(sectionToInject, message.nextSibling);
                 }
                 return true;
             }
+
+            // Not (or no longer) in the no-results state: drop the replacement
+            // message and restore the native one if a previous pass hid it.
+            searchPage.querySelectorAll('.jellyseerr-no-results-message').forEach(el => el.remove());
+            searchPage.querySelectorAll('.jellyseerr-native-message-hidden').forEach(el => el.classList.remove('jellyseerr-native-message-hidden'));
 
             const lastPrimary = findLastPrimarySection();
             if (lastPrimary) {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-styles.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/ui/ui-styles.js
@@ -21,6 +21,10 @@
             /* LAYOUT & ICONS */
             .jellyseerr-section { margin-bottom: 1em; }
             .jellyseerr-section .itemsContainer { }
+            /* Hides the native (React-owned) no-results message while the plugin
+               shows its own replacement — the native element must never be
+               mutated directly or React's reconciler crashes (NotFoundError). */
+            .jellyseerr-native-message-hidden { display: none !important; }
             #jellyseerr-search-icon { position: absolute; right: 10px; top: 68%; transform: translateY(-50%); user-select: none; z-index: 10; transition: filter .2s, opacity .2s, transform .2s; }
             .inputContainer { position: relative !important; }
             .jellyseerr-icon { width: 30px; height: 50px; filter: drop-shadow(2px 2px 6px #000); }


### PR DESCRIPTION
## Summary

Fixes the `NotFoundError: Failed to execute 'removeChild' on 'Node'` crash on the search page (the bug behind #792) with a minimal, root-cause-targeted change — no features removed.

## Root cause

jellyfin-web's `SearchResults` renders both the no-results message and the results container as plain **keyless divs**, so React reuses the same DOM node when switching between those states. With react-query's cache, retyping a previously-searched query transitions **directly** between them (no `<Loading/>` commit in between). The plugin's `positionSection()` did:

```js
noResultsMessage.textContent = desiredText;
```

on the React-owned message div. That replaces React's own text node — so on the next reconciliation of that (reused) div, React calls `removeChild` on a node that no longer exists and throws. This matches the reported repro exactly: search → delete part → type another string → delete → correct it, a few times, with a no-results state along the way.

Notably, merely *inserting* the Seerr section among React's children is tolerated by the reconciler — the text mutation was the sole trigger.

## Fix

- Never mutate the React-owned message: hide it with a CSS class (attribute-only changes are safe) and show a plugin-owned replacement message with the same localized text beside it.
- New `clearInjectedSearchResults()` helper removes everything the plugin injected and restores the native message; all four cleanup paths (new query, query cleared, navigation away, Seerr inactive) go through it so no stale takeover survives.
- Seerr-only filter toggle now handles both messages.

3 files, +50/−14. Inline placement, infinite scroll, the Seerr-only filter, the search-field icon, and unbounded results all keep working.

## Verification

- **Deterministic repro** (React 18 + jsdom harness mimicking the jellyfin-web search page): old code crashes with the exact reported error inside react-dom's text commit; fixed code survives the same input gauntlet (24 no-results takeovers) with zero errors and no leftover nodes.
- **Real environment**: built the plugin (`JellyfinTarget=jf12`, .NET 10) and ran it in fresh `jellyfin/jellyfin:12.0-rc6` and `jellyfin/jellyfin:unstable` containers with a scanned movie library and a stubbed Seerr backend, driving the real web UI with headless Chromium through the reporter's repro sequence (type/delete/retype across result and no-result queries):
  - stock plugin: crashes on **both** images with the exact reported error (`node_modules.react-dom.bundle.js`, search page torn down by React Router)
  - this branch: **0 errors on both images**, Seerr section + cards render inline, no-results takeover shows the localized message and restores the native one cleanly when results return
- `node --check` passes on all touched files; `git diff --check` clean.

## Why not #792's approach

Tested that branch in the same environment: the crash disappears, but only because the integration stops running entirely — jellyfin-web rewrites `?query=` on every keystroke, and that branch's `onNavigate` teardown cancels its own pending search each time, so no Seerr request is ever made and nothing renders (details in the comment on #792).
