### PR TITLE
docs: unify manifest URLs and validate legacy releases

### DIFF
--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -1,0 +1,33 @@
+name: Validate legacy plugin manifest
+
+# Run on every PR so a required check never stays pending because of path filters.
+on:
+  pull_request:
+  merge_group:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-legacy-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: '3.x'
+      - name: Check out the shared manifest validator
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: n00bcodr/jellyfin-plugins
+          # Shared validator from jellyfin-plugins PR #2. Keep this immutable;
+          # update deliberately when its validation policy changes.
+          ref: 14154a1840341c61ec62fb0b971d7299fb959c9d
+          path: .manifest-validator
+          persist-credentials: false
+      - name: Validate ordering, build pairs and latest ZIP checksums
+        run: python3 .manifest-validator/tools/validate_manifest.py manifest.json --checksums 2

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -1,6 +1,6 @@
 name: Validate legacy plugin manifest
 
-# Run on every PR so a required check never stays pending because of path filters.
+# Run on every PR, including changes to the validation workflow itself.
 on:
   pull_request:
   merge_group:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,20 @@ Every PR runs a few automated checks (GitHub Actions, `.github/workflows/`). The
 
 Two more workflows exist but aren't part of the PR gate: **Check Unused Translation Keys** and **OpenSSF Scorecard** are both maintainer-triggered/scheduled, not run against your PR - a scorecard badge or unused-key report you might see elsewhere in the repo isn't something your PR needs to pass.
 
+### Manifest releases
+
+The legacy `manifest.json` must keep both Jellyfin builds of each supported release, ordered by
+plugin version descending and then `targetAbi` descending. Use the shared release/publishing tools
+from [jellyfin-plugins](https://github.com/n00bcodr/jellyfin-plugins/tree/main/tools); do not run jprm
+on the unified catalog. Submit updates through PRs in both repositories and merge after validation.
+
+An administrator must require the **`validate-legacy-manifest`** check on this repository's `main`
+branch, and **`validate-manifest`** on `jellyfin-plugins/main`, with PRs required, up-to-date branches
+or merge queues, no bypass actors, and no force pushes or branch deletion. Enable Actions first.
+The workflow alone cannot prevent a direct push from exposing a bad manifest before CI completes.
+The legacy workflow pins an immutable revision of the shared validator; review and update that pin
+when its rules change. The companion repository's tools README contains the release procedure.
+
 ## 🧪 Testing
 
 Before submitting a PR, ensure you've tested:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,20 +169,6 @@ Every PR runs a few automated checks (GitHub Actions, `.github/workflows/`). The
 
 Two more workflows exist but aren't part of the PR gate: **Check Unused Translation Keys** and **OpenSSF Scorecard** are both maintainer-triggered/scheduled, not run against your PR - a scorecard badge or unused-key report you might see elsewhere in the repo isn't something your PR needs to pass.
 
-### Manifest releases
-
-The legacy `manifest.json` must keep both Jellyfin builds of each supported release, ordered by
-plugin version descending and then `targetAbi` descending. Use the shared release/publishing tools
-from [jellyfin-plugins](https://github.com/n00bcodr/jellyfin-plugins/tree/main/tools); do not run jprm
-on the unified catalog. Submit updates through PRs in both repositories and merge after validation.
-
-An administrator must require the **`validate-legacy-manifest`** check on this repository's `main`
-branch, and **`validate-manifest`** on `jellyfin-plugins/main`, with PRs required, up-to-date branches
-or merge queues, no bypass actors, and no force pushes or branch deletion. Enable Actions first.
-The workflow alone cannot prevent a direct push from exposing a bad manifest before CI completes.
-The legacy workflow pins an immutable revision of the shared validator; review and update that pin
-when its rules change. The companion repository's tools README contains the release procedure.
-
 ## 🧪 Testing
 
 Before submitting a PR, ensure you've tested:

--- a/README.md
+++ b/README.md
@@ -46,14 +46,11 @@ Quick links:
 2. Click **➕** and add the repository:
 
 > [!NOTE]
-> **If you are on Jellyfin version 12, use the version 12 manifest**
-> ``` 
-> https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/12/manifest.json 
 > ```
-> **If you are on 10.11.x, use the version 11 manifest**
-> ``` 
-> https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json 
+> https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/manifest.json
 > ```
+>
+> One manifest for every Jellyfin version (10.11.x, 12.x incl. RCs): Jellyfin picks the matching build automatically.
 
 3. Go to **Catalog** tab, find **Jellyfin Enhanced**, and click **Install**
 4. **Restart** your Jellyfin server

--- a/docs/faq-support/faq.md
+++ b/docs/faq-support/faq.md
@@ -40,7 +40,7 @@ The userscript has been discontinued as the plugin functionality has grown signi
 
 | Plugin | Jellyfin 10.11 | Jellyfin 10.10 | Notes |
 |--------|----------------|----------------|-------|
-| Jellyfin Enhanced | ✅ | ❌ | Use 10.11 manifest |
+| Jellyfin Enhanced | ✅ | ✅ (frozen at 10.11.1.0) | One manifest for all lines |
 
 ### Plugin not appearing after installation?
 

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -19,7 +19,7 @@
 3. Give the repository a name (e.g., "Jellyfin Enhanced")
 4. Set the **Repository URL** to the manifest:
    ```
-   https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json
+   https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/manifest.json
    ```
 
 5. Click **Save**

--- a/docs/other-projects/other-projects.md
+++ b/docs/other-projects/other-projects.md
@@ -145,7 +145,7 @@ A beautiful, modern theme for Jellyfin with multiple color variants.
 **Repository URL:** Unified Manifest for all plugins
 
 ```
-https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json
+https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/manifest.json
 ```
 
 ### Installing Themes
@@ -165,7 +165,7 @@ https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.
 
 | Plugin | Jellyfin 10.11 | Jellyfin 10.10 | Notes |
 |--------|----------------|----------------|-------|
-| Jellyfin Enhanced | ✅ | ❌ | Use 10.11 manifest |
+| Jellyfin Enhanced | ✅ | ✅ (frozen at 10.11.1.0) | One manifest for all lines |
 | Jellyfin Tweaks | ✅ | ✅ | |
 | JS Injector | ✅ | ✅ |  |
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,14 +2,22 @@
   {
     "name": "Jellyfin Enhanced",
     "guid": "f69e946a-4b3c-4e9a-8f0a-8d7c1b2c4d9b",
-    "description": "A combination of the Jellyfin Enhanced and Jellyfin Elsewhere userscripts, providing a comprehensive set of tweaks and features for Jellyfin.",
     "overview": "Jellyfin Enhanced and Jellyfin Elsewhere for a better Jellyfin experience.",
+    "description": "A combination of the Jellyfin Enhanced and Jellyfin Elsewhere userscripts, providing a comprehensive set of tweaks and features for Jellyfin.",
     "owner": "n00bcodr",
     "category": "General",
     "imageUrl": "https://raw.githubusercontent.com/n00bcodr/Jellyfin-Enhanced/master/docs/images/icon.png",
     "versions": [
       {
-        "changelog": "- chore(ci)(deps): bump the github-actions group with 3 updates ([#777](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/777))\n - feat: enable quality tags in Home Videos and Photos libraries ([#778](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/778))\n - Translations update from Hosted Weblate ([#779](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/779))\n - Translations update from Hosted Weblate ([#780](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/780))\n - Translations update from Hosted Weblate ([#782](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/782))\n - Update README.md\n - fix: reliably place Seerr search results after Movies/Series rows\n - fix: hide media tag overlays on small list-row thumbnails\n - fix: prevent tag pipeline from freezing on fast large-library search\n - fix: stop redundant settings.json writes and re-download the full tag cache every load\n - fix(jellyseerr): stop search freeze and cancel superseded requests\n - Update .gitignore\n - fix: search page removeChild crash — stop mutating React-owned no-results message ([#795](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/795))\n - Add opt-in community usage analytics ([#791](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/791))\n - fix(tags): preserve Matroska LanguageBCP47 regions ([#790](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/790))\n - Anime episodes from Shoko in calendar ([#776](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/776))\n - fix: queue tag cache build as its own task and push analytics on startup",
+        "changelog": "**Build for Jellyfin 12.**\n\n- chore(ci)(deps): bump the github-actions group with 3 updates ([#777](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/777))\n - feat: enable quality tags in Home Videos and Photos libraries ([#778](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/778))\n - Translations update from Hosted Weblate ([#779](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/779))\n - Translations update from Hosted Weblate ([#780](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/780))\n - Translations update from Hosted Weblate ([#782](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/782))\n - Update README.md\n - fix: reliably place Seerr search results after Movies/Series rows\n - fix: hide media tag overlays on small list-row thumbnails\n - fix: prevent tag pipeline from freezing on fast large-library search\n - fix: stop redundant settings.json writes and re-download the full tag cache every load\n - fix(jellyseerr): stop search freeze and cancel superseded requests\n - Update .gitignore\n - fix: search page removeChild crash — stop mutating React-owned no-results message ([#795](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/795))\n - Add opt-in community usage analytics ([#791](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/791))\n - fix(tags): preserve Matroska LanguageBCP47 regions ([#790](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/790))\n - Anime episodes from Shoko in calendar ([#776](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/776))\n - fix: queue tag cache build as its own task and push analytics on startup",
+        "targetAbi": "12.0.0.0",
+        "version": "12.5.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.5.0.0/Jellyfin.Plugin.JellyfinEnhanced_12.0.0.zip",
+        "checksum": "399DE61DF5CDBA36295CCC67455A5618",
+        "timestamp": "2026-08-30T17:30:15"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11.** On Jellyfin 12 the catalog installs the Jellyfin 12 build of this version automatically.\n\n- chore(ci)(deps): bump the github-actions group with 3 updates ([#777](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/777))\n - feat: enable quality tags in Home Videos and Photos libraries ([#778](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/778))\n - Translations update from Hosted Weblate ([#779](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/779))\n - Translations update from Hosted Weblate ([#780](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/780))\n - Translations update from Hosted Weblate ([#782](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/782))\n - Update README.md\n - fix: reliably place Seerr search results after Movies/Series rows\n - fix: hide media tag overlays on small list-row thumbnails\n - fix: prevent tag pipeline from freezing on fast large-library search\n - fix: stop redundant settings.json writes and re-download the full tag cache every load\n - fix(jellyseerr): stop search freeze and cancel superseded requests\n - Update .gitignore\n - fix: search page removeChild crash — stop mutating React-owned no-results message ([#795](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/795))\n - Add opt-in community usage analytics ([#791](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/791))\n - fix(tags): preserve Matroska LanguageBCP47 regions ([#790](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/790))\n - Anime episodes from Shoko in calendar ([#776](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/776))\n - fix: queue tag cache build as its own task and push analytics on startup",
         "targetAbi": "10.11.0.0",
         "version": "12.5.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.5.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -17,7 +25,15 @@
         "timestamp": "2026-08-30T17:29:59"
       },
       {
-        "changelog": "- fix(bookmarks): scope bookmark matching to the correct episode\n - fix(spoiler-guard): keep movie multi-version names when stripping fields\n - fix(jellyseerr): fix search race causing leaked scroll listeners\n - fix(item-details): fix awards/reviews overflow and external-link icon sizing on third-party themes\n - fix(recommendations): hide standalone page reliably when navigating home",
+        "changelog": "**Build for Jellyfin 12.**\n\n- fix(bookmarks): scope bookmark matching to the correct episode\n - fix(spoiler-guard): keep movie multi-version names when stripping fields\n - fix(jellyseerr): fix search race causing leaked scroll listeners\n - fix(item-details): fix awards/reviews overflow and external-link icon sizing on third-party themes\n - fix(recommendations): hide standalone page reliably when navigating home",
+        "targetAbi": "12.0.0.0",
+        "version": "12.4.1.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.4.1.0/Jellyfin.Plugin.JellyfinEnhanced_12.0.0.zip",
+        "checksum": "88926A246A0F65386F99C0C9CEFEAE07",
+        "timestamp": "2026-08-23T18:58:10"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11.** On Jellyfin 12 the catalog installs the Jellyfin 12 build of this version automatically.\n\n- fix(bookmarks): scope bookmark matching to the correct episode\n - fix(spoiler-guard): keep movie multi-version names when stripping fields\n - fix(jellyseerr): fix search race causing leaked scroll listeners\n - fix(item-details): fix awards/reviews overflow and external-link icon sizing on third-party themes\n - fix(recommendations): hide standalone page reliably when navigating home",
         "targetAbi": "10.11.0.0",
         "version": "12.4.1.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.4.1.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -25,7 +41,15 @@
         "timestamp": "2026-08-23T18:57:55"
       },
       {
-        "changelog": "- fix(subtitles): sync position preview with the bottom-anchored render\n - feat(reviews): support half-star ratings\n - feat(jellyseerr): option to link available items' posters straight to Jellyfin\n - feat(config-page): show which tab a What's New setting lives in",
+        "changelog": "**Build for Jellyfin 12.**\n\n- fix(subtitles): sync position preview with the bottom-anchored render\n - feat(reviews): support half-star ratings\n - feat(jellyseerr): option to link available items' posters straight to Jellyfin\n - feat(config-page): show which tab a What's New setting lives in",
+        "targetAbi": "12.0.0.0",
+        "version": "12.4.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.4.0.0/Jellyfin.Plugin.JellyfinEnhanced_12.0.0.zip",
+        "checksum": "4CFFA70B5C306FB5A7F517D648A9F6B4",
+        "timestamp": "2026-08-22T09:47:34"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11.** On Jellyfin 12 the catalog installs the Jellyfin 12 build of this version automatically.\n\n- fix(subtitles): sync position preview with the bottom-anchored render\n - feat(reviews): support half-star ratings\n - feat(jellyseerr): option to link available items' posters straight to Jellyfin\n - feat(config-page): show which tab a What's New setting lives in",
         "targetAbi": "10.11.0.0",
         "version": "12.4.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.4.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -33,7 +57,15 @@
         "timestamp": "2026-08-22T09:47:17"
       },
       {
-        "changelog": "- Fix German FSK rating colors ([#749](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/749))\n - chore(ci)(deps): bump the github-actions group with 4 updates ([#753](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/753))\n - fix: honour \"Remove from Continue Watching\" on Home Screen Sections rows ([#761](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/761))\n - feat(spoiler-guard): advanced per-category reveals for the next unwatched episode and current season ([#762](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/762))\n - feat(tags): derive collection language tags from member movies ([#607](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/607))\n - feat(activity-feed): add server-wide recent activity page ([#605](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/605))\n - feat(language-tags): add admin-configurable language priority ([#760](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/760))\n - fix(tags): stack same-corner tag containers instead of overlapping\n - Images for MDBlist Ratings\n - chore(ci)(deps): bump the github-actions group with 5 updates ([#764](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/764))\n - feat: add MDBList Ratings\n - fix(qualityTags): Ultra-wide 1080p files show a 4K Quality Tag  [#765](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/765)\n - feat(jellyseerr): show root folder free space in request modal ([#768](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/768))\n - fix(jellyseerr): don't require REQUEST_ADVANCED for basic requests\n - fix(subtitles): anchor position to bottom edge, add gap between cue boxes\n - feat(recommendations): add genre browsing row ([#759](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/759))\n - fix(jellyseerr): keep infinite scroll going on short pages\n - fix(recommendations): register plugin page sidebar link\n - feat(recommendations): add sort and filter to category pages [#759](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/759)\n - feat(requests): add Open in Seerr/Radarr/Sonarr links to request cards ([#759](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/759))\n - fix(custom-tabs): darken home backdrop for Recommendations/Activity/Bookmarks\n - fix(recommendations): align page title and rows with card grid\n - fix(requests): scope card navigation to title and play button only\n - feat(activity): prefer Thumb image over Primary for activity row posters\n - fix(activity): use series image for episodes, show episode number\n - chore(logging): quiet noisy per-item console logs\n - feat(config-page): unsaved-changes indicator, tab-bar scroll fade, section quick-nav\n - feat(whats-new): auto-detect and surface newly added settings\n - fix(seerr): restore dropped cache-clear call after user import\n - docs: document Activity Feed, Maintenance Mode, full API index, CI checks\n - feat(arr): import Sonarr/Radarr instances from Seerr\n - feat(config-page): flash the jump target for What's New and section nav\n - feat(whats-new): name the version in the banner when everything's from one release",
+        "changelog": "**Build for Jellyfin 12.**\n\n- Fix German FSK rating colors ([#749](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/749))\n - chore(ci)(deps): bump the github-actions group with 4 updates ([#753](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/753))\n - fix: honour \"Remove from Continue Watching\" on Home Screen Sections rows ([#761](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/761))\n - feat(spoiler-guard): advanced per-category reveals for the next unwatched episode and current season ([#762](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/762))\n - feat(tags): derive collection language tags from member movies ([#607](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/607))\n - feat(activity-feed): add server-wide recent activity page ([#605](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/605))\n - feat(language-tags): add admin-configurable language priority ([#760](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/760))\n - fix(tags): stack same-corner tag containers instead of overlapping\n - Images for MDBlist Ratings\n - chore(ci)(deps): bump the github-actions group with 5 updates ([#764](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/764))\n - feat: add MDBList Ratings\n - fix(qualityTags): Ultra-wide 1080p files show a 4K Quality Tag  [#765](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/765)\n - feat(jellyseerr): show root folder free space in request modal ([#768](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/768))\n - fix(jellyseerr): don't require REQUEST_ADVANCED for basic requests\n - fix(subtitles): anchor position to bottom edge, add gap between cue boxes\n - feat(recommendations): add genre browsing row ([#759](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/759))\n - fix(jellyseerr): keep infinite scroll going on short pages\n - fix(recommendations): register plugin page sidebar link\n - feat(recommendations): add sort and filter to category pages [#759](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/759)\n - feat(requests): add Open in Seerr/Radarr/Sonarr links to request cards ([#759](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/759))\n - fix(custom-tabs): darken home backdrop for Recommendations/Activity/Bookmarks\n - fix(recommendations): align page title and rows with card grid\n - fix(requests): scope card navigation to title and play button only\n - feat(activity): prefer Thumb image over Primary for activity row posters\n - fix(activity): use series image for episodes, show episode number\n - chore(logging): quiet noisy per-item console logs\n - feat(config-page): unsaved-changes indicator, tab-bar scroll fade, section quick-nav\n - feat(whats-new): auto-detect and surface newly added settings\n - fix(seerr): restore dropped cache-clear call after user import\n - docs: document Activity Feed, Maintenance Mode, full API index, CI checks\n - feat(arr): import Sonarr/Radarr instances from Seerr\n - feat(config-page): flash the jump target for What's New and section nav\n - feat(whats-new): name the version in the banner when everything's from one release",
+        "targetAbi": "12.0.0.0",
+        "version": "12.3.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.3.0.0/Jellyfin.Plugin.JellyfinEnhanced_12.0.0.zip",
+        "checksum": "06BFF31F5A9D3CC10F00001678B94170",
+        "timestamp": "2026-08-19T17:29:31"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11.** On Jellyfin 12 the catalog installs the Jellyfin 12 build of this version automatically.\n\n- Fix German FSK rating colors ([#749](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/749))\n - chore(ci)(deps): bump the github-actions group with 4 updates ([#753](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/753))\n - fix: honour \"Remove from Continue Watching\" on Home Screen Sections rows ([#761](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/761))\n - feat(spoiler-guard): advanced per-category reveals for the next unwatched episode and current season ([#762](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/762))\n - feat(tags): derive collection language tags from member movies ([#607](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/607))\n - feat(activity-feed): add server-wide recent activity page ([#605](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/605))\n - feat(language-tags): add admin-configurable language priority ([#760](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/760))\n - fix(tags): stack same-corner tag containers instead of overlapping\n - Images for MDBlist Ratings\n - chore(ci)(deps): bump the github-actions group with 5 updates ([#764](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/764))\n - feat: add MDBList Ratings\n - fix(qualityTags): Ultra-wide 1080p files show a 4K Quality Tag  [#765](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/765)\n - feat(jellyseerr): show root folder free space in request modal ([#768](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/768))\n - fix(jellyseerr): don't require REQUEST_ADVANCED for basic requests\n - fix(subtitles): anchor position to bottom edge, add gap between cue boxes\n - feat(recommendations): add genre browsing row ([#759](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/759))\n - fix(jellyseerr): keep infinite scroll going on short pages\n - fix(recommendations): register plugin page sidebar link\n - feat(recommendations): add sort and filter to category pages [#759](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/759)\n - feat(requests): add Open in Seerr/Radarr/Sonarr links to request cards ([#759](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/759))\n - fix(custom-tabs): darken home backdrop for Recommendations/Activity/Bookmarks\n - fix(recommendations): align page title and rows with card grid\n - fix(requests): scope card navigation to title and play button only\n - feat(activity): prefer Thumb image over Primary for activity row posters\n - fix(activity): use series image for episodes, show episode number\n - chore(logging): quiet noisy per-item console logs\n - feat(config-page): unsaved-changes indicator, tab-bar scroll fade, section quick-nav\n - feat(whats-new): auto-detect and surface newly added settings\n - fix(seerr): restore dropped cache-clear call after user import\n - docs: document Activity Feed, Maintenance Mode, full API index, CI checks\n - feat(arr): import Sonarr/Radarr instances from Seerr\n - feat(config-page): flash the jump target for What's New and section nav\n - feat(whats-new): name the version in the banner when everything's from one release",
         "targetAbi": "10.11.0.0",
         "version": "12.3.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.3.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -41,7 +73,15 @@
         "timestamp": "2026-08-19T17:29:22"
       },
       {
-        "changelog": "- Translations update from Hosted Weblate ([#737](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/737))\n - Update translation_validation.yml\n - fix(player): harden OSD track cycling (waits for the menu, stops matching English UI text) ([#738](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/738))\n - Update translation_validation.yml\n - Update translation_validation.yml\n - fix(tags): preserve explicit language regions in flag resolution (pt-BR, es-419, zh-Hant…) ([#739](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/739))\n - fix: re-scope all per-user state when switching users without a page reload ([#740](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/740))\n - Translations update from Hosted Weblate ([#743](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/743))\n - Player shortcuts without opening panels (API-driven track cycling, aspect ratio, playback info, segment skip) ([#742](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/742))\n - feat(player): auto-skip intros/outros from Jellyfin's media segments ([#744](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/744))\n - fix(pausescreen): apply delay setting live and stop digit keys from leaking to OSD seek\n - feat(jellyseerr): default Seerr results to open in the More Info modal\n - Add official German FSK colors and normalization ([#748](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/748))\n - fix(elsewhere): make Default Region a dropdown and honor per-user override",
+        "changelog": "**Build for Jellyfin 12.**\n\n- Translations update from Hosted Weblate ([#737](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/737))\n - Update translation_validation.yml\n - fix(player): harden OSD track cycling (waits for the menu, stops matching English UI text) ([#738](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/738))\n - Update translation_validation.yml\n - Update translation_validation.yml\n - fix(tags): preserve explicit language regions in flag resolution (pt-BR, es-419, zh-Hant…) ([#739](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/739))\n - fix: re-scope all per-user state when switching users without a page reload ([#740](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/740))\n - Translations update from Hosted Weblate ([#743](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/743))\n - Player shortcuts without opening panels (API-driven track cycling, aspect ratio, playback info, segment skip) ([#742](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/742))\n - feat(player): auto-skip intros/outros from Jellyfin's media segments ([#744](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/744))\n - fix(pausescreen): apply delay setting live and stop digit keys from leaking to OSD seek\n - feat(jellyseerr): default Seerr results to open in the More Info modal\n - Add official German FSK colors and normalization ([#748](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/748))\n - fix(elsewhere): make Default Region a dropdown and honor per-user override",
+        "targetAbi": "12.0.0.0",
+        "version": "12.2.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.2.0.0/Jellyfin.Plugin.JellyfinEnhanced_12.0.0.zip",
+        "checksum": "F7C4DC5CD61AE7914C183C075DE4EBB3",
+        "timestamp": "2026-08-08T22:41:24"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11.** On Jellyfin 12 the catalog installs the Jellyfin 12 build of this version automatically.\n\n- Translations update from Hosted Weblate ([#737](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/737))\n - Update translation_validation.yml\n - fix(player): harden OSD track cycling (waits for the menu, stops matching English UI text) ([#738](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/738))\n - Update translation_validation.yml\n - Update translation_validation.yml\n - fix(tags): preserve explicit language regions in flag resolution (pt-BR, es-419, zh-Hant…) ([#739](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/739))\n - fix: re-scope all per-user state when switching users without a page reload ([#740](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/740))\n - Translations update from Hosted Weblate ([#743](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/743))\n - Player shortcuts without opening panels (API-driven track cycling, aspect ratio, playback info, segment skip) ([#742](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/742))\n - feat(player): auto-skip intros/outros from Jellyfin's media segments ([#744](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/744))\n - fix(pausescreen): apply delay setting live and stop digit keys from leaking to OSD seek\n - feat(jellyseerr): default Seerr results to open in the More Info modal\n - Add official German FSK colors and normalization ([#748](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/748))\n - fix(elsewhere): make Default Region a dropdown and honor per-user override",
         "targetAbi": "10.11.0.0",
         "version": "12.2.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.2.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -49,7 +89,15 @@
         "timestamp": "2026-08-08T22:41:14"
       },
       {
-        "changelog": "- Update Jellyfin version badges in README\n - fix(jellyseerr): stop duplicate search results row\n - Revert \"fix(jellyseerr): stop duplicate search results row\"\n - fix(jellyseerr): stop duplicate search results row\n - fix: don't add sidebar links to dashboardDocument\n - chore(ci)(deps): bump the github-actions group with 6 updates ([#720](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/720))\n - feat(jellyseerr): add Seerr Recommendations page\n - fix(maintenance-mode): stop unchecked account/remote toggles reverting to disable_accounts\n - fix(maintenance-mode): reconcile account/remote state when Action changes while active\n - fix: Seerr results row cannot be touch-scrolled on phones ([#721](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/721))\n - feat(requests-page): track ARR import lifecycle and add bounded download history ([#717](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/717))\n - feat(panel): searchable section navigation for the user settings panel ([#722](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/722))\n - Update ratings.css\n - refactor: modularize the client by feature ([#723](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/723))\n - feat(panel): dynamic subtitle styling warnings and live preview fixes\n - feat(header): collapse native-tabs fallback links into a native-styled menu on mobile\n - Translations update from Hosted Weblate ([#728](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/728))\n - fix(i18n): validate {{icon:xxx}} placeholders and fix Norwegian typo ([#729](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/729))\n - chore(ci): migrate dependency-review to allow-licenses\n - chore(docs): Update Star History badges to new chart endpoint\n - feat(i18n): complete Hebrew and Finnish translations, refresh Continue Watching wording\n - fix(i18n): translate remaining stale strings in he.json and fi.json\n - fix(i18n): translate remaining real gaps flagged by Weblate checks\n - fix(i18n): translate 4 more real gaps found in a second Weblate check pass\n - Translations update from Hosted Weblate ([#730](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/730))\n - fix(panel): subtitle preset selection not applying or highlighting\n - feat(awards): add Wikidata-sourced award wins/nominations ([#654](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/654))\n - fix(qualitytags): Detect 8K/4320p and use width-based fallback\n - chore(ci)(deps): bump actions/stale from 10.4.0 to 11.0.0 ([#734](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/734))\n - chore(ci)(deps): bump the github-actions group across 1 directory with 3 updates ([#733](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/733))\n - fix(bookmarks): add Others tab for non-movie/TV bookmarks",
+        "changelog": "**Build for Jellyfin 12.**\n\n- Update Jellyfin version badges in README\n - fix(jellyseerr): stop duplicate search results row\n - Revert \"fix(jellyseerr): stop duplicate search results row\"\n - fix(jellyseerr): stop duplicate search results row\n - fix: don't add sidebar links to dashboardDocument\n - chore(ci)(deps): bump the github-actions group with 6 updates ([#720](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/720))\n - feat(jellyseerr): add Seerr Recommendations page\n - fix(maintenance-mode): stop unchecked account/remote toggles reverting to disable_accounts\n - fix(maintenance-mode): reconcile account/remote state when Action changes while active\n - fix: Seerr results row cannot be touch-scrolled on phones ([#721](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/721))\n - feat(requests-page): track ARR import lifecycle and add bounded download history ([#717](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/717))\n - feat(panel): searchable section navigation for the user settings panel ([#722](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/722))\n - Update ratings.css\n - refactor: modularize the client by feature ([#723](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/723))\n - feat(panel): dynamic subtitle styling warnings and live preview fixes\n - feat(header): collapse native-tabs fallback links into a native-styled menu on mobile\n - Translations update from Hosted Weblate ([#728](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/728))\n - fix(i18n): validate {{icon:xxx}} placeholders and fix Norwegian typo ([#729](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/729))\n - chore(ci): migrate dependency-review to allow-licenses\n - chore(docs): Update Star History badges to new chart endpoint\n - feat(i18n): complete Hebrew and Finnish translations, refresh Continue Watching wording\n - fix(i18n): translate remaining stale strings in he.json and fi.json\n - fix(i18n): translate remaining real gaps flagged by Weblate checks\n - fix(i18n): translate 4 more real gaps found in a second Weblate check pass\n - Translations update from Hosted Weblate ([#730](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/730))\n - fix(panel): subtitle preset selection not applying or highlighting\n - feat(awards): add Wikidata-sourced award wins/nominations ([#654](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/654))\n - fix(qualitytags): Detect 8K/4320p and use width-based fallback\n - chore(ci)(deps): bump actions/stale from 10.4.0 to 11.0.0 ([#734](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/734))\n - chore(ci)(deps): bump the github-actions group across 1 directory with 3 updates ([#733](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/733))\n - fix(bookmarks): add Others tab for non-movie/TV bookmarks",
+        "targetAbi": "12.0.0.0",
+        "version": "12.1.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.1.0.0/Jellyfin.Plugin.JellyfinEnhanced_12.0.0.zip",
+        "checksum": "C69E4652E8F38342DE52968313D614D8",
+        "timestamp": "2026-08-04T20:24:53"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11.** On Jellyfin 12 the catalog installs the Jellyfin 12 build of this version automatically.\n\n- Update Jellyfin version badges in README\n - fix(jellyseerr): stop duplicate search results row\n - Revert \"fix(jellyseerr): stop duplicate search results row\"\n - fix(jellyseerr): stop duplicate search results row\n - fix: don't add sidebar links to dashboardDocument\n - chore(ci)(deps): bump the github-actions group with 6 updates ([#720](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/720))\n - feat(jellyseerr): add Seerr Recommendations page\n - fix(maintenance-mode): stop unchecked account/remote toggles reverting to disable_accounts\n - fix(maintenance-mode): reconcile account/remote state when Action changes while active\n - fix: Seerr results row cannot be touch-scrolled on phones ([#721](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/721))\n - feat(requests-page): track ARR import lifecycle and add bounded download history ([#717](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/717))\n - feat(panel): searchable section navigation for the user settings panel ([#722](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/722))\n - Update ratings.css\n - refactor: modularize the client by feature ([#723](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/723))\n - feat(panel): dynamic subtitle styling warnings and live preview fixes\n - feat(header): collapse native-tabs fallback links into a native-styled menu on mobile\n - Translations update from Hosted Weblate ([#728](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/728))\n - fix(i18n): validate {{icon:xxx}} placeholders and fix Norwegian typo ([#729](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/729))\n - chore(ci): migrate dependency-review to allow-licenses\n - chore(docs): Update Star History badges to new chart endpoint\n - feat(i18n): complete Hebrew and Finnish translations, refresh Continue Watching wording\n - fix(i18n): translate remaining stale strings in he.json and fi.json\n - fix(i18n): translate remaining real gaps flagged by Weblate checks\n - fix(i18n): translate 4 more real gaps found in a second Weblate check pass\n - Translations update from Hosted Weblate ([#730](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/730))\n - fix(panel): subtitle preset selection not applying or highlighting\n - feat(awards): add Wikidata-sourced award wins/nominations ([#654](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/654))\n - fix(qualitytags): Detect 8K/4320p and use width-based fallback\n - chore(ci)(deps): bump actions/stale from 10.4.0 to 11.0.0 ([#734](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/734))\n - chore(ci)(deps): bump the github-actions group across 1 directory with 3 updates ([#733](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/733))\n - fix(bookmarks): add Others tab for non-movie/TV bookmarks",
         "targetAbi": "10.11.0.0",
         "version": "12.1.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.1.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -57,7 +105,15 @@
         "timestamp": "2026-08-04T20:24:46"
       },
       {
-        "changelog": "- fix: duplicate approval notifications and un-approvable pending requests on available shows ([#658](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/658))\n - feat: centralize Seerr status logic in seerr-status.js\n - README: fix: Seerr URL ([#664](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/664))\n - docs: Formatting fixes ([#666](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/666))\n - fix: pick richest audio layout instead of first match in getChannelTag\n - fix: skip synthetic je:navigate event for no-op pushState/replaceState calls ([#657](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/657))\n - fix: allow Administrator API keys to access any user's settings files\n - feat: add admin-scoped write endpoints for reviews and bookmarks\n - chore(ci)(deps): bump actions/checkout from 6.0.3 to 7.0.0 ([#671](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/671))\n - chore(ci)(deps): bump trufflesecurity/trufflehog from 3.95.5 to 3.95.6 in the github-actions group ([#670](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/670))\n - fix: show Request More button when only specials season is unrequested\n - feat: add letterboxd link for people details pages\n - feat: show release/air date chip on item detail pages ([#661](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/661))\n - fix: show MusicVideo bookmarks in the Bookmarks Library\n - fix: skip Report Issue button entirely for non-reportable item types\n - feat: Jellyfin 12 compatibility ([#681](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/681))\n - Load Material Symbols Rounded for release icons\n - Show API keys in config form\n - chore(ci)(deps): bump the github-actions group with 2 updates ([#682](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/682))\n - chore(ci)(deps): bump actions/cache from 5.0.5 to 6.1.0 ([#683](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/683))\n - Admin visibility and management of user-hidden content + bug fixes ([#684](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/684))\n - feat: reliable Remove from Continue Watching + add Remove from Next Up (multi-select & confirm) ([#685](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/685))\n - fix: don't require both Sonarr and Radarr for Requests Page ([#689](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/689))\n - feat(spoiler-guard): per-user opt-in spoiler protection for unwatched content (Jellyfin 10.11 + 12) ([#691](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/691))\n - chore(ci)(deps): bump the github-actions group with 4 updates ([#696](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/696))\n - Fix MutationObserver leak in addUserPreferencesLink (one observer piled up per navigation) ([#694](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/694))\n - feat: serve third-party assets from a local CDN cache (+ off-thread tag-cache updates) ([#692](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/692))\n - feat(spoiler-guard): per-user image identity tags for native clients ([#700](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/700))\n - fix(jellyseerr): stop runaway search requests after leaving search page\n - fix(requests-tab): stop polling when a sibling home tab becomes active\n - fix(native-tabs): only log \"not on home page\" once per transition\n - fix(jellyseerr): sort server dropdown alphabetically, fix default selection\n - style(jellyseerr): restyle season/collection checkboxes as toggle switches\n - chore(ci)(deps): bump the github-actions group with 6 updates ([#703](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/703))\n - fix(tag-cache): stop re-saving the whole cache on no-op library events ([#704](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/704))\n - fix(tags): fix ignore-selector checks matching the wrong element\n - fix(perf): cap concurrent requests for provider and review fetches\n - feat(shortcuts): allow disabling individual keyboard shortcuts\n - feat(jellyseerr): add Seerr detail-page link with More Info modal integration\n - chore(ci)(deps): bump actions/setup-python from 6.3.0 to 7.0.0 ([#710](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/710))\n - chore(ci)(deps): bump the github-actions group with 3 updates ([#709](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/709))\n - chore(ci)(deps): bump actions/setup-dotnet from 5.4.0 to 6.0.0 ([#712](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/712))\n - chore(ci)(deps): bump actions/setup-node from 6.4.0 to 7.0.0 ([#711](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/711))\n - Fix rating normalization logic\n - fix(tags): memory-bounded tag cache builds + honor Server-Side Tag Cache setting (startup OOM crash loop) ([#713](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/713))\n - docs: API overhaul ([#668](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/668))\n - docs: fix bookmark JSON casing and auth header per live server verification",
+        "changelog": "**Build for Jellyfin 12.**\n\n- fix: duplicate approval notifications and un-approvable pending requests on available shows ([#658](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/658))\n - feat: centralize Seerr status logic in seerr-status.js\n - README: fix: Seerr URL ([#664](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/664))\n - docs: Formatting fixes ([#666](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/666))\n - fix: pick richest audio layout instead of first match in getChannelTag\n - fix: skip synthetic je:navigate event for no-op pushState/replaceState calls ([#657](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/657))\n - fix: allow Administrator API keys to access any user's settings files\n - feat: add admin-scoped write endpoints for reviews and bookmarks\n - chore(ci)(deps): bump actions/checkout from 6.0.3 to 7.0.0 ([#671](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/671))\n - chore(ci)(deps): bump trufflesecurity/trufflehog from 3.95.5 to 3.95.6 in the github-actions group ([#670](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/670))\n - fix: show Request More button when only specials season is unrequested\n - feat: add letterboxd link for people details pages\n - feat: show release/air date chip on item detail pages ([#661](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/661))\n - fix: show MusicVideo bookmarks in the Bookmarks Library\n - fix: skip Report Issue button entirely for non-reportable item types\n - feat: Jellyfin 12 compatibility ([#681](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/681))\n - Load Material Symbols Rounded for release icons\n - Show API keys in config form\n - chore(ci)(deps): bump the github-actions group with 2 updates ([#682](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/682))\n - chore(ci)(deps): bump actions/cache from 5.0.5 to 6.1.0 ([#683](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/683))\n - Admin visibility and management of user-hidden content + bug fixes ([#684](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/684))\n - feat: reliable Remove from Continue Watching + add Remove from Next Up (multi-select & confirm) ([#685](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/685))\n - fix: don't require both Sonarr and Radarr for Requests Page ([#689](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/689))\n - feat(spoiler-guard): per-user opt-in spoiler protection for unwatched content (Jellyfin 10.11 + 12) ([#691](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/691))\n - chore(ci)(deps): bump the github-actions group with 4 updates ([#696](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/696))\n - Fix MutationObserver leak in addUserPreferencesLink (one observer piled up per navigation) ([#694](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/694))\n - feat: serve third-party assets from a local CDN cache (+ off-thread tag-cache updates) ([#692](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/692))\n - feat(spoiler-guard): per-user image identity tags for native clients ([#700](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/700))\n - fix(jellyseerr): stop runaway search requests after leaving search page\n - fix(requests-tab): stop polling when a sibling home tab becomes active\n - fix(native-tabs): only log \"not on home page\" once per transition\n - fix(jellyseerr): sort server dropdown alphabetically, fix default selection\n - style(jellyseerr): restyle season/collection checkboxes as toggle switches\n - chore(ci)(deps): bump the github-actions group with 6 updates ([#703](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/703))\n - fix(tag-cache): stop re-saving the whole cache on no-op library events ([#704](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/704))\n - fix(tags): fix ignore-selector checks matching the wrong element\n - fix(perf): cap concurrent requests for provider and review fetches\n - feat(shortcuts): allow disabling individual keyboard shortcuts\n - feat(jellyseerr): add Seerr detail-page link with More Info modal integration\n - chore(ci)(deps): bump actions/setup-python from 6.3.0 to 7.0.0 ([#710](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/710))\n - chore(ci)(deps): bump the github-actions group with 3 updates ([#709](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/709))\n - chore(ci)(deps): bump actions/setup-dotnet from 5.4.0 to 6.0.0 ([#712](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/712))\n - chore(ci)(deps): bump actions/setup-node from 6.4.0 to 7.0.0 ([#711](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/711))\n - Fix rating normalization logic\n - fix(tags): memory-bounded tag cache builds + honor Server-Side Tag Cache setting (startup OOM crash loop) ([#713](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/713))\n - docs: API overhaul ([#668](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/668))\n - docs: fix bookmark JSON casing and auth header per live server verification",
+        "targetAbi": "12.0.0.0",
+        "version": "12.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.0.0.0/Jellyfin.Plugin.JellyfinEnhanced_12.0.0.zip",
+        "checksum": "CDF945315990FE417973B650848D39B3",
+        "timestamp": "2026-07-23T16:48:46"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11.** On Jellyfin 12 the catalog installs the Jellyfin 12 build of this version automatically.\n\n- fix: duplicate approval notifications and un-approvable pending requests on available shows ([#658](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/658))\n - feat: centralize Seerr status logic in seerr-status.js\n - README: fix: Seerr URL ([#664](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/664))\n - docs: Formatting fixes ([#666](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/666))\n - fix: pick richest audio layout instead of first match in getChannelTag\n - fix: skip synthetic je:navigate event for no-op pushState/replaceState calls ([#657](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/657))\n - fix: allow Administrator API keys to access any user's settings files\n - feat: add admin-scoped write endpoints for reviews and bookmarks\n - chore(ci)(deps): bump actions/checkout from 6.0.3 to 7.0.0 ([#671](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/671))\n - chore(ci)(deps): bump trufflesecurity/trufflehog from 3.95.5 to 3.95.6 in the github-actions group ([#670](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/670))\n - fix: show Request More button when only specials season is unrequested\n - feat: add letterboxd link for people details pages\n - feat: show release/air date chip on item detail pages ([#661](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/661))\n - fix: show MusicVideo bookmarks in the Bookmarks Library\n - fix: skip Report Issue button entirely for non-reportable item types\n - feat: Jellyfin 12 compatibility ([#681](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/681))\n - Load Material Symbols Rounded for release icons\n - Show API keys in config form\n - chore(ci)(deps): bump the github-actions group with 2 updates ([#682](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/682))\n - chore(ci)(deps): bump actions/cache from 5.0.5 to 6.1.0 ([#683](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/683))\n - Admin visibility and management of user-hidden content + bug fixes ([#684](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/684))\n - feat: reliable Remove from Continue Watching + add Remove from Next Up (multi-select & confirm) ([#685](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/685))\n - fix: don't require both Sonarr and Radarr for Requests Page ([#689](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/689))\n - feat(spoiler-guard): per-user opt-in spoiler protection for unwatched content (Jellyfin 10.11 + 12) ([#691](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/691))\n - chore(ci)(deps): bump the github-actions group with 4 updates ([#696](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/696))\n - Fix MutationObserver leak in addUserPreferencesLink (one observer piled up per navigation) ([#694](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/694))\n - feat: serve third-party assets from a local CDN cache (+ off-thread tag-cache updates) ([#692](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/692))\n - feat(spoiler-guard): per-user image identity tags for native clients ([#700](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/700))\n - fix(jellyseerr): stop runaway search requests after leaving search page\n - fix(requests-tab): stop polling when a sibling home tab becomes active\n - fix(native-tabs): only log \"not on home page\" once per transition\n - fix(jellyseerr): sort server dropdown alphabetically, fix default selection\n - style(jellyseerr): restyle season/collection checkboxes as toggle switches\n - chore(ci)(deps): bump the github-actions group with 6 updates ([#703](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/703))\n - fix(tag-cache): stop re-saving the whole cache on no-op library events ([#704](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/704))\n - fix(tags): fix ignore-selector checks matching the wrong element\n - fix(perf): cap concurrent requests for provider and review fetches\n - feat(shortcuts): allow disabling individual keyboard shortcuts\n - feat(jellyseerr): add Seerr detail-page link with More Info modal integration\n - chore(ci)(deps): bump actions/setup-python from 6.3.0 to 7.0.0 ([#710](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/710))\n - chore(ci)(deps): bump the github-actions group with 3 updates ([#709](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/709))\n - chore(ci)(deps): bump actions/setup-dotnet from 5.4.0 to 6.0.0 ([#712](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/712))\n - chore(ci)(deps): bump actions/setup-node from 6.4.0 to 7.0.0 ([#711](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/711))\n - Fix rating normalization logic\n - fix(tags): memory-bounded tag cache builds + honor Server-Side Tag Cache setting (startup OOM crash loop) ([#713](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/713))\n - docs: API overhaul ([#668](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/668))\n - docs: fix bookmark JSON casing and auth header per live server verification",
         "targetAbi": "10.11.0.0",
         "version": "12.0.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/12.0.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -65,7 +121,7 @@
         "timestamp": "2026-07-23T16:48:39"
       },
       {
-        "changelog": "- docs: add images and expand features/settings\n - chore(ci)(deps): bump actions/setup-dotnet from 5.2.0 to 5.3.0 in the github-actions group ([#643](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/643))\n - Show transcode buffer, codec badges & refresh\n - fix: Improve bookmark modal\n - fix: Add missed size hints and labels to branding inputs\n - feat: Sync Jellyfin Watchlist to Seerr\n - feat: Approve/decline request buttons on downloads page with localized status chips\n - feat: add Maintenance Mode ([#638](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/638))\n - fix: improve Custom Tabs mount resilience and compat diagnostics\n - docs: update Seerr docs for request status, approve/decline, and watchlist sync\n - chore(ci)(deps): bump the github-actions group with 3 updates ([#651](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/651))",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- docs: add images and expand features/settings\n - chore(ci)(deps): bump actions/setup-dotnet from 5.2.0 to 5.3.0 in the github-actions group ([#643](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/643))\n - Show transcode buffer, codec badges & refresh\n - fix: Improve bookmark modal\n - fix: Add missed size hints and labels to branding inputs\n - feat: Sync Jellyfin Watchlist to Seerr\n - feat: Approve/decline request buttons on downloads page with localized status chips\n - feat: add Maintenance Mode ([#638](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/638))\n - fix: improve Custom Tabs mount resilience and compat diagnostics\n - docs: update Seerr docs for request status, approve/decline, and watchlist sync\n - chore(ci)(deps): bump the github-actions group with 3 updates ([#651](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/651))",
         "targetAbi": "10.11.0.0",
         "version": "11.12.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.12.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -73,7 +129,7 @@
         "timestamp": "2026-06-10T19:54:41"
       },
       {
-        "changelog": "- chore(ci)(deps): bump the github-actions group with 3 updates ([#631](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/631))\n - Add DevMode and improved script cache-busting\n - Per-user cache for hidden-content and invalidation\n - Ignore JSON nulls when deserializing user settings",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- chore(ci)(deps): bump the github-actions group with 3 updates ([#631](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/631))\n - Add DevMode and improved script cache-busting\n - Per-user cache for hidden-content and invalidation\n - Ignore JSON nulls when deserializing user settings",
         "targetAbi": "10.11.0.0",
         "version": "11.11.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.11.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -81,7 +137,7 @@
         "timestamp": "2026-05-25T19:35:26"
       },
       {
-        "changelog": "- chore(ci)(deps): bump actions/dependency-review-action from 4.9.0 to 5.0.0 ([#603](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/603))\n - chore(ci)(deps): bump github/codeql-action from 4.35.3 to 4.35.4 in the github-actions group ([#602](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/602))\n - Update Jellyfin Desktop Compatible version\n - fix: admin config page UI bugs ([#604](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/604))\n - Use Material Symbols for User Review Icon\n - [StepSecurity] Apply security best practices\n - [StepSecurity] Apply security best practices ([#613](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/613))\n - chore(ci)(deps): bump the github-actions group with 2 updates\n - Bump Jellyfin.Controller and Jellyfin.Model\n - Bump Jellyfin.Model from 10.11.0 to 10.11.8\n - Bump Newtonsoft.Json from 13.0.1 to 13.0.4\n - chore(ci)(deps): bump the github-actions group with 2 updates ([#614](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/614))\n - Bump Newtonsoft.Json from 13.0.1 to 13.0.4 ([#617](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/617))\n - Bump Jellyfin.Model from 10.11.0 to 10.11.8 ([#616](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/616))\n - Merge branch 'main' into dependabot/nuget/Jellyfin.Plugin.JellyfinEnhanced/multi-1ae101d347\n - Bump Jellyfin.Controller and Jellyfin.Model ([#615](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/615))\n - Update stale.yml\n - Translations update from Hosted Weblate ([#624](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/624))\n - Update JellyfinEnhanced.csproj\n - fix: compatibility shim for IUserManager.Users → GetUsers() breaking change in Jellyfin 10.11.9\n - fix: audio language icon on Elegantfin\n - fix(jellyseerr): fix stale AVAILABLE status, deleted season re-requests, and TVDB season naming\n - Revert \"fix: audio language icon on Elegantfin\"\n - Remove long press user icon to open Enhanced Panel\n - Fix icons in more-info-modal not showing on some devices\n - Change Overview to embylinkbutton\n - fix: quality category toggles now behave like all other user settings\n - Update elsewhere.js",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- chore(ci)(deps): bump actions/dependency-review-action from 4.9.0 to 5.0.0 ([#603](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/603))\n - chore(ci)(deps): bump github/codeql-action from 4.35.3 to 4.35.4 in the github-actions group ([#602](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/602))\n - Update Jellyfin Desktop Compatible version\n - fix: admin config page UI bugs ([#604](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/604))\n - Use Material Symbols for User Review Icon\n - [StepSecurity] Apply security best practices\n - [StepSecurity] Apply security best practices ([#613](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/613))\n - chore(ci)(deps): bump the github-actions group with 2 updates\n - Bump Jellyfin.Controller and Jellyfin.Model\n - Bump Jellyfin.Model from 10.11.0 to 10.11.8\n - Bump Newtonsoft.Json from 13.0.1 to 13.0.4\n - chore(ci)(deps): bump the github-actions group with 2 updates ([#614](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/614))\n - Bump Newtonsoft.Json from 13.0.1 to 13.0.4 ([#617](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/617))\n - Bump Jellyfin.Model from 10.11.0 to 10.11.8 ([#616](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/616))\n - Merge branch 'main' into dependabot/nuget/Jellyfin.Plugin.JellyfinEnhanced/multi-1ae101d347\n - Bump Jellyfin.Controller and Jellyfin.Model ([#615](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/615))\n - Update stale.yml\n - Translations update from Hosted Weblate ([#624](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/624))\n - Update JellyfinEnhanced.csproj\n - fix: compatibility shim for IUserManager.Users → GetUsers() breaking change in Jellyfin 10.11.9\n - fix: audio language icon on Elegantfin\n - fix(jellyseerr): fix stale AVAILABLE status, deleted season re-requests, and TVDB season naming\n - Revert \"fix: audio language icon on Elegantfin\"\n - Remove long press user icon to open Enhanced Panel\n - Fix icons in more-info-modal not showing on some devices\n - Change Overview to embylinkbutton\n - fix: quality category toggles now behave like all other user settings\n - Update elsewhere.js",
         "targetAbi": "10.11.0.0",
         "version": "11.10.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.10.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -89,7 +145,7 @@
         "timestamp": "2026-05-24T10:11:47"
       },
       {
-        "changelog": "- chore(ci)(deps): bump trufflesecurity/trufflehog from 3.94.3 to 3.95.2 in the github-actions group ([#575](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/575))\n - Translated using Weblate (Russian)\n - Added translation using Weblate (Bulgarian)\n - i18n: add Bulgarian locale ([#578](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/578))\n - Resolve merge conflict in bg.json\n - Change Issue type translation key\n - feat: add frame-by-frame video controls (, and .) ([#579](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/579))\n - dont gate TMDB collections with API Key\n - Update ratings.css\n - Missed  \"jellyseerr_btn_rejected\" translation\n - Jellyfin Helper favicon.ico ([#584](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/584))\n - Update plugin-icons.js\n - Remove from Continue Watching and Hidden Content: non-destructive, and now work on all devices (no longer DOM-only) Also add hidden content settings to admin page instead of only in the user settings. ([#573](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/573))\n - feat: better Seerr request quota support ([#583](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/583))\n - chore(ci)(deps): bump github/codeql-action from 4.35.2 to 4.35.3 in the github-actions group ([#586](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/586))\n - feat: trigger Seerr recently-added scan on Jellyfin item added ([#588](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/588))\n - feat: split Quality Tags into 6 reorderable categories ([#560](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/560)) ([#585](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/585))\n - Fix and update translations\n - Update configPage.html\n - fix: Click outside the modal to close more-info-modal\n - feat: Add \"Jump to Last Position\" shortcut (Z)\n - feat: Add subtitle position grid and fix vanilla style bleed-through\n - docs: add troubleshooting entries\n - Update bug.md\n - Translated using Weblate (Russian)\n - Translated using Weblate (English (United Kingdom))\n - Translated using Weblate (Polish)\n - Revert \"Translated using Weblate (Polish)\"\n - Revert \"Translated using Weblate (English (United Kingdom))\"\n - Revert \"Translated using Weblate (Russian)\"\n - Translated using Weblate (Russian)\n - Translated using Weblate (Slovak)\n - Translated using Weblate (Hungarian)\n - Translated using Weblate (Chinese (Simplified Han script))\n - Translated using Weblate (Polish)\n - Translated using Weblate (Swedish)\n - Update cs.json\n - fix(seerr): allow re-requesting items with stale Available status\n - Update ui.js\n - feat: user reviews for seasons/episodes + average rating on posters and item details ([#597](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/597))\n - fix: load request-manager before api.js\n - fix(seerr): Cloudflare / reverse-proxy / forward-auth compatibility + cache flush on config save ([#599](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/599))\n - fix: osd-rating not being updated on episode change\n - Add note about subtitle position settings",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- chore(ci)(deps): bump trufflesecurity/trufflehog from 3.94.3 to 3.95.2 in the github-actions group ([#575](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/575))\n - Translated using Weblate (Russian)\n - Added translation using Weblate (Bulgarian)\n - i18n: add Bulgarian locale ([#578](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/578))\n - Resolve merge conflict in bg.json\n - Change Issue type translation key\n - feat: add frame-by-frame video controls (, and .) ([#579](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/579))\n - dont gate TMDB collections with API Key\n - Update ratings.css\n - Missed  \"jellyseerr_btn_rejected\" translation\n - Jellyfin Helper favicon.ico ([#584](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/584))\n - Update plugin-icons.js\n - Remove from Continue Watching and Hidden Content: non-destructive, and now work on all devices (no longer DOM-only) Also add hidden content settings to admin page instead of only in the user settings. ([#573](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/573))\n - feat: better Seerr request quota support ([#583](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/583))\n - chore(ci)(deps): bump github/codeql-action from 4.35.2 to 4.35.3 in the github-actions group ([#586](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/586))\n - feat: trigger Seerr recently-added scan on Jellyfin item added ([#588](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/588))\n - feat: split Quality Tags into 6 reorderable categories ([#560](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/560)) ([#585](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/585))\n - Fix and update translations\n - Update configPage.html\n - fix: Click outside the modal to close more-info-modal\n - feat: Add \"Jump to Last Position\" shortcut (Z)\n - feat: Add subtitle position grid and fix vanilla style bleed-through\n - docs: add troubleshooting entries\n - Update bug.md\n - Translated using Weblate (Russian)\n - Translated using Weblate (English (United Kingdom))\n - Translated using Weblate (Polish)\n - Revert \"Translated using Weblate (Polish)\"\n - Revert \"Translated using Weblate (English (United Kingdom))\"\n - Revert \"Translated using Weblate (Russian)\"\n - Translated using Weblate (Russian)\n - Translated using Weblate (Slovak)\n - Translated using Weblate (Hungarian)\n - Translated using Weblate (Chinese (Simplified Han script))\n - Translated using Weblate (Polish)\n - Translated using Weblate (Swedish)\n - Update cs.json\n - fix(seerr): allow re-requesting items with stale Available status\n - Update ui.js\n - feat: user reviews for seasons/episodes + average rating on posters and item details ([#597](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/597))\n - fix: load request-manager before api.js\n - fix(seerr): Cloudflare / reverse-proxy / forward-auth compatibility + cache flush on config save ([#599](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/599))\n - fix: osd-rating not being updated on episode change\n - Add note about subtitle position settings",
         "targetAbi": "10.11.0.0",
         "version": "11.9.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.9.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -97,7 +153,7 @@
         "timestamp": "2026-05-10T12:31:01"
       },
       {
-        "changelog": "- fix(config): inject configPage.css via ApiClient.getUrl for reverse-proxy support ([#572](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/572))\n - Scope all generic Jellyfin class styles to JellyfinEnhancedPage\n - Update configPage.css",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- fix(config): inject configPage.css via ApiClient.getUrl for reverse-proxy support ([#572](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/572))\n - Scope all generic Jellyfin class styles to JellyfinEnhancedPage\n - Update configPage.css",
         "targetAbi": "10.11.0.0",
         "version": "11.8.1.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.8.1.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -105,7 +161,7 @@
         "timestamp": "2026-04-26T21:11:26"
       },
       {
-        "changelog": "- Use helper for external links & add fallback\n - Add Seerr permission audit & enforce perms\n - Fix Lists in Documentation\n - Add 404 page, assets, and fix doc links\n - Add mdx-truly-sane-lists to MkDocs dependencies\n - chore(ci)(deps): bump the github-actions group with 3 updates ([#567](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/567))\n - Update elsewhere.js\n - Settings UI Redesign ([#569](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/569))\n - Change Radarr Icon and z-Index so that backbutton and profile picture are visible\n - Remove loopback addresses from SSRF\n - Fix Active Streams widget styling\n - Update configPage.html\n - fix: resolve multiple requests page polling\n - refactor(config): reorganise settings layout and simplify feature-toggle styling",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Use helper for external links & add fallback\n - Add Seerr permission audit & enforce perms\n - Fix Lists in Documentation\n - Add 404 page, assets, and fix doc links\n - Add mdx-truly-sane-lists to MkDocs dependencies\n - chore(ci)(deps): bump the github-actions group with 3 updates ([#567](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/567))\n - Update elsewhere.js\n - Settings UI Redesign ([#569](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/569))\n - Change Radarr Icon and z-Index so that backbutton and profile picture are visible\n - Remove loopback addresses from SSRF\n - Fix Active Streams widget styling\n - Update configPage.html\n - fix: resolve multiple requests page polling\n - refactor(config): reorganise settings layout and simplify feature-toggle styling",
         "targetAbi": "10.11.0.0",
         "version": "11.8.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.8.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -113,7 +169,7 @@
         "timestamp": "2026-04-25T17:24:53"
       },
       {
-        "changelog": "- fix: hidden users could not see their own reviews ([#548](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/548))\n - Fix avatar image source for requests page ([#551](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/551))\n - Clear caches on video change; simplify item ID lookup\n - Update .gitignore\n - feat: Add Active Streams widget and session API\n - chore(ci)(deps): bump trufflesecurity/trufflehog from 3.94.2 to 3.94.3 in the github-actions group ([#553](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/553))\n - chore(ci)(deps): bump actions/upload-pages-artifact from 4.0.0 to 5.0.0 ([#554](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/554))\n - Refactor config UI, stream image & IDs\n - Add configurable pause screen delay\n - Hide IP for non-admins and remove app version\n - feat: multi-instance Sonarr/Radarr support ([#559](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/559))\n - Handle ratings when 0\n - Use <img> icons and themeable ARR dropdown\n - Add external configPage.css and refactor HTML\n - Missed translation key\n - Improve Active Streams Icons\n - Add admin broadcast to Active Streams\n - Improve logging: user display & polling dedup\n - Stop polling when page is not visible\n - Avoid redundant user-settings POSTs\n - Show all instances in calendar labels\n - Docs: Add multi-instance ARR and Active Streams\n - Update JellyfinEnhancedController.cs",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- fix: hidden users could not see their own reviews ([#548](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/548))\n - Fix avatar image source for requests page ([#551](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/551))\n - Clear caches on video change; simplify item ID lookup\n - Update .gitignore\n - feat: Add Active Streams widget and session API\n - chore(ci)(deps): bump trufflesecurity/trufflehog from 3.94.2 to 3.94.3 in the github-actions group ([#553](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/553))\n - chore(ci)(deps): bump actions/upload-pages-artifact from 4.0.0 to 5.0.0 ([#554](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/554))\n - Refactor config UI, stream image & IDs\n - Add configurable pause screen delay\n - Hide IP for non-admins and remove app version\n - feat: multi-instance Sonarr/Radarr support ([#559](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/559))\n - Handle ratings when 0\n - Use <img> icons and themeable ARR dropdown\n - Add external configPage.css and refactor HTML\n - Missed translation key\n - Improve Active Streams Icons\n - Add admin broadcast to Active Streams\n - Improve logging: user display & polling dedup\n - Stop polling when page is not visible\n - Avoid redundant user-settings POSTs\n - Show all instances in calendar labels\n - Docs: Add multi-instance ARR and Active Streams\n - Update JellyfinEnhancedController.cs",
         "targetAbi": "10.11.0.0",
         "version": "11.7.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.7.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -121,7 +177,7 @@
         "timestamp": "2026-04-18T17:12:52"
       },
       {
-        "changelog": "- Update flag image source to use CDN for flags ([#535](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/535))\n - chore(ci)(deps): bump trufflesecurity/trufflehog from 3.94.1 to 3.94.2 in the github-actions group ([#537](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/537))\n - fix: fall back from regional locale to base language ([#539](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/539))\n - fix: custom tabs render empty after dashboard navigation ([#540](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/540))\n - Add play activity variants across locales\n - feat: User Reviews ([#542](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/542))\n - feat: add \"Request More\" button next to Series heading on Series pages ([#543](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/543))\n - Adding to the user reviews feature. Admin controls for users. Bugs ([#545](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/545))\n - Use mapped countryCode for flag URL",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Update flag image source to use CDN for flags ([#535](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/535))\n - chore(ci)(deps): bump trufflesecurity/trufflehog from 3.94.1 to 3.94.2 in the github-actions group ([#537](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/537))\n - fix: fall back from regional locale to base language ([#539](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/539))\n - fix: custom tabs render empty after dashboard navigation ([#540](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/540))\n - Add play activity variants across locales\n - feat: User Reviews ([#542](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/542))\n - feat: add \"Request More\" button next to Series heading on Series pages ([#543](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/543))\n - Adding to the user reviews feature. Admin controls for users. Bugs ([#545](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/545))\n - Use mapped countryCode for flag URL",
         "targetAbi": "10.11.0.0",
         "version": "11.6.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.6.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -129,7 +185,7 @@
         "timestamp": "2026-04-11T11:43:29"
       },
       {
-        "changelog": "- fix: prevent plugin UI disappearing after upgrade and crashing at start up ([#531](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/531))",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- fix: prevent plugin UI disappearing after upgrade and crashing at start up ([#531](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/531))",
         "targetAbi": "10.11.0.0",
         "version": "11.5.1.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.5.1.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -137,7 +193,7 @@
         "timestamp": "2026-04-05T19:55:25"
       },
       {
-        "changelog": "- Added Catalan, Basque and Galician flag codes ([#501](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/501))\n - Changed 2 translations that werent working. ([#506](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/506))\n - fix: prevent duplicate avatar downloads filling up browser temp files ([#504](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/504))\n - fix: fall back to show poster for seasons missing artwork ([#505](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/505))\n - 2 more corrections catalan tl ([#507](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/507))\n - chore(ci)(deps): bump the github-actions group with 2 updates ([#508](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/508))\n - chore(ci)(deps): bump actions/configure-pages from 5.0.0 to 6.0.0 ([#509](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/509))\n - chore(ci)(deps): bump actions/deploy-pages from 4.0.5 to 5.0.0 ([#510](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/510))\n - fix: move non-sensitive derived values from private-config to public-config ([#517](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/517))\n - fix: wait for access token before Seerr initialization ([#518](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/518))\n - fix: include primary language in translation fallback chain ([#519](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/519))\n - Fix broken Troubleshooting link in issue template\n - add czech and slovak language ([#521](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/521))\n - fix: Clear stale UseCustomTabs/UsePluginPages flags when plugins not installed ([#522](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/522))\n - fix: Bookmarks tab empty, add sidebar nav and Custom Tabs support ([#523](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/523))\n - refactor: enhance activity icon matching with regex patterns and normalize text from Jellyfin\n - fix: filter download queue by user requests for non-admin users ([#524](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/524))\n - Mismatched ellipsis\n - perf: Consolidate MutationObservers and unify tag systems into single pipeline ([#515](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/515))\n - perf: replace 100+ GitHub HEAD requests with server-side locale enumeration ([#527](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/527))\n - Weblate for translations\n - Add Weblate translation badges",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Added Catalan, Basque and Galician flag codes ([#501](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/501))\n - Changed 2 translations that werent working. ([#506](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/506))\n - fix: prevent duplicate avatar downloads filling up browser temp files ([#504](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/504))\n - fix: fall back to show poster for seasons missing artwork ([#505](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/505))\n - 2 more corrections catalan tl ([#507](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/507))\n - chore(ci)(deps): bump the github-actions group with 2 updates ([#508](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/508))\n - chore(ci)(deps): bump actions/configure-pages from 5.0.0 to 6.0.0 ([#509](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/509))\n - chore(ci)(deps): bump actions/deploy-pages from 4.0.5 to 5.0.0 ([#510](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/510))\n - fix: move non-sensitive derived values from private-config to public-config ([#517](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/517))\n - fix: wait for access token before Seerr initialization ([#518](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/518))\n - fix: include primary language in translation fallback chain ([#519](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/519))\n - Fix broken Troubleshooting link in issue template\n - add czech and slovak language ([#521](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/521))\n - fix: Clear stale UseCustomTabs/UsePluginPages flags when plugins not installed ([#522](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/522))\n - fix: Bookmarks tab empty, add sidebar nav and Custom Tabs support ([#523](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/523))\n - refactor: enhance activity icon matching with regex patterns and normalize text from Jellyfin\n - fix: filter download queue by user requests for non-admin users ([#524](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/524))\n - Mismatched ellipsis\n - perf: Consolidate MutationObservers and unify tag systems into single pipeline ([#515](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/515))\n - perf: replace 100+ GitHub HEAD requests with server-side locale enumeration ([#527](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/527))\n - Weblate for translations\n - Add Weblate translation badges",
         "targetAbi": "10.11.0.0",
         "version": "11.5.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.5.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -145,7 +201,7 @@
         "timestamp": "2026-04-04T10:23:49"
       },
       {
-        "changelog": "- docs: installation, troubleshooting, etc ([#475](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/475))\n - fix: prevent plugin from overwriting user's language on every page load ([#469](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/469))\n - feat: add Simplified Chinese (zh-CN) support ([#466](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/466))\n - Update languagetags.js ([#464](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/464))\n - fix: show proper season names and metadata for TheTVDB ([#468](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/468))\n - chore(ci)(deps): bump the github-actions group with 2 updates ([#460](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/460))\n - fix: Jellyseerr search not triggering on Jellyfin 10.11.x ([#473](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/473))\n - Invalidate locales cache when plugin version changes\n - Add Jellyseerr issue indicator to report button\n - Improve pause screen timing, safety checks, and logging\n - chore(ci)(deps): bump the github-actions group with 3 updates ([#483](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/483))\n - fix: scope global .material-icons CSS to prevent volume OSD shrinking ([#484](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/484))\n - docs: fix: Jellyseerr URL mappings clarifications ([#489](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/489))\n - Catalan Translation ([#490](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/490))\n - feat: quality profile mode for auto-movie-request ([#485](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/485))\n - feat: Auto import Jellyfin users to Seerr ([#492](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/492))\n - Rename Jellyseerr references to Seerr in config UI\n - Improve Jellyseerr user import UX and docs\n - Update Discord link in README.md ([#493](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/493))\n - Update ICON_MAP with Catalan TL\n - Separate mappings into languages\n - feat: Config page search & setting dependency enforcement ([#495](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/495))\n - Update activity icons with polish language ([#496](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/496))\n - 4k series requests ([#497](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/497))\n - Update Seerr icon and descriptions in UI and documentation\n - refactor: Update documentation to replace Jellyseerr references with Seerr\n - v11.4.0.0",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- docs: installation, troubleshooting, etc ([#475](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/475))\n - fix: prevent plugin from overwriting user's language on every page load ([#469](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/469))\n - feat: add Simplified Chinese (zh-CN) support ([#466](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/466))\n - Update languagetags.js ([#464](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/464))\n - fix: show proper season names and metadata for TheTVDB ([#468](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/468))\n - chore(ci)(deps): bump the github-actions group with 2 updates ([#460](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/460))\n - fix: Jellyseerr search not triggering on Jellyfin 10.11.x ([#473](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/473))\n - Invalidate locales cache when plugin version changes\n - Add Jellyseerr issue indicator to report button\n - Improve pause screen timing, safety checks, and logging\n - chore(ci)(deps): bump the github-actions group with 3 updates ([#483](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/483))\n - fix: scope global .material-icons CSS to prevent volume OSD shrinking ([#484](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/484))\n - docs: fix: Jellyseerr URL mappings clarifications ([#489](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/489))\n - Catalan Translation ([#490](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/490))\n - feat: quality profile mode for auto-movie-request ([#485](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/485))\n - feat: Auto import Jellyfin users to Seerr ([#492](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/492))\n - Rename Jellyseerr references to Seerr in config UI\n - Improve Jellyseerr user import UX and docs\n - Update Discord link in README.md ([#493](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/493))\n - Update ICON_MAP with Catalan TL\n - Separate mappings into languages\n - feat: Config page search & setting dependency enforcement ([#495](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/495))\n - Update activity icons with polish language ([#496](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/496))\n - 4k series requests ([#497](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/497))\n - Update Seerr icon and descriptions in UI and documentation\n - refactor: Update documentation to replace Jellyseerr references with Seerr\n - v11.4.0.0",
         "targetAbi": "10.11.0.0",
         "version": "11.4.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.4.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -153,7 +209,7 @@
         "timestamp": "2026-03-28T13:17:45"
       },
       {
-        "changelog": "- Add blocklisted and deleted request statuses\n - Update TMDB settings on load; add autoMovieRequest\n - Add option to show downloads on Requests page\n - Add physical media quality tags and detection\n - Update config.js\n - Show advanced Jellyseerr request modal\n - Add Jellyseerr search results toggle\n - Inject JellyfinEnhanced as JE in bookmarks module\n - Add forced 'Only Requested' calendar mode\n - Add Jellyfin season links and 4K badges\n - Add getItemCached helper and use across modules\n - Use event navigation & prefetched currentUser\n - Add Jellyseerr caching, TMDB enrichment\n - Invalidate caches and emit events on requests\n - added Arabic language ([#454](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/454))\n - Fix: Calendar respects user library access (Issue [#443](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/443)) ([#453](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/453))\n - Normalize quality labels; improve audio detection\n - More CodeQL fixes\n - Remove unused constants - CodeQL\n - Add time/remaining watch progress modes and save\n - Use idle-based scheduling for pause overlay\n - Update .gitignore\n - Enable re-request for deleted items and tweak UI\n - fix: Plugin Pages and Custom Tabs working together ([#457](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/457))\n - Update configPage.html",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Add blocklisted and deleted request statuses\n - Update TMDB settings on load; add autoMovieRequest\n - Add option to show downloads on Requests page\n - Add physical media quality tags and detection\n - Update config.js\n - Show advanced Jellyseerr request modal\n - Add Jellyseerr search results toggle\n - Inject JellyfinEnhanced as JE in bookmarks module\n - Add forced 'Only Requested' calendar mode\n - Add Jellyfin season links and 4K badges\n - Add getItemCached helper and use across modules\n - Use event navigation & prefetched currentUser\n - Add Jellyseerr caching, TMDB enrichment\n - Invalidate caches and emit events on requests\n - added Arabic language ([#454](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/454))\n - Fix: Calendar respects user library access (Issue [#443](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/443)) ([#453](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/453))\n - Normalize quality labels; improve audio detection\n - More CodeQL fixes\n - Remove unused constants - CodeQL\n - Add time/remaining watch progress modes and save\n - Use idle-based scheduling for pause overlay\n - Update .gitignore\n - Enable re-request for deleted items and tweak UI\n - fix: Plugin Pages and Custom Tabs working together ([#457](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/457))\n - Update configPage.html",
         "targetAbi": "10.11.0.0",
         "version": "11.3.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.3.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -161,7 +217,7 @@
         "timestamp": "2026-03-15T16:37:28"
       },
       {
-        "changelog": "-",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Critical security update",
         "targetAbi": "10.11.0.0",
         "version": "11.2.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.2.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -169,15 +225,7 @@
         "timestamp": "2026-03-07T23:31:15"
       },
       {
-        "changelog": "- Critical security update",
-        "targetAbi": "10.10.7.0",
-        "version": "10.11.1.0",
-        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.11.1.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
-        "checksum": "9C0828014F9E8E93177F147DDD921B8C",
-        "timestamp": "2026-03-07T22:52:52"
-      },
-      {
-        "changelog": "- Create pt-BR.json\n - Pause colored ratings polling during playback\n - feat: add cast/actors support for hidden content system ([#390](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/390))\n - Update ratings.css\n - fix(ratings): update South Korea rating selector to KR-19\n - fix: prevent hide icon from appearing on image editor cards\n - Add 'Show Requested Items Only' calendar setting\n - Jellyseerr Rebranding - 1st pass\n - Add en-US and en-GB identical to en\n - Added dutch locale ([#411](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/411))\n - fix: hidden content page and hide button improvements ([#407](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/407))\n - fix(subtitles): disable custom subtitles now respects default subtitle settings ([#414](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/414))\n - Add en-GB/en-US locales and normalize lang codes\n - Add Jellyseerr request API and TV 'Request More'\n - fix: prevent duplicate Jellyseerr requests from auto-season-request ([#418](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/418))\n - Add isAdmin setting and persist admin status\n - Embed Material Symbols Rounded via @font-face",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Create pt-BR.json\n - Pause colored ratings polling during playback\n - feat: add cast/actors support for hidden content system ([#390](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/390))\n - Update ratings.css\n - fix(ratings): update South Korea rating selector to KR-19\n - fix: prevent hide icon from appearing on image editor cards\n - Add 'Show Requested Items Only' calendar setting\n - Jellyseerr Rebranding - 1st pass\n - Add en-US and en-GB identical to en\n - Added dutch locale ([#411](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/411))\n - fix: hidden content page and hide button improvements ([#407](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/407))\n - fix(subtitles): disable custom subtitles now respects default subtitle settings ([#414](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/414))\n - Add en-GB/en-US locales and normalize lang codes\n - Add Jellyseerr request API and TV 'Request More'\n - fix: prevent duplicate Jellyseerr requests from auto-season-request ([#418](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/418))\n - Add isAdmin setting and persist admin status\n - Embed Material Symbols Rounded via @font-face",
         "targetAbi": "10.11.0.0",
         "version": "11.1.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.1.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -185,7 +233,7 @@
         "timestamp": "2026-02-27T19:41:54"
       },
       {
-        "changelog": "- norwegian locale translation file added\n - fix: open Jellyseerr title links externally from search cards\n - Improve Calendar UI for small screens\n - fix selectors for custom tabs\n - fix: harden user/branding endpoints and issue query handling\n - fix: restrict sensitive jellyseerr actions to admins\n - fix(discovery): repair actor infinite scroll and default More From to All\n - feat: add IMAX quality tag detection\n - style: use rgba color for IMAX quality tag\n - feat: add File Transformation plugin warning on config page\n - docs: add screenshot for PR reference\n - style: add JSDoc comments to File Transformation check\n - Delete .github/ft-warning-screenshot.png\n - Add GNU General Public License v3\n - Update README.md\n - Use database to fetch item ids and episode ids from sonarr providers\n - Update README.md\n - Remove 10.10.7-specific code\n - feat: add Refresh Translation Cache scheduled task\n - Remove version specific trigger\n - Add translation validation script and workflows\n - Update ratings.css\n - feat: per-user hidden content system ([#335](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/335))\n - Add DefaultLanguage config.\n - Update validate-translations.js\n - Add Traditional Chinese (Hong Kong) translation\n - docs: initial commit\n - Update docs.yml\n - Move Hidden Content and Jellyseerr modal option\n - Add comprehensive plugin documentation\n - Update mkdocs.yml\n - Add translations module with caching\n - Update configPage.html\n - Fix Global Language Settings\n - Another pass at documentation!\n - Update mkdocs.yml\n - Add HSS discovery handler for Jellyseerr modal\n - More doc changes\n - Update manifest.json\n - Update Discord community link\n - Dont auto-request season with 0 episodes\n - Add hidden-content localization entries\n - Add support for unmonitored series in calendar view  ([#379](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/379))\n - Darken backdrop for calendar and requests tabs\n - Add Jellyseerr Issues to Downloads page\n - Missed translation keys\n - Update issue-reporter.js\n - Sorted the Ratings alphabetically and removed duplicates ([#380](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/380))\n - Add custom subtitle color controls\n - Fix hide icon not showing when there are no hidden items\n - Hidden Content: plugin page & custom tab support\n - Add Requests filter to Calendar\n - Request non-special TV seasons; skip empty seasons\n - docs: Introduce Material for MkDocs ([#387](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/387))\n - Missed changes for hidden-content\n -  update docs\n - Update configPage.html\n - Docs: enhance features, fix formatting & nav\n - Revamp README: restructure docs and features\n - This doesn't stop!\n - ahh.. here we go again!\n - Update docs: clarify version and plugin links",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- norwegian locale translation file added\n - fix: open Jellyseerr title links externally from search cards\n - Improve Calendar UI for small screens\n - fix selectors for custom tabs\n - fix: harden user/branding endpoints and issue query handling\n - fix: restrict sensitive jellyseerr actions to admins\n - fix(discovery): repair actor infinite scroll and default More From to All\n - feat: add IMAX quality tag detection\n - style: use rgba color for IMAX quality tag\n - feat: add File Transformation plugin warning on config page\n - docs: add screenshot for PR reference\n - style: add JSDoc comments to File Transformation check\n - Delete .github/ft-warning-screenshot.png\n - Add GNU General Public License v3\n - Update README.md\n - Use database to fetch item ids and episode ids from sonarr providers\n - Update README.md\n - Remove 10.10.7-specific code\n - feat: add Refresh Translation Cache scheduled task\n - Remove version specific trigger\n - Add translation validation script and workflows\n - Update ratings.css\n - feat: per-user hidden content system ([#335](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/335))\n - Add DefaultLanguage config.\n - Update validate-translations.js\n - Add Traditional Chinese (Hong Kong) translation\n - docs: initial commit\n - Update docs.yml\n - Move Hidden Content and Jellyseerr modal option\n - Add comprehensive plugin documentation\n - Update mkdocs.yml\n - Add translations module with caching\n - Update configPage.html\n - Fix Global Language Settings\n - Another pass at documentation!\n - Update mkdocs.yml\n - Add HSS discovery handler for Jellyseerr modal\n - More doc changes\n - Update manifest.json\n - Update Discord community link\n - Dont auto-request season with 0 episodes\n - Add hidden-content localization entries\n - Add support for unmonitored series in calendar view  ([#379](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/379))\n - Darken backdrop for calendar and requests tabs\n - Add Jellyseerr Issues to Downloads page\n - Missed translation keys\n - Update issue-reporter.js\n - Sorted the Ratings alphabetically and removed duplicates ([#380](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/380))\n - Add custom subtitle color controls\n - Fix hide icon not showing when there are no hidden items\n - Hidden Content: plugin page & custom tab support\n - Add Requests filter to Calendar\n - Request non-special TV seasons; skip empty seasons\n - docs: Introduce Material for MkDocs ([#387](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/387))\n - Missed changes for hidden-content\n -  update docs\n - Update configPage.html\n - Docs: enhance features, fix formatting & nav\n - Revamp README: restructure docs and features\n - This doesn't stop!\n - ahh.. here we go again!\n - Update docs: clarify version and plugin links",
         "targetAbi": "10.11.0.0",
         "version": "11.0.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/11.0.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
@@ -193,7 +241,23 @@
         "timestamp": "2026-02-14T09:39:24"
       },
       {
-        "changelog": "- Respect Plugin Pages Settings\n - Add *arr URL mapping support\n - Add markdown support to reviews\n - Refactor reviews page detection to use onViewPage hook\n - Leverage helpers for throttling, debouncing, and observers\n - Update quality tag documentation for codecs and features\n - Fix load order for dependencies\n - Rework Calendar UI ([#338](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/338))\n - Update funding.yml\n - Update funding.yml\n - Missed \"All Day\" Translation\n - Fix clicking on items not navigating to item in request custom tab\n - Remove debug logging for person tags\n - fix: Add custom tab flags and conditional init\n - Small css tweaks\n - Remove in-memory season request cache\n - Add ArrTags sync filter and UI\n - Update pr.json\n - Fix backdrop issue in custom tabs\n - Update README.md\n - Add plugin-pages support for Bookmarks\n - Fallback to series rating only if missing\n - Add configurable auto-refresh for Downloads page",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Critical security update",
+        "targetAbi": "10.10.7.0",
+        "version": "10.11.1.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.11.1.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
+        "checksum": "9C0828014F9E8E93177F147DDD921B8C",
+        "timestamp": "2026-03-07T22:52:52"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Respect Plugin Pages Settings\n - Add *arr URL mapping support\n - Add markdown support to reviews\n - Refactor reviews page detection to use onViewPage hook\n - Leverage helpers for throttling, debouncing, and observers\n - Update quality tag documentation for codecs and features\n - Fix load order for dependencies\n - Rework Calendar UI ([#338](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/338))\n - Update funding.yml\n - Update funding.yml\n - Missed \"All Day\" Translation\n - Fix clicking on items not navigating to item in request custom tab\n - Remove debug logging for person tags\n - fix: Add custom tab flags and conditional init\n - Small css tweaks\n - Remove in-memory season request cache\n - Add ArrTags sync filter and UI\n - Update pr.json\n - Fix backdrop issue in custom tabs\n - Update README.md\n - Add plugin-pages support for Bookmarks\n - Fallback to series rating only if missing\n - Add configurable auto-refresh for Downloads page",
+        "targetAbi": "10.11.0.0",
+        "version": "10.11.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.11.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "CFC644A2DAC90A059639C8B7B8EFE034",
+        "timestamp": "2026-02-06T22:06:42"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Respect Plugin Pages Settings\n - Add *arr URL mapping support\n - Add markdown support to reviews\n - Refactor reviews page detection to use onViewPage hook\n - Leverage helpers for throttling, debouncing, and observers\n - Update quality tag documentation for codecs and features\n - Fix load order for dependencies\n - Rework Calendar UI ([#338](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/338))\n - Update funding.yml\n - Update funding.yml\n - Missed \"All Day\" Translation\n - Fix clicking on items not navigating to item in request custom tab\n - Remove debug logging for person tags\n - fix: Add custom tab flags and conditional init\n - Small css tweaks\n - Remove in-memory season request cache\n - Add ArrTags sync filter and UI\n - Update pr.json\n - Fix backdrop issue in custom tabs\n - Update README.md\n - Add plugin-pages support for Bookmarks\n - Fallback to series rating only if missing\n - Add configurable auto-refresh for Downloads page",
         "targetAbi": "10.10.7.0",
         "version": "10.11.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.11.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -201,7 +265,15 @@
         "timestamp": "2026-02-06T22:06:51"
       },
       {
-        "changelog": "- Enforce icon size on card with !important\n - Keep last calendar view in user settings\n - fix: Jellyseerr proxy URL fallback on HTTP errors\n - Fix calendar range handling (UTC) and pass RFC3339 start/end to Sonarr/Radarr\n - Add watchlist re-addition prevention feature\n - Improve logging and result tracking in watchlist sync\n - Reduce unnecessary info logs\n - Use new item by provider id endpoint to navigate in calendar\n - Add manual refresh and improve polling for downloads\n - Remove status filter from download queue request\n - Add PeopleTagsEnabled to config handling\n - Improve handling of downloads poll interval config\n - Enhance request status colors and section classes\n - Add detailed logging to Jellyseerr watchlist sync\n - Add downloads tab filtering and search UI\n - Add i18n support for requests page and update translations\n - Update ratings.css\n - Add video format detection and badges to quality tags\n - Set calendar default view mode to 'agenda'\n - Add Custom Tabs support for Calendar and Requests pages\n - Refactor JS file structure and update imports\n - Update CONTRIBUTING.md",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Enforce icon size on card with !important\n - Keep last calendar view in user settings\n - fix: Jellyseerr proxy URL fallback on HTTP errors\n - Fix calendar range handling (UTC) and pass RFC3339 start/end to Sonarr/Radarr\n - Add watchlist re-addition prevention feature\n - Improve logging and result tracking in watchlist sync\n - Reduce unnecessary info logs\n - Use new item by provider id endpoint to navigate in calendar\n - Add manual refresh and improve polling for downloads\n - Remove status filter from download queue request\n - Add PeopleTagsEnabled to config handling\n - Improve handling of downloads poll interval config\n - Enhance request status colors and section classes\n - Add detailed logging to Jellyseerr watchlist sync\n - Add downloads tab filtering and search UI\n - Add i18n support for requests page and update translations\n - Update ratings.css\n - Add video format detection and badges to quality tags\n - Set calendar default view mode to 'agenda'\n - Add Custom Tabs support for Calendar and Requests pages\n - Refactor JS file structure and update imports\n - Update CONTRIBUTING.md",
+        "targetAbi": "10.11.0.0",
+        "version": "10.10.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.10.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "C67E7ACC3182508DEE51045692BA5694",
+        "timestamp": "2026-02-01T14:02:35"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Enforce icon size on card with !important\n - Keep last calendar view in user settings\n - fix: Jellyseerr proxy URL fallback on HTTP errors\n - Fix calendar range handling (UTC) and pass RFC3339 start/end to Sonarr/Radarr\n - Add watchlist re-addition prevention feature\n - Improve logging and result tracking in watchlist sync\n - Reduce unnecessary info logs\n - Use new item by provider id endpoint to navigate in calendar\n - Add manual refresh and improve polling for downloads\n - Remove status filter from download queue request\n - Add PeopleTagsEnabled to config handling\n - Improve handling of downloads poll interval config\n - Enhance request status colors and section classes\n - Add detailed logging to Jellyseerr watchlist sync\n - Add downloads tab filtering and search UI\n - Add i18n support for requests page and update translations\n - Update ratings.css\n - Add video format detection and badges to quality tags\n - Set calendar default view mode to 'agenda'\n - Add Custom Tabs support for Calendar and Requests pages\n - Refactor JS file structure and update imports\n - Update CONTRIBUTING.md",
         "targetAbi": "10.10.7.0",
         "version": "10.10.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.10.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -209,7 +281,15 @@
         "timestamp": "2026-02-01T14:02:44"
       },
       {
-        "changelog": "- Fix http link\n - Switch to Material Symbols Rounded icons in calendar page\n - fix: Navigate to available items form Calendar ([#313](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/313))\n - feat: Highlight calendar entries for favorites and watched series ([#314](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/314))\n - Change Menu Icon to material_icon for consistency\n - Revamp calendar event indicators for watchlist/watched\n - Update Translations\n - Refactor nav items to use anchor elements\n - Add interactive filtering to calendar legend\n - Add dynamic theme color support to calendar and requests pages\n - Handle server ID mismatch during plugin initialization\n - Fix ColorRatings on Scyfin and Elegantfin\n - Remove icons.js from config page to fix initialization conflicts\n - Refactor agenda event indicators layout\n - Add view mode hash support and default mobile to agenda\n - Fix season pack size calculation in requests page\n - Access to Calendar/Requests pages with Plugin Pages\n - Fix for calendar item without file but with bookmark\n - Parameter to disable Plugin Pages integration\n - Add note in configPage and improve logging\n - Update configPage.html\n - Add custom icon classes and badge for source labels\n - Translations for Coming Soon\n - Add 'Coming Soon' filter and release date display to requests\n - Add seamless infinite scroll to discovery sections\n - Refactor infinite scroll to require seamlessScroll module\n - Create CONTRIBUTING.md\n - Translations for People Tags\n - Add People Tags feature for cast member info\n - Remove useless call to calendar & new endpoint item by providers\n - Rename sonarr to Sonarr\n - Fix Semicolon",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Fix http link\n - Switch to Material Symbols Rounded icons in calendar page\n - fix: Navigate to available items form Calendar ([#313](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/313))\n - feat: Highlight calendar entries for favorites and watched series ([#314](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/314))\n - Change Menu Icon to material_icon for consistency\n - Revamp calendar event indicators for watchlist/watched\n - Update Translations\n - Refactor nav items to use anchor elements\n - Add interactive filtering to calendar legend\n - Add dynamic theme color support to calendar and requests pages\n - Handle server ID mismatch during plugin initialization\n - Fix ColorRatings on Scyfin and Elegantfin\n - Remove icons.js from config page to fix initialization conflicts\n - Refactor agenda event indicators layout\n - Add view mode hash support and default mobile to agenda\n - Fix season pack size calculation in requests page\n - Access to Calendar/Requests pages with Plugin Pages\n - Fix for calendar item without file but with bookmark\n - Parameter to disable Plugin Pages integration\n - Add note in configPage and improve logging\n - Update configPage.html\n - Add custom icon classes and badge for source labels\n - Translations for Coming Soon\n - Add 'Coming Soon' filter and release date display to requests\n - Add seamless infinite scroll to discovery sections\n - Refactor infinite scroll to require seamlessScroll module\n - Create CONTRIBUTING.md\n - Translations for People Tags\n - Add People Tags feature for cast member info\n - Remove useless call to calendar & new endpoint item by providers\n - Rename sonarr to Sonarr\n - Fix Semicolon",
+        "targetAbi": "10.11.0.0",
+        "version": "10.9.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.9.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "7A1130D0288E9E931F136C858674DA40",
+        "timestamp": "2026-01-30T00:24:08"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Fix http link\n - Switch to Material Symbols Rounded icons in calendar page\n - fix: Navigate to available items form Calendar ([#313](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/313))\n - feat: Highlight calendar entries for favorites and watched series ([#314](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/314))\n - Change Menu Icon to material_icon for consistency\n - Revamp calendar event indicators for watchlist/watched\n - Update Translations\n - Refactor nav items to use anchor elements\n - Add interactive filtering to calendar legend\n - Add dynamic theme color support to calendar and requests pages\n - Handle server ID mismatch during plugin initialization\n - Fix ColorRatings on Scyfin and Elegantfin\n - Remove icons.js from config page to fix initialization conflicts\n - Refactor agenda event indicators layout\n - Add view mode hash support and default mobile to agenda\n - Fix season pack size calculation in requests page\n - Access to Calendar/Requests pages with Plugin Pages\n - Fix for calendar item without file but with bookmark\n - Parameter to disable Plugin Pages integration\n - Add note in configPage and improve logging\n - Update configPage.html\n - Add custom icon classes and badge for source labels\n - Translations for Coming Soon\n - Add 'Coming Soon' filter and release date display to requests\n - Add seamless infinite scroll to discovery sections\n - Refactor infinite scroll to require seamlessScroll module\n - Create CONTRIBUTING.md\n - Translations for People Tags\n - Add People Tags feature for cast member info\n - Remove useless call to calendar & new endpoint item by providers\n - Rename sonarr to Sonarr\n - Fix Semicolon",
         "targetAbi": "10.10.7.0",
         "version": "10.9.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.9.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -217,7 +297,15 @@
         "timestamp": "2026-01-30T00:24:15"
       },
       {
-        "changelog": "- Remove Jellyseerr Icon references\n - Set fixed heights for poster images in requests page\n - Update Jellyseerr connection status icons in README\n - Remove Jellyseerr Icons\n - Improve navigation handling for calendar and requests pages\n - Replace fixed calendar grid with minmax for flexible widths\n - Refactor requests localization keys and add missing translations\n - Change defaults for requests and calendar pages to false\n - Modify arr/requests endpoint to enforce Jellyseerr user permissions\n - Rename Seerr folders to Jellyseerr\n - Change Namespace from Seerr to Jellyseerr\n - Hopefully fix Play button not directly playing items in request page",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Remove Jellyseerr Icon references\n - Set fixed heights for poster images in requests page\n - Update Jellyseerr connection status icons in README\n - Remove Jellyseerr Icons\n - Improve navigation handling for calendar and requests pages\n - Replace fixed calendar grid with minmax for flexible widths\n - Refactor requests localization keys and add missing translations\n - Change defaults for requests and calendar pages to false\n - Modify arr/requests endpoint to enforce Jellyseerr user permissions\n - Rename Seerr folders to Jellyseerr\n - Change Namespace from Seerr to Jellyseerr\n - Hopefully fix Play button not directly playing items in request page",
+        "targetAbi": "10.11.0.0",
+        "version": "10.8.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.8.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "16A5981BF10E0D3CB742DCD17120EEB8",
+        "timestamp": "2026-01-26T22:37:17"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Remove Jellyseerr Icon references\n - Set fixed heights for poster images in requests page\n - Update Jellyseerr connection status icons in README\n - Remove Jellyseerr Icons\n - Improve navigation handling for calendar and requests pages\n - Replace fixed calendar grid with minmax for flexible widths\n - Refactor requests localization keys and add missing translations\n - Change defaults for requests and calendar pages to false\n - Modify arr/requests endpoint to enforce Jellyseerr user permissions\n - Rename Seerr folders to Jellyseerr\n - Change Namespace from Seerr to Jellyseerr\n - Hopefully fix Play button not directly playing items in request page",
         "targetAbi": "10.10.7.0",
         "version": "10.8.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.8.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -225,7 +313,15 @@
         "timestamp": "2026-01-26T22:37:26"
       },
       {
-        "changelog": "- Refactor discovery modules with shared utilities and fix All filter\n - fix: feature toggle for colored ratings\n - Fix Plugin Icons overriding default material icon styles\n - Add support for Apple Touch Icons in branding\n - Update configPage.html\n - Add option to exclude rejected items from suggestions\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Refactor discovery modules with shared utilities and fix All filter\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Update item-details.js\n - Merge branch 'jake/discovery-refactor-and-filter-fix' of https://github.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced into pr/285\n - Refactor discovery modules with shared utilities and fix All filter ([#285](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/285))\n - Add missed JellyseerrExcludeRejectedItems to Public-Config\n - Add i18n for discovery filter and update button styles\n - Update README.md\n - v10.6.0.0\n - Add requests page with sonarr/radarr/jellyseerr request monitoring\n - Remove unused references\n - Enhance requests page UI\n - Add Calendar Page for Sonarr/Radarr releases\n - Reduce the size of 2x overlay\n - Update README.md\n - Refactor navigation and logging for enhanced UI consistency\n - Improve branding uploads with image dimension preview\n - Improve sidebar navigation injection and resilience",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Refactor discovery modules with shared utilities and fix All filter\n - fix: feature toggle for colored ratings\n - Fix Plugin Icons overriding default material icon styles\n - Add support for Apple Touch Icons in branding\n - Update configPage.html\n - Add option to exclude rejected items from suggestions\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Refactor discovery modules with shared utilities and fix All filter\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Update item-details.js\n - Merge branch 'jake/discovery-refactor-and-filter-fix' of https://github.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced into pr/285\n - Refactor discovery modules with shared utilities and fix All filter ([#285](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/285))\n - Add missed JellyseerrExcludeRejectedItems to Public-Config\n - Add i18n for discovery filter and update button styles\n - Update README.md\n - v10.6.0.0\n - Add requests page with sonarr/radarr/jellyseerr request monitoring\n - Remove unused references\n - Enhance requests page UI\n - Add Calendar Page for Sonarr/Radarr releases\n - Reduce the size of 2x overlay\n - Update README.md\n - Refactor navigation and logging for enhanced UI consistency\n - Improve branding uploads with image dimension preview\n - Improve sidebar navigation injection and resilience",
+        "targetAbi": "10.11.0.0",
+        "version": "10.7.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.7.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "5A9E061DFBE0FCD90E0D046DD109B48C",
+        "timestamp": "2026-01-25T19:14:04"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Refactor discovery modules with shared utilities and fix All filter\n - fix: feature toggle for colored ratings\n - Fix Plugin Icons overriding default material icon styles\n - Add support for Apple Touch Icons in branding\n - Update configPage.html\n - Add option to exclude rejected items from suggestions\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Refactor discovery modules with shared utilities and fix All filter\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Update item-details.js\n - Merge branch 'jake/discovery-refactor-and-filter-fix' of https://github.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced into pr/285\n - Refactor discovery modules with shared utilities and fix All filter ([#285](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/285))\n - Add missed JellyseerrExcludeRejectedItems to Public-Config\n - Add i18n for discovery filter and update button styles\n - Update README.md\n - v10.6.0.0\n - Add requests page with sonarr/radarr/jellyseerr request monitoring\n - Remove unused references\n - Enhance requests page UI\n - Add Calendar Page for Sonarr/Radarr releases\n - Reduce the size of 2x overlay\n - Update README.md\n - Refactor navigation and logging for enhanced UI consistency\n - Improve branding uploads with image dimension preview\n - Improve sidebar navigation injection and resilience",
         "targetAbi": "10.10.7.0",
         "version": "10.7.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.7.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -233,7 +329,15 @@
         "timestamp": "2026-01-25T19:14:11"
       },
       {
-        "changelog": "- Refactor discovery modules with shared utilities and fix All filter\n - fix: feature toggle for colored ratings\n - Fix Plugin Icons overriding default material icon styles\n - Add support for Apple Touch Icons in branding\n - Update configPage.html\n - Add option to exclude rejected items from suggestions\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Refactor discovery modules with shared utilities and fix All filter\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Update item-details.js\n - Merge branch 'jake/discovery-refactor-and-filter-fix' of https://github.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced into pr/285\n - Refactor discovery modules with shared utilities and fix All filter ([#285](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/285))\n - Add missed JellyseerrExcludeRejectedItems to Public-Config\n - Add i18n for discovery filter and update button styles\n - Update README.md",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Refactor discovery modules with shared utilities and fix All filter\n - fix: feature toggle for colored ratings\n - Fix Plugin Icons overriding default material icon styles\n - Add support for Apple Touch Icons in branding\n - Update configPage.html\n - Add option to exclude rejected items from suggestions\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Refactor discovery modules with shared utilities and fix All filter\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Update item-details.js\n - Merge branch 'jake/discovery-refactor-and-filter-fix' of https://github.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced into pr/285\n - Refactor discovery modules with shared utilities and fix All filter ([#285](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/285))\n - Add missed JellyseerrExcludeRejectedItems to Public-Config\n - Add i18n for discovery filter and update button styles\n - Update README.md",
+        "targetAbi": "10.11.0.0",
+        "version": "10.6.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.6.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "E6608972A623F9822943AC89A5F1A710",
+        "timestamp": "2026-01-23T23:22:10"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Refactor discovery modules with shared utilities and fix All filter\n - fix: feature toggle for colored ratings\n - Fix Plugin Icons overriding default material icon styles\n - Add support for Apple Touch Icons in branding\n - Update configPage.html\n - Add option to exclude rejected items from suggestions\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Refactor discovery modules with shared utilities and fix All filter\n - Update discovery-filter-utils.js\n - Update item-details.js\n - Update item-details.js\n - Merge branch 'jake/discovery-refactor-and-filter-fix' of https://github.com/4eh5xitv6787h645ebv/Jellyfin-Enhanced into pr/285\n - Refactor discovery modules with shared utilities and fix All filter ([#285](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/285))\n - Add missed JellyseerrExcludeRejectedItems to Public-Config\n - Add i18n for discovery filter and update button styles\n - Update README.md",
         "targetAbi": "10.10.7.0",
         "version": "10.6.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.6.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -241,7 +345,15 @@
         "timestamp": "2026-01-23T23:22:20"
       },
       {
-        "changelog": "- Add cache-busting for settings.json\n - Fix random button showing watched series\n - Improve status handling for movie collections UI\n - Add extras: colored ratings, theme selector, activity and plugin icons\n - Fix links\n - Add logging and simplify observers in icon scripts\n - Wrap example images in links and update styles\n - Refactor feature initializers to use JellyfinEnhanced namespace\n - Improve config UI and plugin icon handling\n - Add login image feature to manual login screen\n - Use TMDB for total episode count in auto season requests\n - Add mobile client mapping warning to config page\n - Add custom plugin links to dashboard sidebar\n - Fix jellyseerr links opening in app\n - Refactor Jellyseerr config UI with collapsible sections\n - Fix placeholder examples for custom plugin links\n - Add warning about 10.10 compatibility for plugin icons\n - Add section for personal scripts and update file structure",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Add cache-busting for settings.json\n - Fix random button showing watched series\n - Improve status handling for movie collections UI\n - Add extras: colored ratings, theme selector, activity and plugin icons\n - Fix links\n - Add logging and simplify observers in icon scripts\n - Wrap example images in links and update styles\n - Refactor feature initializers to use JellyfinEnhanced namespace\n - Improve config UI and plugin icon handling\n - Add login image feature to manual login screen\n - Use TMDB for total episode count in auto season requests\n - Add mobile client mapping warning to config page\n - Add custom plugin links to dashboard sidebar\n - Fix jellyseerr links opening in app\n - Refactor Jellyseerr config UI with collapsible sections\n - Fix placeholder examples for custom plugin links\n - Add warning about 10.10 compatibility for plugin icons\n - Add section for personal scripts and update file structure",
+        "targetAbi": "10.11.0.0",
+        "version": "10.5.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.5.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "CC14AA65E6C40F96B5B84D4D71060182",
+        "timestamp": "2026-01-21T15:15:24"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add cache-busting for settings.json\n - Fix random button showing watched series\n - Improve status handling for movie collections UI\n - Add extras: colored ratings, theme selector, activity and plugin icons\n - Fix links\n - Add logging and simplify observers in icon scripts\n - Wrap example images in links and update styles\n - Refactor feature initializers to use JellyfinEnhanced namespace\n - Improve config UI and plugin icon handling\n - Add login image feature to manual login screen\n - Use TMDB for total episode count in auto season requests\n - Add mobile client mapping warning to config page\n - Add custom plugin links to dashboard sidebar\n - Fix jellyseerr links opening in app\n - Refactor Jellyseerr config UI with collapsible sections\n - Fix placeholder examples for custom plugin links\n - Add warning about 10.10 compatibility for plugin icons\n - Add section for personal scripts and update file structure",
         "targetAbi": "10.10.7.0",
         "version": "10.5.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.5.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -249,7 +361,15 @@
         "timestamp": "2026-01-21T15:15:31"
       },
       {
-        "changelog": "- Update README.md\n - Add Esc to close more-info-modal\n - Minor fixes for Jellyseerr in-library items\n - Add hover tooltip for Partially Available TV shows with active downloads\n - Reduce Logging\n - Update playback.js\n - Collections in More Info Modal\n - Fix Collection results opening more-info-modal\n - Update redirect for random button [Bang Redirect]",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Update README.md\n - Add Esc to close more-info-modal\n - Minor fixes for Jellyseerr in-library items\n - Add hover tooltip for Partially Available TV shows with active downloads\n - Reduce Logging\n - Update playback.js\n - Collections in More Info Modal\n - Fix Collection results opening more-info-modal\n - Update redirect for random button [Bang Redirect]",
+        "targetAbi": "10.11.0.0",
+        "version": "10.4.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.4.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "96438DDA652EBCF4B532831ED1A78C3D",
+        "timestamp": "2026-01-16T19:09:03"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Update README.md\n - Add Esc to close more-info-modal\n - Minor fixes for Jellyseerr in-library items\n - Add hover tooltip for Partially Available TV shows with active downloads\n - Reduce Logging\n - Update playback.js\n - Collections in More Info Modal\n - Fix Collection results opening more-info-modal\n - Update redirect for random button [Bang Redirect]",
         "targetAbi": "10.10.7.0",
         "version": "10.4.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.4.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -257,7 +377,15 @@
         "timestamp": "2026-01-16T19:09:10"
       },
       {
-        "changelog": "- stop tags from being added again on hover\n - Add preview and baseurl support for Custom Branding\n - Fix reporting button on Seasons and Episodes\n - feat: handle nested collections and different item types",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**",
+        "targetAbi": "10.11.0.0",
+        "version": "10.3.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.3.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "DFA080C6CDEDE6F11281085520E9EEBF",
+        "timestamp": "2026-01-11T20:19:11"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- stop tags from being added again on hover\n - Add preview and baseurl support for Custom Branding\n - Fix reporting button on Seasons and Episodes\n - feat: handle nested collections and different item types",
         "targetAbi": "10.10.7.0",
         "version": "10.3.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.3.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -265,7 +393,15 @@
         "timestamp": "2026-01-11T18:41:19"
       },
       {
-        "changelog": "- feat: implemented icons selection and switch logic\n - fix: add empty array fallback in the case shortcuts arent available right away\n - fix: trigger window location check on load to load icons fix: tag icon replaced dynamically\n - fix: initialize stubs to help with initialization\n - fix: wrap lucide icons with center styling\n - feat: replace all emoji inside js files with JE.icon() function call\n - feat: translation token replacement for emoji fix: add missing emoji (ⓘ) fix: better fallback handling\n - chore: update all translation files with icon tokens instead of literal emoji\n - Merge branch 'main' into feat_optional-icons\n - fix: update new translations to use icon tokens instead of emoji\n - Update README.md\n - Update README.md\n - Add infinite scroll to network discovery section\n - Fix card sizing to match native Jellyfin\n - Fix card sizing to exactly match native Jellyfin\n - Fix card sizing to match native Jellyfin exactly\n - Performance optimization for network-discovery.js\n - Add genre, tag, and person discovery sections\n - Fix discovery sections rendering on hidden pages\n - Use dynamic TMDB genre lookup instead of hardcoded list\n - Use dynamic TMDB search for networks instead of hardcoded list\n - Fix network discovery to use separate TV network and company IDs\n - Update manifest to point to fork repository\n - Target Jellyfin 10.11+ for v10.1.0.1\n - Add checksum for v10.1.0.1 release\n - Revert manifest.json to upstream\n - Update translations and Controller to use the plugin config\n - fix formatting for linediffs\n - Merge branch 'main' into feat_optional-icons\n - Feat: Customizable icons ([#262](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/262))\n - Remove unused translations\n - Cache Jellyseerr user-status\n - Add some missing icons and change configpage layout\n - Fix icons for names like fastForward\n - Add margin for tags if they have cardIndicators\n - Add options for watch % display\n - Fix warning_off icon for issue reporter\n - Update issue-reporting errors\n - Custom Branding",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- feat: implemented icons selection and switch logic\n - fix: add empty array fallback in the case shortcuts arent available right away\n - fix: trigger window location check on load to load icons fix: tag icon replaced dynamically\n - fix: initialize stubs to help with initialization\n - fix: wrap lucide icons with center styling\n - feat: replace all emoji inside js files with JE.icon() function call\n - feat: translation token replacement for emoji fix: add missing emoji (ⓘ) fix: better fallback handling\n - chore: update all translation files with icon tokens instead of literal emoji\n - Merge branch 'main' into feat_optional-icons\n - fix: update new translations to use icon tokens instead of emoji\n - Update README.md\n - Update README.md\n - Add infinite scroll to network discovery section\n - Fix card sizing to match native Jellyfin\n - Fix card sizing to exactly match native Jellyfin\n - Fix card sizing to match native Jellyfin exactly\n - Performance optimization for network-discovery.js\n - Add genre, tag, and person discovery sections\n - Fix discovery sections rendering on hidden pages\n - Use dynamic TMDB genre lookup instead of hardcoded list\n - Use dynamic TMDB search for networks instead of hardcoded list\n - Fix network discovery to use separate TV network and company IDs\n - Update manifest to point to fork repository\n - Target Jellyfin 10.11+ for v10.1.0.1\n - Add checksum for v10.1.0.1 release\n - Revert manifest.json to upstream\n - Update translations and Controller to use the plugin config\n - fix formatting for linediffs\n - Merge branch 'main' into feat_optional-icons\n - Feat: Customizable icons ([#262](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/262))\n - Remove unused translations\n - Cache Jellyseerr user-status\n - Add some missing icons and change configpage layout\n - Fix icons for names like fastForward\n - Add margin for tags if they have cardIndicators\n - Add options for watch % display\n - Fix warning_off icon for issue reporter\n - Update issue-reporting errors\n - Custom Branding",
+        "targetAbi": "10.11.0.0",
+        "version": "10.2.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.2.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "B797A4822C094A7F363C462ACD0129D5",
+        "timestamp": "2026-01-11T01:07:17"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- feat: implemented icons selection and switch logic\n - fix: add empty array fallback in the case shortcuts arent available right away\n - fix: trigger window location check on load to load icons fix: tag icon replaced dynamically\n - fix: initialize stubs to help with initialization\n - fix: wrap lucide icons with center styling\n - feat: replace all emoji inside js files with JE.icon() function call\n - feat: translation token replacement for emoji fix: add missing emoji (ⓘ) fix: better fallback handling\n - chore: update all translation files with icon tokens instead of literal emoji\n - Merge branch 'main' into feat_optional-icons\n - fix: update new translations to use icon tokens instead of emoji\n - Update README.md\n - Update README.md\n - Add infinite scroll to network discovery section\n - Fix card sizing to match native Jellyfin\n - Fix card sizing to exactly match native Jellyfin\n - Fix card sizing to match native Jellyfin exactly\n - Performance optimization for network-discovery.js\n - Add genre, tag, and person discovery sections\n - Fix discovery sections rendering on hidden pages\n - Use dynamic TMDB genre lookup instead of hardcoded list\n - Use dynamic TMDB search for networks instead of hardcoded list\n - Fix network discovery to use separate TV network and company IDs\n - Update manifest to point to fork repository\n - Target Jellyfin 10.11+ for v10.1.0.1\n - Add checksum for v10.1.0.1 release\n - Revert manifest.json to upstream\n - Update translations and Controller to use the plugin config\n - fix formatting for linediffs\n - Merge branch 'main' into feat_optional-icons\n - Feat: Customizable icons ([#262](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/262))\n - Remove unused translations\n - Cache Jellyseerr user-status\n - Add some missing icons and change configpage layout\n - Fix icons for names like fastForward\n - Add margin for tags if they have cardIndicators\n - Add options for watch % display\n - Fix warning_off icon for issue reporter\n - Update issue-reporting errors\n - Custom Branding",
         "targetAbi": "10.10.7.0",
         "version": "10.2.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.2.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -273,7 +409,15 @@
         "timestamp": "2026-01-11T01:07:25"
       },
       {
-        "changelog": "- Fix Translations\n - Prevent closing a modal that doesnt exist\n - Fix: show enhanced details for seasons\n - Feat: switch watch progress between percentage and time\n - show days, months, years for long items and fix rounding\n - Add pointer cursor style\n - feat: new skip intro/outro shortcut",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Fix Translations\n - Prevent closing a modal that doesnt exist\n - Fix: show enhanced details for seasons\n - Feat: switch watch progress between percentage and time\n - show days, months, years for long items and fix rounding\n - Add pointer cursor style\n - feat: new skip intro/outro shortcut",
+        "targetAbi": "10.11.0.0",
+        "version": "10.1.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.1.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "CB3690E85FF6B7B6C2A214419D633807",
+        "timestamp": "2026-01-06T21:07:27"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Fix Translations\n - Prevent closing a modal that doesnt exist\n - Fix: show enhanced details for seasons\n - Feat: switch watch progress between percentage and time\n - show days, months, years for long items and fix rounding\n - Add pointer cursor style\n - feat: new skip intro/outro shortcut",
         "targetAbi": "10.10.7.0",
         "version": "10.1.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.1.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -281,7 +425,15 @@
         "timestamp": "2026-01-06T21:07:33"
       },
       {
-        "changelog": "- Add option to require all prior episodes watched for auto season request\n - Fix typo in Auto Season Request\n - Update logging to use 'Auto-Season-Request' label\n - Update .gitattributes\n - Add automatic movie request feature\n - Refactor and enhance Jellyseerr card UI interactions\n - Hover on desktop not working still\n - Move Jellyseerr icon to cardtext Secondary\n - Add status badge to Jellyseerr result cards\n - Fix 4k Split Button\n - Fix Border Right Width as well\n - Add request button and status chips in more-info-modal\n - Translations\n - Mobile CSS Fixes\n - Missed translations\n - Refactor overview display logic for media cards\n - Dont reserve space for status chip if it doesn't exist\n - Add refresh button to the more-info-modal\n - Remove open links with TMDB option.\n - Close more-info-modal on page navigation\n - Update Jellyseerr Link in more-info-modal to use mapping\n - Group Downloads by downloadID and show ETA in more-info-modal\n - Item exists in library, link to library item\n - Link available chips to media items\n - Remove TMDB Ghosts\n - Update 4k button styles\n - Fix the requested button status\n - Use viewShow for issue button and add backdrop\n - Use hotCache for OSD ratings and stop genre tags on video page\n - Add comprehensive bookmarks system with visual markers and library management\n - Remove Migration Support for browser to server storage\n - Update en.json\n - Cancel Button Display Flex\n - Update Readme to add Bookmarks and Jellyseerr files\n - Remove background for OSD-ratings\n - Update Watchlist to fetch all requests from Jellyseerr\n - Remove the usage of pending-watchlist.json",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Add option to require all prior episodes watched for auto season request\n - Fix typo in Auto Season Request\n - Update logging to use 'Auto-Season-Request' label\n - Update .gitattributes\n - Add automatic movie request feature\n - Refactor and enhance Jellyseerr card UI interactions\n - Hover on desktop not working still\n - Move Jellyseerr icon to cardtext Secondary\n - Add status badge to Jellyseerr result cards\n - Fix 4k Split Button\n - Fix Border Right Width as well\n - Add request button and status chips in more-info-modal\n - Translations\n - Mobile CSS Fixes\n - Missed translations\n - Refactor overview display logic for media cards\n - Dont reserve space for status chip if it doesn't exist\n - Add refresh button to the more-info-modal\n - Remove open links with TMDB option.\n - Close more-info-modal on page navigation\n - Update Jellyseerr Link in more-info-modal to use mapping\n - Group Downloads by downloadID and show ETA in more-info-modal\n - Item exists in library, link to library item\n - Link available chips to media items\n - Remove TMDB Ghosts\n - Update 4k button styles\n - Fix the requested button status\n - Use viewShow for issue button and add backdrop\n - Use hotCache for OSD ratings and stop genre tags on video page\n - Add comprehensive bookmarks system with visual markers and library management\n - Remove Migration Support for browser to server storage\n - Update en.json\n - Cancel Button Display Flex\n - Update Readme to add Bookmarks and Jellyseerr files\n - Remove background for OSD-ratings\n - Update Watchlist to fetch all requests from Jellyseerr\n - Remove the usage of pending-watchlist.json",
+        "targetAbi": "10.11.0.0",
+        "version": "10.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.0.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "8F1D2B58CE9B7848BDFF6744BBA6AFCB",
+        "timestamp": "2026-01-04T00:41:03"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add option to require all prior episodes watched for auto season request\n - Fix typo in Auto Season Request\n - Update logging to use 'Auto-Season-Request' label\n - Update .gitattributes\n - Add automatic movie request feature\n - Refactor and enhance Jellyseerr card UI interactions\n - Hover on desktop not working still\n - Move Jellyseerr icon to cardtext Secondary\n - Add status badge to Jellyseerr result cards\n - Fix 4k Split Button\n - Fix Border Right Width as well\n - Add request button and status chips in more-info-modal\n - Translations\n - Mobile CSS Fixes\n - Missed translations\n - Refactor overview display logic for media cards\n - Dont reserve space for status chip if it doesn't exist\n - Add refresh button to the more-info-modal\n - Remove open links with TMDB option.\n - Close more-info-modal on page navigation\n - Update Jellyseerr Link in more-info-modal to use mapping\n - Group Downloads by downloadID and show ETA in more-info-modal\n - Item exists in library, link to library item\n - Link available chips to media items\n - Remove TMDB Ghosts\n - Update 4k button styles\n - Fix the requested button status\n - Use viewShow for issue button and add backdrop\n - Use hotCache for OSD ratings and stop genre tags on video page\n - Add comprehensive bookmarks system with visual markers and library management\n - Remove Migration Support for browser to server storage\n - Update en.json\n - Cancel Button Display Flex\n - Update Readme to add Bookmarks and Jellyseerr files\n - Remove background for OSD-ratings\n - Update Watchlist to fetch all requests from Jellyseerr\n - Remove the usage of pending-watchlist.json",
         "targetAbi": "10.10.7.0",
         "version": "10.0.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/10.0.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -289,7 +441,15 @@
         "timestamp": "2026-01-04T00:41:10"
       },
       {
-        "changelog": "- Replace icon progress indicators with SVG\n - Jellyseerr Buton Processing state fix when 4K requests are enabled.\n - Fix CSS syntax error in 4k popup item style\n - Show available items as updating when downloads active\n - Add ETA display to download popover in UI\n - Add Polish locale file\n - Refresh button in Jellyseerr Results actually does something now!\n - Add Jellyseerr More Info modal\n - Remove je-extra-media-info container and related styles\n - Add TMDB and Rotten Tomatoes ratings to UI\n - Update README.md\n - Fix some classes clashing with slideshow.css",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Replace icon progress indicators with SVG\n - Jellyseerr Buton Processing state fix when 4K requests are enabled.\n - Fix CSS syntax error in 4k popup item style\n - Show available items as updating when downloads active\n - Add ETA display to download popover in UI\n - Add Polish locale file\n - Refresh button in Jellyseerr Results actually does something now!\n - Add Jellyseerr More Info modal\n - Remove je-extra-media-info container and related styles\n - Add TMDB and Rotten Tomatoes ratings to UI\n - Update README.md\n - Fix some classes clashing with slideshow.css",
+        "targetAbi": "10.11.0.0",
+        "version": "9.11.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.11.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "0D7F89F66898B79F8AA7E1B955ED6ED8",
+        "timestamp": "2025-12-30T11:48:17"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Replace icon progress indicators with SVG\n - Jellyseerr Buton Processing state fix when 4K requests are enabled.\n - Fix CSS syntax error in 4k popup item style\n - Show available items as updating when downloads active\n - Add ETA display to download popover in UI\n - Add Polish locale file\n - Refresh button in Jellyseerr Results actually does something now!\n - Add Jellyseerr More Info modal\n - Remove je-extra-media-info container and related styles\n - Add TMDB and Rotten Tomatoes ratings to UI\n - Update README.md\n - Fix some classes clashing with slideshow.css",
         "targetAbi": "10.10.7.0",
         "version": "9.11.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.11.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -297,7 +457,15 @@
         "timestamp": "2025-12-30T11:48:27"
       },
       {
-        "changelog": "- Improve mobile styles for tag overlays\n - Add container for enhanced media info items\n - Add File Size and Watched % for BoxSets and Playlists\n - Defer tag queue processing with requestIdleCallback\n - Refactor tag cache and UI observers for performance\n - Show existing Jellyseerr issues in issue reporter modal\n - Add Russian Translation\n - Add Pirate Translations, cuz why not!\n - Improve pause screen timer reset logic\n - Improve long press handling for video speed 2x\n - Add TMDB collection support to Jellyseerr search\n - Update watchlist sync to respect config and fix return value\n - Refactor and clarify *arr settings and tag sync UI\n - Add option to enable Druidblack metadata icons\n - Add support for custom languages in language selector\n - Add missed translation for Collection Modal\n - Localize collection request button label\n - Update README.md",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Improve mobile styles for tag overlays\n - Add container for enhanced media info items\n - Add File Size and Watched % for BoxSets and Playlists\n - Defer tag queue processing with requestIdleCallback\n - Refactor tag cache and UI observers for performance\n - Show existing Jellyseerr issues in issue reporter modal\n - Add Russian Translation\n - Add Pirate Translations, cuz why not!\n - Improve pause screen timer reset logic\n - Improve long press handling for video speed 2x\n - Add TMDB collection support to Jellyseerr search\n - Update watchlist sync to respect config and fix return value\n - Refactor and clarify *arr settings and tag sync UI\n - Add option to enable Druidblack metadata icons\n - Add support for custom languages in language selector\n - Add missed translation for Collection Modal\n - Localize collection request button label\n - Update README.md",
+        "targetAbi": "10.11.0.0",
+        "version": "9.10.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.10.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "BF327ED2014F640CAB2497D366A84F5F",
+        "timestamp": "2025-12-27T14:23:23"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Improve mobile styles for tag overlays\n - Add container for enhanced media info items\n - Add File Size and Watched % for BoxSets and Playlists\n - Defer tag queue processing with requestIdleCallback\n - Refactor tag cache and UI observers for performance\n - Show existing Jellyseerr issues in issue reporter modal\n - Add Russian Translation\n - Add Pirate Translations, cuz why not!\n - Improve pause screen timer reset logic\n - Improve long press handling for video speed 2x\n - Add TMDB collection support to Jellyseerr search\n - Update watchlist sync to respect config and fix return value\n - Refactor and clarify *arr settings and tag sync UI\n - Add option to enable Druidblack metadata icons\n - Add support for custom languages in language selector\n - Add missed translation for Collection Modal\n - Localize collection request button label\n - Update README.md",
         "targetAbi": "10.10.7.0",
         "version": "9.10.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.10.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -305,7 +473,15 @@
         "timestamp": "2025-12-27T14:23:32"
       },
       {
-        "changelog": "- Optimize tag rendering and queue handling in tag scripts\n - Improve tag overlay responsiveness and styling\n - Update Jellyseerr URL mapping examples and descriptions\n - Add rating tags and OSD rating feature\n - Improve issue reporting button logic and UI\n - Add Jellyseerr similar and recommended sections to item details\n - Add option to exclude library items from Jellyseerr Recommendations",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\nMerry Christmas and Happy New Year to everyone! 🎄🥳 \n\n\n- Optimize tag rendering and queue handling in tag scripts\n - Improve tag overlay responsiveness and styling\n - Update Jellyseerr URL mapping examples and descriptions\n - Add rating tags and OSD rating feature\n - Improve issue reporting button logic and UI\n - Add Jellyseerr similar and recommended sections to item details\n - Add option to exclude library items from Jellyseerr Recommendations",
+        "targetAbi": "10.11.0.0",
+        "version": "9.9.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.9.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "B425FB47C3383662F9E134DD86C828A3",
+        "timestamp": "2025-12-24T15:59:47"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Optimize tag rendering and queue handling in tag scripts\n - Improve tag overlay responsiveness and styling\n - Update Jellyseerr URL mapping examples and descriptions\n - Add rating tags and OSD rating feature\n - Improve issue reporting button logic and UI\n - Add Jellyseerr similar and recommended sections to item details\n - Add option to exclude library items from Jellyseerr Recommendations",
         "targetAbi": "10.10.7.0",
         "version": "9.9.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.9.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -313,7 +489,15 @@
         "timestamp": "2025-12-24T15:59:54"
       },
       {
-        "changelog": "- Fix Log spam for watchlist\n - Update AutoSeasonRequestMonitor.cs\n - Initial Commit - Issue reporter rough Integration\n - fixed some UI issues\n - Added config and checks\n - Added Season and Episode selection\n - removed files not present\n - Added Jellyseerr issue reporting to README\n - old mapping for textual problem types were removed\n - Add missing Jellyseerr report issue translations and fix modal backdrop visibility\n - Fix Translations for Issue Reporting\n - Add onClose handler to Jellyseerr modal for cleanup\n - Sync Jellyseerr requests with watchlist items",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Fix Log spam for watchlist\n - Update AutoSeasonRequestMonitor.cs\n - Initial Commit - Issue reporter rough Integration\n - fixed some UI issues\n - Added config and checks\n - Added Season and Episode selection\n - removed files not present\n - Added Jellyseerr issue reporting to README\n - old mapping for textual problem types were removed\n - Add missing Jellyseerr report issue translations and fix modal backdrop visibility\n - Fix Translations for Issue Reporting\n - Add onClose handler to Jellyseerr modal for cleanup\n - Sync Jellyseerr requests with watchlist items",
+        "targetAbi": "10.11.0.0",
+        "version": "9.8.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.8.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "380B6985EFE8676A87F6096FCECB410C",
+        "timestamp": "2025-12-20T14:04:23"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Fix Log spam for watchlist\n - Update AutoSeasonRequestMonitor.cs\n - Initial Commit - Issue reporter rough Integration\n - fixed some UI issues\n - Added config and checks\n - Added Season and Episode selection\n - removed files not present\n - Added Jellyseerr issue reporting to README\n - old mapping for textual problem types were removed\n - Add missing Jellyseerr report issue translations and fix modal backdrop visibility\n - Fix Translations for Issue Reporting\n - Add onClose handler to Jellyseerr modal for cleanup\n - Sync Jellyseerr requests with watchlist items",
         "targetAbi": "10.10.7.0",
         "version": "9.8.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.8.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -321,7 +505,15 @@
         "timestamp": "2025-12-20T14:04:29"
       },
       {
-        "changelog": "- Update configPage.html\n - Revert \"Add File Size and Watched % for BoxSets and Playlists\"\n - Add centralized observer management and performance helpers\n - Fix elsewhere where it does not consider filtered services",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Update configPage.html\n - Revert \"Add File Size and Watched % for BoxSets and Playlists\"\n - Add centralized observer management and performance helpers\n - Fix elsewhere where it does not consider filtered services",
+        "targetAbi": "10.11.0.0",
+        "version": "9.7.1.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.7.1.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "8A0C648BFCB2EA6AF6EDC43D0721C65C",
+        "timestamp": "2025-12-14T00:49:40"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Update configPage.html\n - Revert \"Add File Size and Watched % for BoxSets and Playlists\"\n - Add centralized observer management and performance helpers\n - Fix elsewhere where it does not consider filtered services",
         "targetAbi": "10.10.7.0",
         "version": "9.7.1.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.7.1.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -329,7 +521,15 @@
         "timestamp": "2025-12-14T00:49:47"
       },
       {
-        "changelog": "- Update audio language map and implement scroll for more than 3 tracks\n - Improve logic of letterboxed links\n - Improve auto request : rewrite threshold logic and add Jellyseerr validation\n - Add File Size and Watched % for BoxSets and Playlists",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Update audio language map and implement scroll for more than 3 tracks\n - Improve logic of letterboxed links\n - Improve auto request : rewrite threshold logic and add Jellyseerr validation\n - Add File Size and Watched % for BoxSets and Playlists",
+        "targetAbi": "10.11.0.0",
+        "version": "9.7.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.7.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "FD888976DCE062EC79D7D29588862461",
+        "timestamp": "2025-12-12T19:41:29"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Update audio language map and implement scroll for more than 3 tracks\n - Improve logic of letterboxed links\n - Improve auto request : rewrite threshold logic and add Jellyseerr validation\n - Add File Size and Watched % for BoxSets and Playlists",
         "targetAbi": "10.10.7.0",
         "version": "9.7.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.7.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -337,7 +537,15 @@
         "timestamp": "2025-12-12T19:41:35"
       },
       {
-        "changelog": "- Fix repeated API calls for arr tags and arr tag links\n - Initialize scripts only if the feature is enabled.\n - Fix duplicate shadows for subtitles\n - Display Genre Tags for Seasons",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Fix repeated API calls for arr tags and arr tag links\n - Initialize scripts only if the feature is enabled.\n - Fix duplicate shadows for subtitles\n - Display Genre Tags for Seasons",
+        "targetAbi": "10.11.0.0",
+        "version": "9.6.3.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.6.3.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "F263F9D94F9CE639A5AB66488F3348F7",
+        "timestamp": "2025-12-06T17:49:28"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Fix repeated API calls for arr tags and arr tag links\n - Initialize scripts only if the feature is enabled.\n - Fix duplicate shadows for subtitles\n - Display Genre Tags for Seasons",
         "targetAbi": "10.10.7.0",
         "version": "9.6.3.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.6.3.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -345,7 +553,15 @@
         "timestamp": "2025-12-06T17:49:35"
       },
       {
-        "changelog": "- Add Brazilian language mapping to country codes\n - Add Russian language support for genre icons\n - Fix advanced auto request\n - Add option to select all seasons",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Add Brazilian language mapping to country codes\n - Add Russian language support for genre icons\n - Fix advanced auto request\n - Add option to select all seasons",
+        "targetAbi": "10.11.0.0",
+        "version": "9.6.2.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.6.2.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "23090AA41A6140E2EE34ABC7C9F0AA68",
+        "timestamp": "2025-11-30T12:54:49"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add Brazilian language mapping to country codes\n - Add Russian language support for genre icons\n - Fix advanced auto request\n - Add option to select all seasons",
         "targetAbi": "10.10.7.0",
         "version": "9.6.2.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.6.2.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -353,7 +569,15 @@
         "timestamp": "2025-11-30T12:54:55"
       },
       {
-        "changelog": "- Add admin page selectors to ignore lists in tag scripts\n - Add Series/Season language detection for item details\n - Add data-lang attributes for CSS targeting\n - Update configPage.html\n - Add Enhanced Settings link to user preferences menu",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Add admin page selectors to ignore lists in tag scripts\n - Add Series/Season language detection for item details\n - Add data-lang attributes for CSS targeting\n - Update configPage.html\n - Add Enhanced Settings link to user preferences menu",
+        "targetAbi": "10.11.0.0",
+        "version": "9.6.1.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.6.1.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "8329DEBA1120B35159B809AFFE8515B4",
+        "timestamp": "2025-11-24T12:55:42"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add admin page selectors to ignore lists in tag scripts\n - Add Series/Season language detection for item details\n - Add data-lang attributes for CSS targeting\n - Update configPage.html\n - Add Enhanced Settings link to user preferences menu",
         "targetAbi": "10.10.7.0",
         "version": "9.6.1.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.6.1.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -361,7 +585,15 @@
         "timestamp": "2025-11-24T12:55:49"
       },
       {
-        "changelog": "- Add custom branding options for Elsewhere panel\n - feat: watch progress for item details\n - add styling to support vanilla jellyfin css\n - Add language selection and cache clearing to UI\n - Populate Language Tags in IPEP\n - Improve genre and language detection for Series/Season\n - Add Open Episode Preview keyboard shortcut\n - Better close subtitles dialog\n - Add Jellyseerr URL mapping support\n - Persist active tab in config settings\n - Align placeholders vertically in feature tooltips\n - Add automatic season request feature\n - Update README with download badges for versions\n - Add Jellyseerr watchlist sync and auto-watchlist features\n - Improve translation caching with versioning\n - Update Jellyseerr integration and translation caching docs\n - Improve modal accessibility and keyboard navigation\n - Update README.md\n - Fix version specific logic!",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Add custom branding options for Elsewhere panel\n - feat: watch progress for item details\n - add styling to support vanilla jellyfin css\n - Add language selection and cache clearing to UI\n - Populate Language Tags in IPEP\n - Improve genre and language detection for Series/Season\n - Add Open Episode Preview keyboard shortcut\n - Better close subtitles dialog\n - Add Jellyseerr URL mapping support\n - Persist active tab in config settings\n - Align placeholders vertically in feature tooltips\n - Add automatic season request feature\n - Update README with download badges for versions\n - Add Jellyseerr watchlist sync and auto-watchlist features\n - Improve translation caching with versioning\n - Update Jellyseerr integration and translation caching docs\n - Improve modal accessibility and keyboard navigation\n - Update README.md\n - Fix version specific logic!",
+        "targetAbi": "10.11.0.0",
+        "version": "9.6.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.6.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "715DFB6D3F318AE3A75EA96B4C78EB9D",
+        "timestamp": "2025-11-23T17:50:12"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add custom branding options for Elsewhere panel\n - feat: watch progress for item details\n - add styling to support vanilla jellyfin css\n - Add language selection and cache clearing to UI\n - Populate Language Tags in IPEP\n - Improve genre and language detection for Series/Season\n - Add Open Episode Preview keyboard shortcut\n - Better close subtitles dialog\n - Add Jellyseerr URL mapping support\n - Persist active tab in config settings\n - Align placeholders vertically in feature tooltips\n - Add automatic season request feature\n - Update README with download badges for versions\n - Add Jellyseerr watchlist sync and auto-watchlist features\n - Improve translation caching with versioning\n - Update Jellyseerr integration and translation caching docs\n - Improve modal accessibility and keyboard navigation\n - Update README.md\n - Fix version specific logic!",
         "targetAbi": "10.10.7.0",
         "version": "9.6.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.6.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -369,7 +601,15 @@
         "timestamp": "2025-11-23T17:50:19"
       },
       {
-        "changelog": "\n - Ignore tags on chapter card image container\n - Update plugin.js\n - feat: file size info for shows and seasons\n - feat: fetch translations from GitHub with caching and fallback\n - fix: repair translation validation workflow\n - Add Missed translation keys for Elsewhere panel UI elements\n - add spacing after arr-tag-link-icon",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Ignore tags on chapter card image container\n - Update plugin.js\n - feat: file size info for shows and seasons\n - feat: fetch translations from GitHub with caching and fallback\n - fix: repair translation validation workflow\n - Add Missed translation keys for Elsewhere panel UI elements\n - add spacing after arr-tag-link-icon",
+        "targetAbi": "10.11.0.0",
+        "version": "9.5.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.5.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "6C18138D156399C642FE05631A20DBE4",
+        "timestamp": "2025-11-21T17:52:26"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Ignore tags on chapter card image container\n - Update plugin.js\n - feat: file size info for shows and seasons\n - feat: fetch translations from GitHub with caching and fallback\n - fix: repair translation validation workflow\n - Add Missed translation keys for Elsewhere panel UI elements\n - add spacing after arr-tag-link-icon",
         "targetAbi": "10.10.7.0",
         "version": "9.5.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.5.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -377,7 +617,15 @@
         "timestamp": "2025-11-21T17:52:33"
       },
       {
-        "changelog": "- Add Brazilian Portuguese localization\n - Add Turkish localization\n - Fix ampersand replacement in series names for Sonarr links[#182](https://github.com/n00bcodr/Jellyfin-Enhanced/pull/182)\n - Improve user retrieval logic in plugin initialization to fix translations [#168](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/168)\n - Add delayed pause screen with interaction reset [#179](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/179)\n - Fix review layout to support different themes [#178](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/178)\n - Add Letterboxd external links[#181](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/181)\n - Remove watchlist feature (moved to KefinTweaks)\n - Add *arr tags sync and display synced tags as clickable links[#157](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/157)\n - Improve 4K request popup positioning and button styles[#167](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/167)\n - Add option to disable tags on search page (Gelato compatibility)[#173](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/173)",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Add Brazilian Portuguese localization\n - Add Turkish localization\n - Fix ampersand replacement in series names for Sonarr links[#182](https://github.com/n00bcodr/Jellyfin-Enhanced/pull/182)\n - Improve user retrieval logic in plugin initialization to fix translations [#168](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/168)\n - Add delayed pause screen with interaction reset [#179](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/179)\n - Fix review layout to support different themes [#178](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/178)\n - Add Letterboxd external links[#181](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/181)\n - Remove watchlist feature (moved to KefinTweaks)\n - Add *arr tags sync and display synced tags as clickable links[#157](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/157)\n - Improve 4K request popup positioning and button styles[#167](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/167)\n - Add option to disable tags on search page (Gelato compatibility)[#173](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/173)\n\n - Please add the manifest for 10.11 if you are on 10.11. https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json",
+        "targetAbi": "10.11.0.0",
+        "version": "9.4.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.4.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "3F3211D611A53891F52B64F55C8A669B",
+        "timestamp": "2025-11-20T06:36:32"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add Brazilian Portuguese localization\n - Add Turkish localization\n - Fix ampersand replacement in series names for Sonarr links[#182](https://github.com/n00bcodr/Jellyfin-Enhanced/pull/182)\n - Improve user retrieval logic in plugin initialization to fix translations [#168](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/168)\n - Add delayed pause screen with interaction reset [#179](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/179)\n - Fix review layout to support different themes [#178](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/178)\n - Add Letterboxd external links[#181](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/181)\n - Remove watchlist feature (moved to KefinTweaks)\n - Add *arr tags sync and display synced tags as clickable links[#157](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/157)\n - Improve 4K request popup positioning and button styles[#167](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/167)\n - Add option to disable tags on search page (Gelato compatibility)[#173](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/173)",
         "targetAbi": "10.10.7.0",
         "version": "9.4.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.4.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -385,7 +633,15 @@
         "timestamp": "2025-11-20T06:36:40"
       },
       {
-        "changelog": "- Add endpoint for Jellyseerr partial requests setting",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Add endpoint for Jellyseerr partial requests setting",
+        "targetAbi": "10.11.0.0",
+        "version": "9.3.1.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.3.1.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "9C77A34AB07F391C8E82A97478CB5361",
+        "timestamp": "2025-11-03T16:28:15"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add endpoint for Jellyseerr partial requests setting",
         "targetAbi": "10.10.7.0",
         "version": "9.3.1.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.3.1.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -393,7 +649,15 @@
         "timestamp": "2025-11-03T16:28:23"
       },
       {
-        "changelog": "- 🐛[BUG] Unable to open user menu on WebOS Fixes [#148](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/148)\n - Prevent reviews from running on items without TMDB ID\n - Enable dynamic re-initialization for tag features\n - Improve audio language layout styling (especially on mobile)\n - Add default user settings initialization\n - Improve logging and write logs to JellyfinEnhanced Log file\n - Add manual refresh button to Jellyseerr results\n - Reset all user settings using config directories\n - Add support for Jellyseerr's partial TV season requests setting\n - Fix config check for provider icons on Jellyseerr cards",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- 🐛[BUG] Unable to open user menu on WebOS Fixes [#148](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/148)\n - Prevent reviews from running on items without TMDB ID\n - Enable dynamic re-initialization for tag features\n - Improve audio language layout styling (especially on mobile)\n - Add default user settings initialization\n - Improve logging and write logs to JellyfinEnhanced Log file\n - Add manual refresh button to Jellyseerr results\n - Reset all user settings using config directories\n - Add support for Jellyseerr's partial TV season requests setting\n - Fix config check for provider icons on Jellyseerr cards",
+        "targetAbi": "10.11.0.0",
+        "version": "9.3.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.3.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "3D1B4DE706B823F7D2933C5D5BB1D874",
+        "timestamp": "2025-11-02T16:53:47"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- 🐛[BUG] Unable to open user menu on WebOS Fixes [#148](https://github.com/n00bcodr/Jellyfin-Enhanced/issues/148)\n - Prevent reviews from running on items without TMDB ID\n - Enable dynamic re-initialization for tag features\n - Improve audio language layout styling (especially on mobile)\n - Add default user settings initialization\n - Improve logging and write logs to JellyfinEnhanced Log file\n - Add manual refresh button to Jellyseerr results\n - Reset all user settings using config directories\n - Add support for Jellyseerr's partial TV season requests setting\n - Fix config check for provider icons on Jellyseerr cards",
         "targetAbi": "10.10.7.0",
         "version": "9.3.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.3.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -401,7 +665,15 @@
         "timestamp": "2025-11-02T16:53:56"
       },
       {
-        "changelog": "- Update elsewhere.js resource URLs to use jsdelivr CDN\n - Fix quality tags for TV mode\n - Resetting LanguageTagsEnabled in ResetAllUserSettings\n - fix: add 'Remove from Continue Watching' option on right-click\n - Add 4K request support for Jellyseerr integration\n - Add support for Jellyseerr override rules in requests\n - Add tag position fields to default config mapping\n - Improve config page cache and reset descriptions",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Update elsewhere.js resource URLs to use jsdelivr CDN\n - Fix quality tags for TV mode\n - Resetting LanguageTagsEnabled in ResetAllUserSettings\n - fix: add 'Remove from Continue Watching' option on right-click\n - Add 4K request support for Jellyseerr integration\n - Add support for Jellyseerr override rules in requests\n - Add tag position fields to default config mapping\n - Improve config page cache and reset descriptions\n\n - Please add the manifest for 10.11 if you are on 10.11. https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json",
+        "targetAbi": "10.11.0.0",
+        "version": "9.2.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.2.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "33547A4546C8B1DBD87F5B11F10F51B5",
+        "timestamp": "2025-10-30T06:26:09"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Update elsewhere.js resource URLs to use jsdelivr CDN\n - Fix quality tags for TV mode\n - Resetting LanguageTagsEnabled in ResetAllUserSettings\n - fix: add 'Remove from Continue Watching' option on right-click\n - Add 4K request support for Jellyseerr integration\n - Add support for Jellyseerr override rules in requests\n - Add tag position fields to default config mapping\n - Improve config page cache and reset descriptions",
         "targetAbi": "10.10.7.0",
         "version": "9.2.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.2.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -409,7 +681,15 @@
         "timestamp": "2025-10-30T06:26:14"
       },
       {
-        "changelog": "- Add [Authorize] to Jellyseerr and TMDB endpoints\n - Add check for TMDb link before adding ARR links\n - Enhance README with troubleshooting and error info\n - Add configurable tag cache TTL and cache clear for tags\n - Add language tags overlay with configurable positions for all tags\n - Add caching for file size and audio language lookups\n - Add theme detection and dynamic theming support\n - Refactor reviews processing intervals\n - Improve Continue Watching detection logic\n - Full Blown Release Notes Conversion!\n\n - Please add the manifest for 10.11 if you are on 10.11. https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Add [Authorize] to Jellyseerr and TMDB endpoints\n - Add check for TMDb link before adding ARR links\n - Enhance README with troubleshooting and error info\n - Add configurable tag cache TTL and cache clear for tags\n - Add language tags overlay with configurable positions for all tags\n - Add caching for file size and audio language lookups\n - Add theme detection and dynamic theming support\n - Refactor reviews processing intervals\n - Improve Continue Watching detection logic\n - Full Blown Release Notes Conversion!\n\n - Please add the manifest for 10.11 if you are on 10.11. https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json",
+        "targetAbi": "10.11.0.0",
+        "version": "9.1.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.1.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "AE147D37B4AC67DD40F7A69EBC6B270D",
+        "timestamp": "2025-10-28T06:06:32"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add [Authorize] to Jellyseerr and TMDB endpoints\n - Add check for TMDb link before adding ARR links\n - Enhance README with troubleshooting and error info\n - Add configurable tag cache TTL and cache clear for tags\n - Add language tags overlay with configurable positions for all tags\n - Add caching for file size and audio language lookups\n - Add theme detection and dynamic theming support\n - Refactor reviews processing intervals\n - Improve Continue Watching detection logic\n - Full Blown Release Notes Conversion!\n\n - Please add the manifest for 10.11 if you are on 10.11. https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json",
         "targetAbi": "10.10.7.0",
         "version": "9.1.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.1.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -417,7 +697,15 @@
         "timestamp": "2025-10-28T06:06:40"
       },
       {
-        "changelog": "- Add placeholder and info for splash screen URL\n - Fix subtitle styling for Jellyfin 10.11\n - Watchlist from KefinTweaks\n - Add long press for 2x speed playback feature\n - Migrate Settings to Server!\n - Add option to link Jellyseerr site to Jellyseerr results\n - Add 'reviews expanded by default' setting\n\n - Please add the manifest for 10.11 if you are on 10.11. https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Add placeholder and info for splash screen URL\n - Fix subtitle styling for Jellyfin 10.11\n - Watchlist from KefinTweaks\n - Add long press for 2x speed playback feature\n - Migrate Settings to Server!\n - Add option to link Jellyseerr site to Jellyseerr results\n - Add 'reviews expanded by default' setting",
+        "targetAbi": "10.11.0.0",
+        "version": "9.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.0.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "8B2A6A2798E65B1443F0ADA96EF0C508",
+        "timestamp": "2025-10-26T05:40:12"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add placeholder and info for splash screen URL\n - Fix subtitle styling for Jellyfin 10.11\n - Watchlist from KefinTweaks\n - Add long press for 2x speed playback feature\n - Migrate Settings to Server!\n - Add option to link Jellyseerr site to Jellyseerr results\n - Add 'reviews expanded by default' setting\n\n - Please add the manifest for 10.11 if you are on 10.11. https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json",
         "targetAbi": "10.10.7.0",
         "version": "9.0.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/9.0.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -425,7 +713,15 @@
         "timestamp": "2025-10-26T05:40:18"
       },
       {
-        "changelog": "- Refactor file size and audio language display logic (again!)\n - Refactor reviews.js\n - Restrict genre tag processing to Movie and Series cards\n - Fix HDR10+ regex to match 'hdr10plus' format\n - Show dash placeholder when no audio languages",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Refactor file size and audio language display logic (again!)\n - Refactor reviews.js\n - Restrict genre tag processing to Movie and Series cards\n - Fix HDR10+ regex to match 'hdr10plus' format\n - Show dash placeholder when no audio languages",
+        "targetAbi": "10.11.0.0",
+        "version": "8.1.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/8.1.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "6864136A939C673D2F97BDF041F1A73A",
+        "timestamp": "2025-10-22T05:59:01"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Refactor file size and audio language display logic (again!)\n - Refactor reviews.js\n - Restrict genre tag processing to Movie and Series cards\n - Fix HDR10+ regex to match 'hdr10plus' format\n - Show dash placeholder when no audio languages",
         "targetAbi": "10.10.7.0",
         "version": "8.1.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/8.1.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -433,7 +729,15 @@
         "timestamp": "2025-10-22T05:59:08"
       },
       {
-        "changelog": "- 10.11 Support!",
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- 10.11 Support!",
+        "targetAbi": "10.11.0.0",
+        "version": "8.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/8.0.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.11.0.zip",
+        "checksum": "4571C59DCE6E606ABDBB946B9ABF890F",
+        "timestamp": "2025-10-20T11:37:06"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- 10.11 Support!",
         "targetAbi": "10.10.7.0",
         "version": "8.0.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/8.0.0.0/Jellyfin.Plugin.JellyfinEnhanced_10.10.7.zip",
@@ -441,7 +745,7 @@
         "timestamp": "2025-10-20T11:37:02"
       },
       {
-        "changelog": "- Fix the ordering of Pause Screen setting in the Enhanced Panel\n - Update pause screen to show back button\n - Align watchlist with upstream from ranaldsgift\n - Improve loading of filesize and language tags\n - Add 3D video tag detection and styling\n - Add multi-language support for genre icons",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Fix the ordering of Pause Screen setting in the Enhanced Panel\n - Update pause screen to show back button\n - Align watchlist with upstream from ranaldsgift\n - Improve loading of filesize and language tags\n - Add 3D video tag detection and styling\n - Add multi-language support for genre icons",
         "targetAbi": "10.10.7.0",
         "version": "7.13.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.13.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -449,7 +753,7 @@
         "timestamp": "2025-10-19T19:45:30"
       },
       {
-        "changelog": "- Fix the ordering of Pause Screen setting in the Enhanced Panel\n - Update pause screen to show back button\n - Align watchlist with upstream from ranaldsgift\n - Improve loading of filesize and language tags\n - Add 3D video tag detection and styling\n - Add multi-language support for genre icons",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Fix the ordering of Pause Screen setting in the Enhanced Panel\n - Update pause screen to show back button\n - Align watchlist with upstream from ranaldsgift\n - Improve loading of filesize and language tags\n - Add 3D video tag detection and styling\n - Add multi-language support for genre icons",
         "targetAbi": "10.10.7.0",
         "version": "7.12.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.12.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -457,7 +761,7 @@
         "timestamp": "2025-10-19T18:55:09"
       },
       {
-        "changelog": "- Add option to set disable custom subtitle styles\n - Add new selectors to splash screen hide list",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add option to set disable custom subtitle styles\n - Add new selectors to splash screen hide list",
         "targetAbi": "10.10.7.0",
         "version": "7.11.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.11.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -465,7 +769,7 @@
         "timestamp": "2025-10-15T06:13:49"
       },
       {
-        "changelog": "- Change Jellyseerr API endpoint for connectivity check\n - Add TMDB API key validation to config page\n - Fix TMDB API key query string handling",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Change Jellyseerr API endpoint for connectivity check\n - Add TMDB API key validation to config page\n - Fix TMDB API key query string handling",
         "targetAbi": "10.10.7.0",
         "version": "7.10.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.10.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -473,7 +777,7 @@
         "timestamp": "2025-10-08T06:16:18"
       },
       {
-        "changelog": "- Integrate watchlist into home sections plugin\n - Revert admin update check and install\n - Prevent duplicate ARR links with concurrency lock\n - Add new private-config and move sensitive info there",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Integrate watchlist into home sections plugin\n - Revert admin update check and install\n - Prevent duplicate ARR links with concurrency lock\n - Add new private-config and move sensitive info there",
         "targetAbi": "10.10.7.0",
         "version": "7.9.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.9.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -481,7 +785,7 @@
         "timestamp": "2025-10-07T12:31:43"
       },
       {
-        "changelog": "- Add TMDB API proxy endpoint\n - Update manifest name to 'Jellyfin Enhanced' to fix auto-update\n - Add configurable custom splash screen feature",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add TMDB API proxy endpoint\n - Update manifest name to 'Jellyfin Enhanced' to fix auto-update\n - Add configurable custom splash screen feature",
         "targetAbi": "10.10.7.0",
         "version": "7.8.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.8.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -489,7 +793,7 @@
         "timestamp": "2025-09-30T13:05:09"
       },
       {
-        "changelog": "- Allow requests for seasons with status 7\n - Add option to disable all keyboard shortcuts",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Allow requests for seasons with status 7\n - Add option to disable all keyboard shortcuts",
         "targetAbi": "10.10.7.0",
         "version": "7.7.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.7.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -497,7 +801,7 @@
         "timestamp": "2025-09-28T08:59:08"
       },
       {
-        "changelog": "- Add missed languages to mapping\n - Filter out 'person' results in Jellyseer search API",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add missed languages to mapping\n - Filter out 'person' results in Jellyseer search API",
         "targetAbi": "10.10.7.0",
         "version": "7.6.2.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.6.2.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -505,7 +809,7 @@
         "timestamp": "2025-09-26T15:51:30"
       },
       {
-        "changelog": "- Fix skip button observer management",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Fix skip button observer management",
         "targetAbi": "10.10.7.0",
         "version": "7.6.1.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.6.1.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -513,7 +817,7 @@
         "timestamp": "2025-09-21T05:30:44"
       },
       {
-        "changelog": "- Add admin update check and install\n - Fix Jellyseerr search input handling for TV mode UI\n - Ensure subtitle styles are applied after page load\n - Refactor auto-skip logic to use MutationObserver",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add admin update check and install\n - Fix Jellyseerr search input handling for TV mode UI\n - Ensure subtitle styles are applied after page load\n - Refactor auto-skip logic to use MutationObserver",
         "targetAbi": "10.10.7.0",
         "version": "7.6.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.6.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -521,7 +825,7 @@
         "timestamp": "2025-09-20T17:06:29"
       },
       {
-        "changelog": "- Improve download status popover handling\n - Add auto-refresh for Jellyseerr UI and modals\n - Add Meta key support to shortcut detection\n - Add Elsewhere feature toggle to plugin settings",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Improve download status popover handling\n - Add auto-refresh for Jellyseerr UI and modals\n - Add Meta key support to shortcut detection\n - Add Elsewhere feature toggle to plugin settings",
         "targetAbi": "10.10.7.0",
         "version": "7.5.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.5.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -529,7 +833,7 @@
         "timestamp": "2025-09-18T16:41:38"
       },
       {
-        "changelog": "- Add Genre Tags\n - Add a closebutton for pausescreen to remove the overlay #50\n - Create Hungarian Translations (#52, #49)\n - Add text shadow to subtitle styles #47",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add Genre Tags\n - Add a closebutton for pausescreen to remove the overlay #50\n - Create Hungarian Translations (#52, #49)\n - Add text shadow to subtitle styles #47",
         "targetAbi": "10.10.7.0",
         "version": "7.4.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.4.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -537,7 +841,7 @@
         "timestamp": "2025-09-16T05:03:00"
       },
       {
-        "changelog": "- feat: Watchlist (#48)\n - Depends on Avaiability of Custom Tabs",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- feat: Watchlist (#48)\n - Depends on Avaiability of Custom Tabs",
         "targetAbi": "10.10.7.0",
         "version": "7.3.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.3.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -545,7 +849,7 @@
         "timestamp": "2025-09-14T04:52:00"
       },
       {
-        "changelog": "- Add TMDB reviews feature to item details page\n - Update README.md",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add TMDB reviews feature to item details page\n - Update README.md",
         "targetAbi": "10.10.7.0",
         "version": "7.2.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.2.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -553,7 +857,7 @@
         "timestamp": "2025-09-09T04:47:11"
       },
       {
-        "changelog": "- Add option to show streaming providers on Jellyseerr posters\n - Use ApiClient.getUrl to support setups with base url\n - Remove custom z-index styles from pause screen which is causing issues with ASS subtitles",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add option to show streaming providers on Jellyseerr posters\n - Use ApiClient.getUrl to support setups with base url\n - Remove custom z-index styles from pause screen which is causing issues with ASS subtitles",
         "targetAbi": "10.10.7.0",
         "version": "7.1.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.1.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -561,7 +865,7 @@
         "timestamp": "2025-09-06T12:48:20"
       },
       {
-        "changelog": "- Add advanced Jellyseerr request options and refactor JS #34\n - Spanish translation (#41)\n - Adjust Italian localization text in it.json (#40)\n - Add action to validate json on PRs\n - Make readme better to read.",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add advanced Jellyseerr request options and refactor JS #34\n - Spanish translation (#41)\n - Adjust Italian localization text in it.json (#40)\n - Add action to validate json on PRs\n - Make readme better to read.",
         "targetAbi": "10.10.7.0",
         "version": "7.0.0.1",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/7.0.0.1/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -569,7 +873,7 @@
         "timestamp": "2025-09-05T11:00:32"
       },
       {
-        "changelog": "- Internationalization & Translations - Jellyfin Enhanced is now available in multiple* languages!\n - Improve quality tag detection and sorting logic",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Internationalization & Translations - Jellyfin Enhanced is now available in multiple* languages!\n - Improve quality tag detection and sorting logic",
         "targetAbi": "10.10.7.0",
         "version": "6.6.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/6.6.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -577,7 +881,7 @@
         "timestamp": "2025-09-03T16:30:12"
       },
       {
-        "changelog": "- Add *arr links integration to plugin\n - Adjust 4K threshold and fix title resolution detection",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add *arr links integration to plugin\n - Adjust 4K threshold and fix title resolution detection",
         "targetAbi": "10.10.7.0",
         "version": "6.5.1.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/6.5.1.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -585,7 +889,7 @@
         "timestamp": "2025-09-02T12:29:23"
       },
       {
-        "changelog": "- Support to request individual seasons\n - Improve resolution detection\n - Change clear all bookmarks shortcut",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Support to request individual seasons\n - Improve resolution detection\n - Change clear all bookmarks shortcut",
         "targetAbi": "10.10.7.0",
         "version": "6.5.0.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/6.5.0.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -593,7 +897,7 @@
         "timestamp": "2025-09-01T16:20:24"
       },
       {
-        "changelog": "- Improve Quality Tags logic and styling\n - Minor improvements and bug fixes",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Improve Quality Tags logic and styling\n - Minor improvements and bug fixes",
         "targetAbi": "10.10.7.0",
         "version": "6.4.1.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/6.4.1.0/Jellyfin.Plugin.JellyfinEnhanced.zip",
@@ -602,7 +906,7 @@
       },
       {
         "checksum": "B129839EF0C48064EB03C296D0EAC81C",
-        "changelog": "- New Features: Add Custom Pause Screen and Quality Tags on posters.\n- Behind the scenes: Implement a dedicated log file for easier troubleshooting and improve URL handling.",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- New Features: Add Custom Pause Screen and Quality Tags on posters.\n- Behind the scenes: Implement a dedicated log file for easier troubleshooting and improve URL handling.",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/6.4.0.0/Jellyfin.Plugin.JellyfinEnhanced_6.4.0.0.zip",
         "timestamp": "2025-08-29T20:29:29",
@@ -610,7 +914,7 @@
       },
       {
         "checksum": "2D217DF3C4583541369EE9A38F2FAE46",
-        "changelog": "- Double click/tap on the Jellyseerr Icon to toggle filter to display only Jellyseerr results.\n - Minor: Add more Logging for both client and server. ",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Double click/tap on the Jellyseerr Icon to toggle filter to display only Jellyseerr results.\n - Minor: Add more Logging for both client and server.",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/6.3.0.0/Jellyfin.Plugin.JellyfinEnhanced_6.3.0.0.zip",
         "timestamp": "2025-08-28T17:19:12",
@@ -618,7 +922,7 @@
       },
       {
         "checksum": "8C35A30B6DA0AE024B6FDC9632B628DD",
-        "changelog": "- Improve Jellyseer Results injection logic, fixes a bug where container is injected even before search results from Jellyfin are available.\n - Fixes a bug where TMDB links open in app making it impossible to navigate elsewhere\n - Fixes Jellyseerr section not rendering properly on some themes\n - Change the color of Jellyseerr Request button. ",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Improve Jellyseer Results injection logic, fixes a bug where container is injected even before search results from Jellyfin are available.\n - Fixes a bug where TMDB links open in app making it impossible to navigate elsewhere\n - Fixes Jellyseerr section not rendering properly on some themes\n - Change the color of Jellyseerr Request button.",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/6.2.0.0/Jellyfin.Plugin.JellyfinEnhanced_6.2.0.0.zip",
         "timestamp": "2025-08-27T16:13:12",
@@ -626,7 +930,7 @@
       },
       {
         "checksum": "4FBDAFDB94145D3E077E7C1E6963A481",
-        "changelog": "- Improve Jellyseer Results injection logic, fixes a bug where container is injected even before search results from Jellyfin are available.\n - Fixes a bug where TMDB links open in app making it impossible to navigate elsewhere\n - Fixes Jellyseerr section not rendering properly on some themes\n - Change the color of Jellyseerr Request button. ",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Improve Jellyseer Results injection logic, fixes a bug where container is injected even before search results from Jellyfin are available.\n - Fixes a bug where TMDB links open in app making it impossible to navigate elsewhere\n - Fixes Jellyseerr section not rendering properly on some themes\n - Change the color of Jellyseerr Request button.",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/6.1.1.0/Jellyfin.Plugin.JellyfinEnhanced_6.1.1.0.zip",
         "timestamp": "2025-08-27T05:31:11",
@@ -634,7 +938,7 @@
       },
       {
         "checksum": "A8DB0B7C56E6849F3E5FFFF8345CD1CB",
-        "changelog": "- *One-Time Setup*: Admins configure the connection once with an API key. No more per-user or per-device logins.\n - *Zero User Configuration*: The integration works automatically for all users across all devices without requiring them to enter any credentials.\n - The API key is managed securely on the server, making the connection more robust and reliable.",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- *One-Time Setup*: Admins configure the connection once with an API key. No more per-user or per-device logins.\n - *Zero User Configuration*: The integration works automatically for all users across all devices without requiring them to enter any credentials.\n - The API key is managed securely on the server, making the connection more robust and reliable.",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/6.1.0.0/Jellyfin.Plugin.JellyfinEnhanced_6.1.0.0.zip",
         "timestamp": "2025-08-26T13:01:38",
@@ -642,7 +946,7 @@
       },
       {
         "checksum": "CB91D071F57958E81239277EC87708D5",
-        "changelog": "- Jellyseerr results and requests through Jellyfin Search!\n - Users can now directly login to Jellyseerr from Jellyfin and search and request items\n - Complete refactor for easy future maintainence",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Jellyseerr results and requests through Jellyfin Search!\n - Users can now directly login to Jellyseerr from Jellyfin and search and request items\n - Complete refactor for easy future maintainence",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/6.0.0.0/Jellyfin.Plugin.JellyfinEnhanced_6.0.0.0.zip",
         "timestamp": "2025-08-25T13:37:52",
@@ -650,7 +954,7 @@
       },
       {
         "checksum": "21D8702ECDF8259627E332AB561FFCB8",
-        "changelog": "- User customizable shortcuts!\n - Users can now customize shortcuts directly from the enhanced panel\n - New Setting: Auto Picture-in-Picture (PiP)",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- User customizable shortcuts!\n - Users can now customize shortcuts directly from the enhanced panel\n - New Setting: Auto Picture-in-Picture (PiP)",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/5.4.0.0/Jellyfin.Plugin.JellyfinEnhanced_5.4.0.0.zip",
         "timestamp": "2025-08-24T18:09:33",
@@ -658,7 +962,7 @@
       },
       {
         "checksum": "E0A055673B6ECE00D413B40900DF6266",
-        "changelog": "- New UI Setting: Add available languages with flags in Item Details page\n - Add a new 'Gigantic' Subtitle style and change subtitle units to for better scaling\n - New Schortcut for opening jellyfin enhanced panel, long press user icon in the header (useful for touch devices)\n - Minor: Increase toast blur for better readability\n - Minor: Add debounce for elsewhere panel autocomplete.",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- New UI Setting: Add available languages with flags in Item Details page\n - Add a new 'Gigantic' Subtitle style and change subtitle units to for better scaling\n - New Schortcut for opening jellyfin enhanced panel, long press user icon in the header (useful for touch devices)\n - Minor: Increase toast blur for better readability\n - Minor: Add debounce for elsewhere panel autocomplete.",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/5.3.1.0/Jellyfin.Plugin.JellyfinEnhanced_5.3.1.0.zip",
         "timestamp": "2025-08-23T04:36:40",
@@ -666,7 +970,7 @@
       },
       {
         "checksum": "CD71009DFC17EEDA28EF566C1178594E",
-        "changelog": "- Customizable Shortcuts: The server admin can now set overrides for the existing shortcuts, allowing for personalized key bindings.\n - Improve Elsewhere API failure messages",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Customizable Shortcuts: The server admin can now set overrides for the existing shortcuts, allowing for personalized key bindings.\n - Improve Elsewhere API failure messages",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/5.3.0.0/Jellyfin.Plugin.JellyfinEnhanced_5.3.0.0.zip",
         "timestamp": "2025-08-21T06:12:00",
@@ -674,7 +978,7 @@
       },
       {
         "checksum": "DF7E6772672424F4452EC69AE8EBACD9",
-        "changelog": "- Move all the default settings configuration to the config page to give control to the server owner to enable options by default\n - Tabbed interface in config page separating Enhanced settings and Elsewhere settings\n - Minor: Move the startup task to 'Startup Services' instead of creating a separate category\n - Minor: Mobile UI improvements",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Move all the default settings configuration to the config page to give control to the server owner to enable options by default\n - Tabbed interface in config page separating Enhanced settings and Elsewhere settings\n - Minor: Move the startup task to 'Startup Services' instead of creating a separate category\n - Minor: Mobile UI improvements",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/5.2.0.0/Jellyfin.Plugin.JellyfinEnhanced_5.2.0.0.zip",
         "timestamp": "2025-08-20T06:12:00",
@@ -682,7 +986,7 @@
       },
       {
         "checksum": "DEB52B57618432D7380B22F184499773",
-        "changelog": "Use [file-transformation-plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) to 'inject' javascript without modifying index.html\n -This is to help with all the permission issues for docker installs.\n - Fallback if file-transformation-plugin is not installed to the regulat index.html modification\n - Add an option to reset Jellyfin Enhanced settings to default for all users",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\nUse [file-transformation-plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) to 'inject' javascript without modifying index.html\n -This is to help with all the permission issues for docker installs.\n - Fallback if file-transformation-plugin is not installed to the regulat index.html modification\n - Add an option to reset Jellyfin Enhanced settings to default for all users",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/5.1.0.0/Jellyfin.Plugin.JellyfinEnhanced_5.1.0.0.zip",
         "timestamp": "2025-08-18T16:34:21",
@@ -690,11 +994,321 @@
       },
       {
         "checksum": "88E4B205DE902CDD3062D648BFB7EC7D",
-        "changelog": "Initial release. \n - Combine Jellyfin Enhanced and Jellyfin Elsewhere \n - Add Remove from Continue Watching \n - Add a button to open the panel in sidebar",
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\nInitial release. \n - Combine Jellyfin Enhanced and Jellyfin Elsewhere \n - Add Remove from Continue Watching \n - Add a button to open the panel in sidebar",
         "targetAbi": "10.10.7.0",
         "sourceUrl": "https://github.com/n00bcodr/Jellyfin-Enhanced/releases/download/5.0.0.0/Jellyfin.Plugin.JellyfinEnhanced_5.0.0.0.zip",
         "timestamp": "2025-08-16T12:48:38",
         "version": "5.0.0.0"
+      }
+    ]
+  },
+  {
+    "name": "JavaScript Injector",
+    "guid": "f5a34f7b-2e8a-4e6a-a722-3a216a81b374",
+    "overview": "Inject custom javascript(s) to the Jellyfin Web UI",
+    "description": "Inject custom javascript(s) to the Jellyfin Web UI",
+    "owner": "n00bcodr",
+    "category": "General",
+    "imageUrl": "https://raw.githubusercontent.com/n00bcodr/jellyfin-javascript-injector/main/icon.png",
+    "versions": [
+      {
+        "changelog": "**Build for Jellyfin 12.**\n\n- Add Jellyfin 12 support via IStartupFilter, drop 10.10.7\n - Add CodeMirror code editor with JSHint linting to config page",
+        "targetAbi": "12.0.0.0",
+        "version": "4.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/4.0.0.0/Jellyfin.Plugin.JavaScriptInjector_12.0.0.zip",
+        "checksum": "E9B247E1CBD473B02CC71BD6E3DAE369",
+        "timestamp": "2026-08-12T15:53:52"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11.** On Jellyfin 12 the catalog installs the Jellyfin 12 build of this version automatically.\n\n- Add Jellyfin 12 support via IStartupFilter, drop 10.10.7\n - Add CodeMirror code editor with JSHint linting to config page",
+        "targetAbi": "10.11.0.0",
+        "version": "4.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/4.0.0.0/Jellyfin.Plugin.JavaScriptInjector_10.11.0.zip",
+        "checksum": "D00392134B71DC10FC625C6A19D839F8",
+        "timestamp": "2026-08-12T15:53:47"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Add search, drag-reorder, import/export, and unsaved-changes guard to config page",
+        "targetAbi": "10.11.0.0",
+        "version": "3.5.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.5.0.0/Jellyfin.Plugin.JavaScriptInjector_10.11.0.zip",
+        "checksum": "AF0D6C50F02595974F5FA509974133C8",
+        "timestamp": "2026-07-19T18:31:45"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Add search, drag-reorder, import/export, and unsaved-changes guard to config page",
+        "targetAbi": "10.10.7.0",
+        "version": "3.5.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.5.0.0/Jellyfin.Plugin.JavaScriptInjector_10.10.7.zip",
+        "checksum": "8178F4C5FCE8F3940ED08B0AE6E48393",
+        "timestamp": "2026-07-19T18:31:55"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Update README with new badge links and images\n - Update funding.yml\n - Create LICENSE\n - Implement XML sanitization for script entries and enhance configuration UI\n - Update configPage.html",
+        "targetAbi": "10.11.0.0",
+        "version": "3.4.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.4.0.0/Jellyfin.Plugin.JavaScriptInjector_10.11.0.zip",
+        "checksum": "88A06677733EACCAD9D8CE3C94D972D5",
+        "timestamp": "2026-03-28T13:40:37"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Update README with new badge links and images\n - Update funding.yml\n - Create LICENSE\n - Implement XML sanitization for script entries and enhance configuration UI\n - Update configPage.html",
+        "targetAbi": "10.10.7.0",
+        "version": "3.4.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.4.0.0/Jellyfin.Plugin.JavaScriptInjector_10.10.7.zip",
+        "checksum": "A731E2CF0293951E590B06A19912E9C5",
+        "timestamp": "2026-03-28T13:40:44"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Update README.md\n - Add quick enable/disable and remove buttons for scripts",
+        "targetAbi": "10.11.0.0",
+        "version": "3.3.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.3.0.0/Jellyfin.Plugin.JavaScriptInjector_10.11.0.zip",
+        "checksum": "38D83C75282B4E5A51D622E3FF58E4CE",
+        "timestamp": "2026-01-18T18:25:22"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Update README.md\n - Add quick enable/disable and remove buttons for scripts",
+        "targetAbi": "10.10.7.0",
+        "version": "3.3.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.3.0.0/Jellyfin.Plugin.JavaScriptInjector_10.10.7.zip",
+        "checksum": "3E185D54B884DED90DDDA901DB7571C3",
+        "timestamp": "2026-01-18T18:25:28"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Implement timestamp cache-busting",
+        "targetAbi": "10.11.0.0",
+        "version": "3.2.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.2.0.0/Jellyfin.Plugin.JavaScriptInjector_10.11.0.zip",
+        "checksum": "6E81F8C8F4E48F7A9E3335A3F81D91FA",
+        "timestamp": "2025-12-07T10:05:50"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Implement timestamp cache-busting",
+        "targetAbi": "10.10.7.0",
+        "version": "3.2.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.2.0.0/Jellyfin.Plugin.JavaScriptInjector_10.10.7.zip",
+        "checksum": "E981E78A61AAA5BE266167A273A29446",
+        "timestamp": "2025-12-07T10:05:55"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Revise repository URL instructions in README\n - refactor: create javascript helper\n - feat: add plugin interface\n - chore: remove unused imports\n - fix: dont validate payload in plugin interface\n - docs: fix example formatting",
+        "targetAbi": "10.11.0.0",
+        "version": "3.1.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.1.0.0/Jellyfin.Plugin.JavaScriptInjector_10.11.0.zip",
+        "checksum": "EA07AEB608FB3CC7FC76302B45ACE4D2",
+        "timestamp": "2025-11-19T19:19:09"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Revise repository URL instructions in README\n - refactor: create javascript helper\n - feat: add plugin interface\n - chore: remove unused imports\n - fix: dont validate payload in plugin interface\n - docs: fix example formatting",
+        "targetAbi": "10.10.7.0",
+        "version": "3.1.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.1.0.0/Jellyfin.Plugin.JavaScriptInjector_10.10.7.zip",
+        "checksum": "CA3DF0B83C5150146A6E1477E62757D0",
+        "timestamp": "2025-11-19T19:19:13"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Fix script path for installations with base url",
+        "targetAbi": "10.11.0.0",
+        "version": "3.0.1.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.0.1.0/Jellyfin.Plugin.JavaScriptInjector_10.11.0.zip",
+        "checksum": "C4EB15CDD6BB7A39F87BD096A69C76C0",
+        "timestamp": "2025-10-22T05:38:25"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Fix script path for installations with base url\n - Please remove this manifest and add the manifest for 10.11 if you are on 10.11. \n https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json",
+        "targetAbi": "10.10.7.0",
+        "version": "3.0.1.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.0.1.0/Jellyfin.Plugin.JavaScriptInjector_10.10.7.zip",
+        "checksum": "A7240CC2FAA7E4F76F67A4C5B7AD161C",
+        "timestamp": "2025-10-22T05:38:30"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Support for 10.11",
+        "targetAbi": "10.11.0.0",
+        "version": "3.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/Jellyfin-JavaScript-Injector/releases/download/3.0.0.0/Jellyfin.Plugin.JavaScriptInjector_10.11.0.zip",
+        "checksum": "1448F94FD472D789E0A2E711F6F929E2",
+        "timestamp": "2025-10-20T17:27:02"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- 10.11 Support!\n - Please add the manifest for 10.11 if you are on 10.11. https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json",
+        "targetAbi": "10.10.7.0",
+        "version": "3.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/jellyfin-javascript-injector/releases/download/3.0.0.0/Jellyfin.Plugin.JavaScriptInjector_10.10.7.zip",
+        "checksum": "EFFE2518CF1AC58C69A24A2934EDD9ED",
+        "timestamp": "2025-10-20T17:27:00"
+      },
+      {
+        "version": "2.0.0.0",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\n- Use [file-transformation-plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) to 'inject' javascript without modifying index.html\n - This is to help with all the permission issues for docker installs.\n - Fallback if file-transformation-plugin is not installed to the regular index.html modification",
+        "targetAbi": "10.9.9.0",
+        "sourceUrl": "https://github.com/n00bcodr/jellyfin-javascript-injector/releases/download/2.0.0.0/javascript-injector-2.0.0.0.zip",
+        "checksum": "89c5e8c0d140e8fcb8826202b1b91de8",
+        "timestamp": "2025-08-19T13:27:21Z"
+      },
+      {
+        "version": "1.1.1.1",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\n- Wrap the injected script block with clear HTML comments for safer and more reliable identification. \n- Update removal logic to use specific regex patterns for injection formats, ensuring idempotent upgrades and preventing accidental removal of unrelated scripts.",
+        "targetAbi": "10.9.9.0",
+        "sourceUrl": "https://github.com/n00bcodr/jellyfin-javascript-injector/releases/download/1.1.1.1/javascript-injector-1.1.1.1.zip",
+        "checksum": "db8d7806b3e112ddaf40caa55fdb0f1d",
+        "timestamp": "2025-08-14T06:30:31Z"
+      },
+      {
+        "version": "1.1.1.0",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\n- Wrap the injected script block with clear HTML comments for safer and more reliable identification. \n- Update removal logic to use specific regex patterns for injection formats, ensuring idempotent upgrades and preventing accidental removal of unrelated scripts.",
+        "targetAbi": "10.9.9.0",
+        "sourceUrl": "https://github.com/n00bcodr/jellyfin-javascript-injector/releases/download/1.1.1.0/javascript-injector-1.1.1.0.zip",
+        "checksum": "39620ac480c10a6a68a7a6fdf2c93990",
+        "timestamp": "2025-08-12T04:44:41Z"
+      },
+      {
+        "version": "1.1.0.0",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\n- Script Visibility \n - Add an option to only load a script for an authenticated session.",
+        "targetAbi": "10.9.9.0",
+        "sourceUrl": "https://github.com/n00bcodr/jellyfin-javascript-injector/releases/download/1.1.0.0/javascript-injector-1.1.0.0.zip",
+        "checksum": "21817433c4aeb9d56774ff376d136240",
+        "timestamp": "2025-08-10T05:22:03Z"
+      },
+      {
+        "version": "1.0.0.0",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\nSupport multiple scripts and dynamic injection",
+        "targetAbi": "10.9.9.0",
+        "sourceUrl": "https://github.com/n00bcodr/jellyfin-javascript-injector/releases/download/1.0.0.0/javascript-injector-1.0.0.0.zip",
+        "checksum": "eb340151e6d2c29690ced20740fba52e",
+        "timestamp": "2025-07-30T13:17:02Z"
+      }
+    ]
+  },
+  {
+    "name": "Jellyfin Tweaks",
+    "guid": "dfee3828-01df-49df-85b1-5c2b75e5ea1a",
+    "overview": "Tweaks for Jellyfin",
+    "description": "Adds useful tweaks to Jellyfin. Based on the original JellyTweaks by gam24.",
+    "owner": "n00bcodr",
+    "category": "General",
+    "imageUrl": "https://raw.githubusercontent.com/n00bcodr/JellyfinTweaks/master/Jellyfin.Plugin.JellyTweaks/images/thumb.png",
+    "versions": [
+      {
+        "changelog": "**Build for Jellyfin 12.**\n\n- Update README with new badges and links\n - Update README.md\n - Update funding.yml\n - Add GNU General Public License v3\n - Jellyfin v12 Support and drop support for Jellyfin 10.10",
+        "targetAbi": "12.0.0.0",
+        "version": "4.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/4.0.0.0/Jellyfin.Plugin.JellyTweaks_12.0.0.zip",
+        "checksum": "2DD2A68862FB15775021683517A01AD5",
+        "timestamp": "2026-08-12T15:43:25"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11.** On Jellyfin 12 the catalog installs the Jellyfin 12 build of this version automatically.\n\n- Update README with new badges and links\n - Update README.md\n - Update funding.yml\n - Add GNU General Public License v3\n - Jellyfin v12 Support and drop support for Jellyfin 10.10",
+        "targetAbi": "10.11.0.0",
+        "version": "4.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/4.0.0.0/Jellyfin.Plugin.JellyTweaks_10.11.0.zip",
+        "checksum": "C5B74F0A4DA9CDA6BD991E78C8580445",
+        "timestamp": "2026-08-12T15:43:13"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Revise installation instructions for Jellyfin plugins\n - Add display and video settings to plugin configuration\n - v3.1.0.0",
+        "targetAbi": "10.11.0.0",
+        "version": "3.1.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/3.1.0.0/Jellyfin.Plugin.JellyTweaks_10.11.0.zip",
+        "checksum": "0BC862688C9045D7C2793CBDA0AA8446",
+        "timestamp": "2026-01-18T19:36:36"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Revise installation instructions for Jellyfin plugins\n - Add display and video settings to plugin configuration\n - v3.1.0.0",
+        "targetAbi": "10.10.7.0",
+        "version": "3.1.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/3.1.0.0/Jellyfin.Plugin.JellyTweaks_10.10.7.zip",
+        "checksum": "2D8B001088037388D169E7297682963C",
+        "timestamp": "2026-01-18T19:36:40"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Fix script path for installations with base url",
+        "targetAbi": "10.11.0.0",
+        "version": "3.0.1.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/3.0.1.0/Jellyfin.Plugin.JellyTweaks_10.11.0.zip",
+        "checksum": "039697408A4EDECD2159FE983DDEF2F6",
+        "timestamp": "2025-10-22T05:53:24"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- Fix script path for installations with base url\n - Please remove this manifest and add the manifest for 10.11 if you are on 10.11. \n https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json",
+        "targetAbi": "10.10.7.0",
+        "version": "3.0.1.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/3.0.1.0/Jellyfin.Plugin.JellyTweaks_10.10.7.zip",
+        "checksum": "E3C411A5934E4573AB1AFFB2B26E0B81",
+        "timestamp": "2025-10-22T05:53:30"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.11 only. Not for Jellyfin 12.**\n\n- Support for 10.11",
+        "targetAbi": "10.11.0.0",
+        "version": "3.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/3.0.0.0/Jellyfin.Plugin.JellyTweaks_10.11.0.zip",
+        "checksum": "73313429BE665341BDB2539BA69A557D",
+        "timestamp": "2025-10-20T17:25:23"
+      },
+      {
+        "changelog": "**Build for Jellyfin 10.10 only. Not for Jellyfin 12.**\n\n- 10.11 Support!\n - Please add the manifest for 10.11 if you are on 10.11. https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/10.11/manifest.json",
+        "targetAbi": "10.10.7.0",
+        "version": "3.0.0.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/3.0.0.0/Jellyfin.Plugin.JellyTweaks_10.10.7.zip",
+        "checksum": "BA7B484572CD3CDC4099E32B6181F934",
+        "timestamp": "2025-10-20T17:25:19"
+      },
+      {
+        "checksum": "9d28727ede403514764b915386fb843c",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\n- Add public config endpoint and update JS to use it, was preventing some users to access the plugin configuration",
+        "targetAbi": "10.9.4.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/2.1.2.0/Jellyfin.Plugin.JellyTweaks.zip",
+        "timestamp": "2025-08-27T16:06:09Z",
+        "version": "2.1.2.0"
+      },
+      {
+        "checksum": "6ae17ddf411fc562b690d12c97389987",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\n- Use [file-transformation-plugin](https://github.com/IAmParadox27/jellyfin-plugin-file-transformation) to 'inject' javascript without modifying index.html\n - This is to help with all the permission issues for docker installs.\n - Fallback if file-transformation-plugin is not installed to the regular index.html modification",
+        "targetAbi": "10.9.4.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/2.1.0.0/Jellyfin.Plugin.JellyTweaks.zip",
+        "timestamp": "2025-08-19T07:02:58Z",
+        "version": "2.1.0.0"
+      },
+      {
+        "checksum": "29622399261e493ce33e2a24296ef76e",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\n- Complete refactor to use localStorage, no longer modifies core files.\n- Added options for Theme Videos, Rewatching, and Episode Images in Next Up.",
+        "targetAbi": "10.9.4.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/2.0.0.0/JellyFin.Tweaks.Plugin.zip",
+        "timestamp": "2025-05-13T16:00:30Z",
+        "version": "2.0.0.0"
+      },
+      {
+        "checksum": "8230646cb5c0dec3e92824999ea283eb",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\n-Fix logic for Force theme music and backdrops",
+        "targetAbi": "10.9.4.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/1.1.3.1/JellyFin.Tweaks.Plugin.zip",
+        "timestamp": "2025-05-13T16:00:30Z",
+        "version": "1.1.3.1"
+      },
+      {
+        "checksum": "992b5104c0334a19e2f9601540580b9a",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\n-Fix logic for Force theme music and backdrops",
+        "targetAbi": "10.9.4.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/1.1.3.0/JellyFin.Tweaks.Plugin.zip",
+        "timestamp": "2025-05-13T15:23:30Z",
+        "version": "1.1.3.0"
+      },
+      {
+        "checksum": "f7515430b1b7f455c0f40aaec1f34e27",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\n-Fix logic for Force theme music",
+        "targetAbi": "10.9.4.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/1.1.2/JellyFin.Tweaks.Plugin.zip",
+        "timestamp": "2025-04-23T03:48:01Z",
+        "version": "1.1.2"
+      },
+      {
+        "checksum": "7ae1d358517b008fc32b8dccb8dc13ac",
+        "changelog": "**Build for Jellyfin 10.9 only. Not for Jellyfin 12.**\n\n- Added Max Days Next Up\n- Added Force Disable Next Video Info\n- Added Force Theme Music\n- Based on gam24's version 1.0.0.4",
+        "targetAbi": "10.9.4.0",
+        "sourceUrl": "https://github.com/n00bcodr/JellyfinTweaks/releases/download/1.1.1/JellyFin.Tweaks.Plugin.zip",
+        "timestamp": "2025-04-22T17:30:21Z",
+        "version": "1.1.1"
       }
     ]
   }


### PR DESCRIPTION
Replace the version-specific installation instructions with one canonical manifest URL and serve the unified catalog at the existing Enhanced `manifest.json` URL. Existing users keep their configured repository; new users use `https://raw.githubusercontent.com/n00bcodr/jellyfin-plugins/main/manifest.json`.

The catalog retains one row per version/ABI, with jf12 before jf10 for each paired release. The 10.10 history is retained, its compatibility-table entry is corrected to the frozen `10.11.1.0` release, and the known stale checksum is corrected.

The new **`validate-legacy-manifest`** workflow validates this served legacy file using the same validator as [jellyfin-plugins #2](https://github.com/n00bcodr/jellyfin-plugins/pull/2), pinned to immutable commit `14154a1840341c61ec62fb0b971d7299fb959c9d`. It checks ordering, mandatory build pairs and newest ZIP checksums on PRs, merge queues, pushes and manual runs. It runs on every PR without path filters. No test files or duplicate validator implementation are added here.

### Validation

The legacy manifest passes the shared validator and checksum verification and is byte-identical to the companion PR's root manifest. The pinned validator commit is fetchable from the upstream repository through PR #2. The unified catalog has also been exercised through actual Jellyfin 12 and 10.11 installations; selecting either member of a pair resolves to the host's matching build.

### Merge and release order

Merge with jellyfin-plugins #2 and check all five live URLs after caches refresh. Ship [#799](https://github.com/n00bcodr/Jellyfin-Enhanced/pull/799) after the canonical URL is live. Historical releases without a jf12 build remain available; the manifest does not impose an upper ABI bound.

---
AI-assisted implementation and testing.
