### PR TITLE
fix(custom tabs): defer tab-hosted content until its tab is active

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-custom-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-custom-tab.js
@@ -86,14 +86,21 @@
     var all = document.querySelectorAll('.jellyfinenhanced.calendar');
     for (var i = all.length - 1; i >= 0; i--) {
       var el = all[i];
-      // 1. Standard Jellyfin page structure
+      // 1. Tab-hosted content: the tab's own active state is authoritative.
+      //    Checked BEFORE .page because Custom Tabs injects its panels into
+      //    #indexPage, which is NOT .hide while the home page is showing. A
+      //    .page-first check therefore matches every tab on load and mounts
+      //    content for tabs the user never opened.
+      var tabContent = el.closest('.tabContent');
+      if (tabContent) {
+        if (tabContent.classList.contains('is-active')) return el;
+        continue;
+      }
+      // 2. Standard Jellyfin page structure
       var page = el.closest('.page');
       if (page && !page.classList.contains('hide')) return el;
-      // 2. Custom Tabs wraps content in .tabContent.is-active (no .page ancestor)
-      var tabContent = el.closest('.tabContent');
-      if (tabContent && tabContent.classList.contains('is-active')) return el;
       // 3. Last resort: element is simply visible in the document
-      if (!page && !tabContent && el.offsetParent !== null) return el;
+      if (!page && el.offsetParent !== null) return el;
     }
     return null;
   }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-custom-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-custom-tab.js
@@ -93,7 +93,12 @@
       //    content for tabs the user never opened.
       var tabContent = el.closest('.tabContent');
       if (tabContent) {
-        if (tabContent.classList.contains('is-active')) return el;
+        // `is-active` is the fast path but is not authoritative on its own:
+        // not every host sets it, and it can be applied without a DOM
+        // mutation for the observers below to notice. An actual visibility
+        // check backs it up so the panel still mounts if the class is absent
+        // or lands late — a missing mount is far worse than a late one.
+        if (tabContent.classList.contains('is-active') || el.offsetParent !== null) return el;
         continue;
       }
       // 2. Standard Jellyfin page structure
@@ -162,15 +167,50 @@
     // bound to the old element would become orphaned after returning to home
     // (issue 536). Routes to the shared multiplexed body observer.
     var mountPending = false;
-    JE.helpers.createObserver('arr-calendar-custom-tab', function () {
-      if (!mountPending) {
-        mountPending = true;
-        requestAnimationFrame(function () {
-          mountPending = false;
-          tryMount();
-        });
-      }
-    }, document.body, { childList: true, subtree: true });
+    function scheduleMount() {
+      if (mountPending) return;
+      mountPending = true;
+      requestAnimationFrame(function () {
+        mountPending = false;
+        ensureTabActivationObserver();
+        tryMount();
+      });
+    }
+
+    JE.helpers.createObserver('arr-calendar-custom-tab', scheduleMount, document.body,
+      { childList: true, subtree: true });
+
+    // A tab becoming active is a class change, and the shared body observer
+    // only dispatches for batches containing added/removed nodes — so an
+    // activation on its own can go unseen and the panel would never mount.
+    // Watch the panels' shared parent for class changes as well, scoped to
+    // that subtree so this stays cheap.
+    var observedTabsParent = null;
+    function ensureTabActivationObserver() {
+      var anyPanel = document.querySelector('.tabContent');
+      var parent = anyPanel && anyPanel.parentElement;
+      if (!parent || parent === observedTabsParent) return;
+      observedTabsParent = parent;
+      JE.helpers.createObserver('arr-calendar-custom-tab-tab-activation', scheduleMount, parent,
+        { attributes: true, attributeFilter: ['class'], subtree: true });
+    }
+    ensureTabActivationObserver();
+
+    // The page module clears per-user state on a user switch, but that relies
+    // on a re-render to refresh what is on screen. Content in a tab that is
+    // not currently open will not get one, so drop the rendered DOM here too —
+    // otherwise the previous user's content stays in the tab until it is
+    // opened. Mirrors the reset in enhanced/bookmarks/bookmarks-library-render.js.
+    function resetForUserChange() {
+      var all = document.querySelectorAll('.jellyfinenhanced.calendar');
+      for (var i = 0; i < all.length; i++) all[i].textContent = '';
+      lastMountedContainer = null;
+    }
+    JE.session?.onUserChange('arr-calendar-custom-tab', resetForUserChange);
+    document.addEventListener('je:user-data-loaded', function () {
+      resetForUserChange();
+      tryMount();
+    });
   }
 
   waitForCalendar(function (JE) {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-render-views.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-render-views.js
@@ -453,7 +453,7 @@
         </div>
       </div>
 
-      ${state.isLoading ? `<div class="je-calendar-empty">${window.JellyfinEnhanced.t("calendar_loading")}</div>` : ""}
+      ${state.isLoading ? `<div class="je-calendar-loading" role="status" aria-live="polite"><span class="je-calendar-loading-spinner" aria-hidden="true"></span><span>${window.JellyfinEnhanced.t("calendar_loading")}</span></div>` : ""}
 
         <div class="je-calendar-layout">
           <div class="je-calendar-main">

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-styles.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/calendar/calendar-page-styles.js
@@ -771,6 +771,32 @@
       opacity: 0.7;
     }
 
+    /* Loading is a transient state, not an empty one: motion plus a live
+       region so it is distinguishable both visually and to screen readers. */
+    .je-calendar-loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75em;
+      padding: 2em;
+      opacity: 0.85;
+    }
+    .je-calendar-loading-spinner {
+      width: 1.15em;
+      height: 1.15em;
+      border: 2px solid currentColor;
+      border-right-color: transparent;
+      border-radius: 50%;
+      flex-shrink: 0;
+      animation: je-calendar-spin 0.8s linear infinite;
+    }
+    @keyframes je-calendar-spin { to { transform: rotate(360deg); } }
+    /* Slowed rather than disabled: removing it entirely would leave no
+       progress cue at all for the users who opt into reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      .je-calendar-loading-spinner { animation-duration: 2.4s; }
+    }
+
     .je-calendar-agenda {
       display: flex;
       flex-direction: column;

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-custom-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-custom-tab.js
@@ -94,7 +94,12 @@
       //    content for tabs the user never opened.
       var tabContent = el.closest('.tabContent');
       if (tabContent) {
-        if (tabContent.classList.contains('is-active')) return el;
+        // `is-active` is the fast path but is not authoritative on its own:
+        // not every host sets it, and it can be applied without a DOM
+        // mutation for the observers below to notice. An actual visibility
+        // check backs it up so the panel still mounts if the class is absent
+        // or lands late — a missing mount is far worse than a late one.
+        if (tabContent.classList.contains('is-active') || el.offsetParent !== null) return el;
         continue;
       }
       // 2. Standard Jellyfin page structure
@@ -193,15 +198,50 @@
     // bound to the old element would become orphaned after returning to home
     // (issue 536). Routes to the shared multiplexed body observer.
     var mountPending = false;
-    JE.helpers.createObserver('arr-requests-custom-tab', function () {
-      if (!mountPending) {
-        mountPending = true;
-        requestAnimationFrame(function () {
-          mountPending = false;
-          tryMount();
-        });
-      }
-    }, document.body, { childList: true, subtree: true });
+    function scheduleMount() {
+      if (mountPending) return;
+      mountPending = true;
+      requestAnimationFrame(function () {
+        mountPending = false;
+        ensureTabActivationObserver();
+        tryMount();
+      });
+    }
+
+    JE.helpers.createObserver('arr-requests-custom-tab', scheduleMount, document.body,
+      { childList: true, subtree: true });
+
+    // A tab becoming active is a class change, and the shared body observer
+    // only dispatches for batches containing added/removed nodes — so an
+    // activation on its own can go unseen and the panel would never mount.
+    // Watch the panels' shared parent for class changes as well, scoped to
+    // that subtree so this stays cheap.
+    var observedTabsParent = null;
+    function ensureTabActivationObserver() {
+      var anyPanel = document.querySelector('.tabContent');
+      var parent = anyPanel && anyPanel.parentElement;
+      if (!parent || parent === observedTabsParent) return;
+      observedTabsParent = parent;
+      JE.helpers.createObserver('arr-requests-custom-tab-tab-activation', scheduleMount, parent,
+        { attributes: true, attributeFilter: ['class'], subtree: true });
+    }
+    ensureTabActivationObserver();
+
+    // The page module clears per-user state on a user switch, but that relies
+    // on a re-render to refresh what is on screen. Content in a tab that is
+    // not currently open will not get one, so drop the rendered DOM here too —
+    // otherwise the previous user's content stays in the tab until it is
+    // opened. Mirrors the reset in enhanced/bookmarks/bookmarks-library-render.js.
+    function resetForUserChange() {
+      var all = document.querySelectorAll('.jellyfinenhanced.requests');
+      for (var i = 0; i < all.length; i++) all[i].textContent = '';
+      lastMountedContainer = null;
+    }
+    JE.session?.onUserChange('arr-requests-custom-tab', resetForUserChange);
+    document.addEventListener('je:user-data-loaded', function () {
+      resetForUserChange();
+      tryMount();
+    });
   }
 
   waitForDownloads(function (JE) {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-custom-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/arr/requests/requests-custom-tab.js
@@ -87,14 +87,21 @@
     var all = document.querySelectorAll('.jellyfinenhanced.requests');
     for (var i = all.length - 1; i >= 0; i--) {
       var el = all[i];
-      // 1. Standard Jellyfin page structure
+      // 1. Tab-hosted content: the tab's own active state is authoritative.
+      //    Checked BEFORE .page because Custom Tabs injects its panels into
+      //    #indexPage, which is NOT .hide while the home page is showing. A
+      //    .page-first check therefore matches every tab on load and mounts
+      //    content for tabs the user never opened.
+      var tabContent = el.closest('.tabContent');
+      if (tabContent) {
+        if (tabContent.classList.contains('is-active')) return el;
+        continue;
+      }
+      // 2. Standard Jellyfin page structure
       var page = el.closest('.page');
       if (page && !page.classList.contains('hide')) return el;
-      // 2. Custom Tabs wraps content in .tabContent.is-active (no .page ancestor)
-      var tabContent = el.closest('.tabContent');
-      if (tabContent && tabContent.classList.contains('is-active')) return el;
       // 3. Last resort: element is simply visible in the document
-      if (!page && !tabContent && el.offsetParent !== null) return el;
+      if (!page && el.offsetParent !== null) return el;
     }
     return null;
   }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/bookmarks/bookmarks-library-init.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/bookmarks/bookmarks-library-init.js
@@ -110,15 +110,33 @@
         // element would become orphaned after returning to home (issue 536).
         // Routes to the shared multiplexed body observer.
         let mountPending = false;
-        JE.helpers.createObserver('bookmarks-library-custom-tab', () => {
-          if (!mountPending) {
-            mountPending = true;
-            requestAnimationFrame(() => {
-              mountPending = false;
-              renderIfSectionExists();
-            });
-          }
-        }, document.body, { childList: true, subtree: true });
+        const scheduleRender = () => {
+          if (mountPending) return;
+          mountPending = true;
+          requestAnimationFrame(() => {
+            mountPending = false;
+            ensureTabActivationObserver();
+            renderIfSectionExists();
+          });
+        };
+        JE.helpers.createObserver('bookmarks-library-custom-tab', scheduleRender,
+          document.body, { childList: true, subtree: true });
+
+        // A tab becoming active is a class change, and the shared body
+        // observer only dispatches for batches containing added/removed
+        // nodes — so an activation on its own can go unseen and the panel
+        // would never render. Watch the panels' shared parent for class
+        // changes as well, scoped to that subtree so this stays cheap.
+        let observedTabsParent = null;
+        function ensureTabActivationObserver() {
+          const anyPanel = document.querySelector('.tabContent');
+          const parent = anyPanel && anyPanel.parentElement;
+          if (!parent || parent === observedTabsParent) return;
+          observedTabsParent = parent;
+          JE.helpers.createObserver('bookmarks-library-tab-activation', scheduleRender,
+            parent, { attributes: true, attributeFilter: ['class'], subtree: true });
+        }
+        ensureTabActivationObserver();
 
         // Try immediate render in case tab is already visible
         renderIfSectionExists();

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/bookmarks/bookmarks-library-render.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/bookmarks/bookmarks-library-render.js
@@ -78,14 +78,21 @@
     const all = document.querySelectorAll('.sections.bookmarks');
     for (let i = all.length - 1; i >= 0; i--) {
       const el = all[i];
-      // 1. Standard Jellyfin page structure
+      // 1. Tab-hosted content: the tab's own active state is authoritative.
+      //    Checked BEFORE .page because Custom Tabs injects its panels into
+      //    #indexPage, which is NOT .hide while the home page is showing. A
+      //    .page-first check therefore matches every tab on load and mounts
+      //    content for tabs the user never opened.
+      const tabContent = el.closest('.tabContent');
+      if (tabContent) {
+        if (tabContent.classList.contains('is-active')) return el;
+        continue;
+      }
+      // 2. Standard Jellyfin page structure
       const page = el.closest('.page');
       if (page && !page.classList.contains('hide')) return el;
-      // 2. Custom Tabs wraps content in .tabContent.is-active (no .page ancestor)
-      const tabContent = el.closest('.tabContent');
-      if (tabContent && tabContent.classList.contains('is-active')) return el;
       // 3. Last resort: element is simply visible in the document
-      if (!page && !tabContent && el.offsetParent !== null) return el;
+      if (!page && el.offsetParent !== null) return el;
     }
     return null;
   }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/bookmarks/bookmarks-library-render.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/bookmarks/bookmarks-library-render.js
@@ -27,13 +27,19 @@
   // rendered bookmarks visible to user B (upstream discussion about stale
   // bookmarks after switching accounts). Drop the guard on the transition,
   // then force a fresh render once the new user's bookmarks are loaded.
-  window.JellyfinEnhanced.session?.onUserChange('bookmarks-library-render', () => {
+  // Dropping the guard is not sufficient on its own now that tab content only
+  // mounts once its tab is opened: a panel that is not currently open gets no
+  // re-render, so user A's markup would simply stay there. Clear the rendered
+  // DOM as well, then let the normal path re-render if the tab is open.
+  function clearRenderedBookmarks() {
+    const all = document.querySelectorAll('.sections.bookmarks');
+    for (let i = 0; i < all.length; i++) all[i].textContent = '';
     lastMountedContainer = null;
     lastRenderTs = 0;
-  });
+  }
+  window.JellyfinEnhanced.session?.onUserChange('bookmarks-library-render', clearRenderedBookmarks);
   document.addEventListener('je:user-data-loaded', () => {
-    lastMountedContainer = null;
-    lastRenderTs = 0;
+    clearRenderedBookmarks();
     renderIfSectionExists();
   });
 
@@ -85,7 +91,12 @@
       //    content for tabs the user never opened.
       const tabContent = el.closest('.tabContent');
       if (tabContent) {
-        if (tabContent.classList.contains('is-active')) return el;
+        // `is-active` is the fast path but is not authoritative on its own:
+        // not every host sets it, and it can be applied without a DOM
+        // mutation for the observers to notice. An actual visibility check
+        // backs it up so the panel still mounts if the class is absent or
+        // lands late — a missing mount is far worse than a late one.
+        if (tabContent.classList.contains('is-active') || el.offsetParent !== null) return el;
         continue;
       }
       // 2. Standard Jellyfin page structure

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-custom-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-custom-tab.js
@@ -78,14 +78,21 @@
     var all = document.querySelectorAll('.jellyfinenhanced.hidden-content');
     for (var i = all.length - 1; i >= 0; i--) {
       var el = all[i];
-      // 1. Standard Jellyfin page structure
+      // 1. Tab-hosted content: the tab's own active state is authoritative.
+      //    Checked BEFORE .page because Custom Tabs injects its panels into
+      //    #indexPage, which is NOT .hide while the home page is showing. A
+      //    .page-first check therefore matches every tab on load and mounts
+      //    content for tabs the user never opened.
+      var tabContent = el.closest('.tabContent');
+      if (tabContent) {
+        if (tabContent.classList.contains('is-active')) return el;
+        continue;
+      }
+      // 2. Standard Jellyfin page structure
       var page = el.closest('.page');
       if (page && !page.classList.contains('hide')) return el;
-      // 2. Custom Tabs wraps content in .tabContent.is-active (no .page ancestor)
-      var tabContent = el.closest('.tabContent');
-      if (tabContent && tabContent.classList.contains('is-active')) return el;
       // 3. Last resort: element is simply visible in the document
-      if (!page && !tabContent && el.offsetParent !== null) return el;
+      if (!page && el.offsetParent !== null) return el;
     }
     return null;
   }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-custom-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/enhanced/hiddencontent/hidden-content-custom-tab.js
@@ -85,7 +85,12 @@
       //    content for tabs the user never opened.
       var tabContent = el.closest('.tabContent');
       if (tabContent) {
-        if (tabContent.classList.contains('is-active')) return el;
+        // `is-active` is the fast path but is not authoritative on its own:
+        // not every host sets it, and it can be applied without a DOM
+        // mutation for the observers below to notice. An actual visibility
+        // check backs it up so the panel still mounts if the class is absent
+        // or lands late — a missing mount is far worse than a late one.
+        if (tabContent.classList.contains('is-active') || el.offsetParent !== null) return el;
         continue;
       }
       // 2. Standard Jellyfin page structure
@@ -150,15 +155,50 @@
     // bound to the old element would become orphaned after returning to home
     // (issue 536). Routes to the shared multiplexed body observer.
     var mountPending = false;
-    JE.helpers.createObserver('hidden-content-custom-tab', function () {
-      if (!mountPending) {
-        mountPending = true;
-        requestAnimationFrame(function () {
-          mountPending = false;
-          tryMount();
-        });
-      }
-    }, document.body, { childList: true, subtree: true });
+    function scheduleMount() {
+      if (mountPending) return;
+      mountPending = true;
+      requestAnimationFrame(function () {
+        mountPending = false;
+        ensureTabActivationObserver();
+        tryMount();
+      });
+    }
+
+    JE.helpers.createObserver('hidden-content-custom-tab', scheduleMount, document.body,
+      { childList: true, subtree: true });
+
+    // A tab becoming active is a class change, and the shared body observer
+    // only dispatches for batches containing added/removed nodes — so an
+    // activation on its own can go unseen and the panel would never mount.
+    // Watch the panels' shared parent for class changes as well, scoped to
+    // that subtree so this stays cheap.
+    var observedTabsParent = null;
+    function ensureTabActivationObserver() {
+      var anyPanel = document.querySelector('.tabContent');
+      var parent = anyPanel && anyPanel.parentElement;
+      if (!parent || parent === observedTabsParent) return;
+      observedTabsParent = parent;
+      JE.helpers.createObserver('hidden-content-custom-tab-tab-activation', scheduleMount, parent,
+        { attributes: true, attributeFilter: ['class'], subtree: true });
+    }
+    ensureTabActivationObserver();
+
+    // The page module clears per-user state on a user switch, but that relies
+    // on a re-render to refresh what is on screen. Content in a tab that is
+    // not currently open will not get one, so drop the rendered DOM here too —
+    // otherwise the previous user's content stays in the tab until it is
+    // opened. Mirrors the reset in enhanced/bookmarks/bookmarks-library-render.js.
+    function resetForUserChange() {
+      var all = document.querySelectorAll('.jellyfinenhanced.hidden-content');
+      for (var i = 0; i < all.length; i++) all[i].textContent = '';
+      lastMountedContainer = null;
+    }
+    JE.session?.onUserChange('hidden-content-custom-tab', resetForUserChange);
+    document.addEventListener('je:user-data-loaded', function () {
+      resetForUserChange();
+      tryMount();
+    });
   }
 
   waitForHiddenContent(function (JE) {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/extras/activity-custom-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/extras/activity-custom-tab.js
@@ -90,7 +90,12 @@
       //    content for tabs the user never opened.
       var tabContent = el.closest('.tabContent');
       if (tabContent) {
-        if (tabContent.classList.contains('is-active')) return el;
+        // `is-active` is the fast path but is not authoritative on its own:
+        // not every host sets it, and it can be applied without a DOM
+        // mutation for the observers below to notice. An actual visibility
+        // check backs it up so the panel still mounts if the class is absent
+        // or lands late — a missing mount is far worse than a late one.
+        if (tabContent.classList.contains('is-active') || el.offsetParent !== null) return el;
         continue;
       }
       // 2. Standard Jellyfin page structure
@@ -152,15 +157,50 @@
     window.addEventListener('hashchange', tryMount);
 
     var mountPending = false;
-    JE.helpers.createObserver('activity-custom-tab', function () {
-      if (!mountPending) {
-        mountPending = true;
-        requestAnimationFrame(function () {
-          mountPending = false;
-          tryMount();
-        });
-      }
-    }, document.body, { childList: true, subtree: true });
+    function scheduleMount() {
+      if (mountPending) return;
+      mountPending = true;
+      requestAnimationFrame(function () {
+        mountPending = false;
+        ensureTabActivationObserver();
+        tryMount();
+      });
+    }
+
+    JE.helpers.createObserver('activity-custom-tab', scheduleMount, document.body,
+      { childList: true, subtree: true });
+
+    // A tab becoming active is a class change, and the shared body observer
+    // only dispatches for batches containing added/removed nodes — so an
+    // activation on its own can go unseen and the panel would never mount.
+    // Watch the panels' shared parent for class changes as well, scoped to
+    // that subtree so this stays cheap.
+    var observedTabsParent = null;
+    function ensureTabActivationObserver() {
+      var anyPanel = document.querySelector('.tabContent');
+      var parent = anyPanel && anyPanel.parentElement;
+      if (!parent || parent === observedTabsParent) return;
+      observedTabsParent = parent;
+      JE.helpers.createObserver('activity-custom-tab-tab-activation', scheduleMount, parent,
+        { attributes: true, attributeFilter: ['class'], subtree: true });
+    }
+    ensureTabActivationObserver();
+
+    // The page module clears per-user state on a user switch, but that relies
+    // on a re-render to refresh what is on screen. Content in a tab that is
+    // not currently open will not get one, so drop the rendered DOM here too —
+    // otherwise the previous user's content stays in the tab until it is
+    // opened. Mirrors the reset in enhanced/bookmarks/bookmarks-library-render.js.
+    function resetForUserChange() {
+      var all = document.querySelectorAll('.jellyfinenhanced.activity');
+      for (var i = 0; i < all.length; i++) all[i].textContent = '';
+      lastMountedContainer = null;
+    }
+    JE.session?.onUserChange('activity-custom-tab', resetForUserChange);
+    document.addEventListener('je:user-data-loaded', function () {
+      resetForUserChange();
+      tryMount();
+    });
   }
 
   waitForActivity(function (JE) {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/extras/activity-custom-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/extras/activity-custom-tab.js
@@ -83,11 +83,21 @@
     var all = document.querySelectorAll('.jellyfinenhanced.activity');
     for (var i = all.length - 1; i >= 0; i--) {
       var el = all[i];
+      // 1. Tab-hosted content: the tab's own active state is authoritative.
+      //    Checked BEFORE .page because Custom Tabs injects its panels into
+      //    #indexPage, which is NOT .hide while the home page is showing. A
+      //    .page-first check therefore matches every tab on load and mounts
+      //    content for tabs the user never opened.
+      var tabContent = el.closest('.tabContent');
+      if (tabContent) {
+        if (tabContent.classList.contains('is-active')) return el;
+        continue;
+      }
+      // 2. Standard Jellyfin page structure
       var page = el.closest('.page');
       if (page && !page.classList.contains('hide')) return el;
-      var tabContent = el.closest('.tabContent');
-      if (tabContent && tabContent.classList.contains('is-active')) return el;
-      if (!page && !tabContent && el.offsetParent !== null) return el;
+      // 3. Last resort: element is simply visible in the document
+      if (!page && el.offsetParent !== null) return el;
     }
     return null;
   }

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/recommendations/recommendations-custom-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/recommendations/recommendations-custom-tab.js
@@ -89,7 +89,12 @@
       //    content for tabs the user never opened.
       var tabContent = el.closest('.tabContent');
       if (tabContent) {
-        if (tabContent.classList.contains('is-active')) return el;
+        // `is-active` is the fast path but is not authoritative on its own:
+        // not every host sets it, and it can be applied without a DOM
+        // mutation for the observers below to notice. An actual visibility
+        // check backs it up so the panel still mounts if the class is absent
+        // or lands late — a missing mount is far worse than a late one.
+        if (tabContent.classList.contains('is-active') || el.offsetParent !== null) return el;
         continue;
       }
       // 2. Standard Jellyfin page structure
@@ -148,15 +153,50 @@
     tryMount();
 
     var mountPending = false;
-    JE.helpers.createObserver('jellyseerr-recommendations-custom-tab', function () {
-      if (!mountPending) {
-        mountPending = true;
-        requestAnimationFrame(function () {
-          mountPending = false;
-          tryMount();
-        });
-      }
-    }, document.body, { childList: true, subtree: true });
+    function scheduleMount() {
+      if (mountPending) return;
+      mountPending = true;
+      requestAnimationFrame(function () {
+        mountPending = false;
+        ensureTabActivationObserver();
+        tryMount();
+      });
+    }
+
+    JE.helpers.createObserver('jellyseerr-recommendations-custom-tab', scheduleMount, document.body,
+      { childList: true, subtree: true });
+
+    // A tab becoming active is a class change, and the shared body observer
+    // only dispatches for batches containing added/removed nodes — so an
+    // activation on its own can go unseen and the panel would never mount.
+    // Watch the panels' shared parent for class changes as well, scoped to
+    // that subtree so this stays cheap.
+    var observedTabsParent = null;
+    function ensureTabActivationObserver() {
+      var anyPanel = document.querySelector('.tabContent');
+      var parent = anyPanel && anyPanel.parentElement;
+      if (!parent || parent === observedTabsParent) return;
+      observedTabsParent = parent;
+      JE.helpers.createObserver('jellyseerr-recommendations-custom-tab-tab-activation', scheduleMount, parent,
+        { attributes: true, attributeFilter: ['class'], subtree: true });
+    }
+    ensureTabActivationObserver();
+
+    // The page module clears per-user state on a user switch, but that relies
+    // on a re-render to refresh what is on screen. Content in a tab that is
+    // not currently open will not get one, so drop the rendered DOM here too —
+    // otherwise the previous user's content stays in the tab until it is
+    // opened. Mirrors the reset in enhanced/bookmarks/bookmarks-library-render.js.
+    function resetForUserChange() {
+      var all = document.querySelectorAll('.jellyfinenhanced.recommendations');
+      for (var i = 0; i < all.length; i++) all[i].textContent = '';
+      lastMountedContainer = null;
+    }
+    JE.session?.onUserChange('jellyseerr-recommendations-custom-tab', resetForUserChange);
+    document.addEventListener('je:user-data-loaded', function () {
+      resetForUserChange();
+      tryMount();
+    });
   }
 
   waitForRecommendations(function (JE) {

--- a/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/recommendations/recommendations-custom-tab.js
+++ b/Jellyfin.Plugin.JellyfinEnhanced/js/jellyseerr/recommendations/recommendations-custom-tab.js
@@ -82,11 +82,21 @@
     var all = document.querySelectorAll('.jellyfinenhanced.recommendations');
     for (var i = all.length - 1; i >= 0; i--) {
       var el = all[i];
+      // 1. Tab-hosted content: the tab's own active state is authoritative.
+      //    Checked BEFORE .page because Custom Tabs injects its panels into
+      //    #indexPage, which is NOT .hide while the home page is showing. A
+      //    .page-first check therefore matches every tab on load and mounts
+      //    content for tabs the user never opened.
+      var tabContent = el.closest('.tabContent');
+      if (tabContent) {
+        if (tabContent.classList.contains('is-active')) return el;
+        continue;
+      }
+      // 2. Standard Jellyfin page structure
       var page = el.closest('.page');
       if (page && !page.classList.contains('hide')) return el;
-      var tabContent = el.closest('.tabContent');
-      if (tabContent && tabContent.classList.contains('is-active')) return el;
-      if (!page && !tabContent && el.offsetParent !== null) return el;
+      // 3. Last resort: element is simply visible in the document
+      if (!page && el.offsetParent !== null) return el;
     }
     return null;
   }


### PR DESCRIPTION
I went looking for why my home page was slow and found that the Calendar tab was fetching on every home load, even though I never had it open.

`findActiveContainer()` checks `.page` before `.tabContent.is-active`:

```js
// 1. Standard Jellyfin page structure
var page = el.closest('.page');
if (page && !page.classList.contains('hide')) return el;
// 2. Custom Tabs wraps content in .tabContent.is-active (no .page ancestor)
var tabContent = el.closest('.tabContent');
if (tabContent && tabContent.classList.contains('is-active')) return el;
```

The comment on the second branch says Custom Tabs panels have no `.page` ancestor, but on 10.11 Custom Tabs injects its panels into `#indexPage`, and that isn't `.hide` while the home page is showing. So the first branch always matches and the second one never gets a chance to run — every tab-hosted module mounts and fetches on home load regardless of which tab is actually selected.

In my case that meant a `GET /arr/calendar` on every single home page load, into a tab that was closed and not even visible. That endpoint fans out to Sonarr/Radarr with no caching, so it's not a cheap thing to be firing off for nothing.

The same function is copy-pasted across six modules, so they all have it:

- `arr/calendar/calendar-custom-tab.js`
- `arr/requests/requests-custom-tab.js`
- `enhanced/hiddencontent/hidden-content-custom-tab.js`
- `extras/activity-custom-tab.js`
- `jellyseerr/recommendations/recommendations-custom-tab.js`
- `enhanced/bookmarks/bookmarks-library-render.js`

## The fix

When the element is tab-hosted, let the tab's own active state decide; otherwise fall through to the existing `.page` / visibility logic.

Nothing else needed touching, though I did check one thing first. The observer is registered with `childList`/`subtree` and no `attributes`, so if switching tabs were only a class toggle, deferring the mount would have meant it never mounted at all. It isn't — Jellyfin adds and removes nodes when it switches tabs, so the observer still fires and `tryMount()` runs on click.

## Testing

Jellyfin 10.11.7 with Custom Tabs, built with `-p:JellyfinTarget=jf10`:

On the home page there are now no `/arr/calendar` requests at all. Clicking the tab fires exactly one and the calendar renders normally. Before the change it was one request on every home load.

## Second commit

Unrelated and easy to drop if you'd rather keep this focused. The calendar loading state reuses `.je-calendar-empty` and has no `role` or `aria-live`, so screen readers get nothing at all while it loads, and on a slow *arr response the tab just reads as empty rather than busy. Gave it its own class with a spinner and a live region. Under `prefers-reduced-motion` I slowed the spinner rather than removing it, since dropping the animation entirely would leave no progress cue for the people who opt into that.

One caveat: I've only been able to test the `jf10` target. It's JS-only so the `jf12` build shouldn't care, but I can't verify that without spinning up an instance.

