### PR TITLE
Revert #798: restore protected request avatar proxying

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -9244,22 +9244,11 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
                         string? username = requestedBy?["username"]?.Value<string>();
                         string? avatar = requestedBy?["avatar"]?.Value<string>();
 
-                        // Proxy avatar through our backend to avoid CORS/mixed content issues.
-                        // Jellyseerr returns two different shapes in `user.avatar`:
-                        //   - a relative path for media-server users, e.g. "/avatarproxy/<jellyfinUserId>"
-                        //   - an absolute Gravatar URL for locally-created Jellyseerr users,
-                        //     e.g. "https://gravatar.com/avatar/<md5>?default=mm&size=200"
-                        // ProxyAvatar only accepts relative Jellyseerr paths (it rejects anything
-                        // containing "://" as an SSRF guard), so wrapping an absolute URL always
-                        // returns 400 and the requester ends up with no avatar. An absolute HTTPS
-                        // URL is already safe for the browser to load directly - <img> needs no
-                        // CORS, and HTTPS rules out mixed content - so pass it through untouched.
+                        // Proxy avatar through our backend to avoid CORS/mixed content issues
                         string? avatarUrl = null;
                         if (!string.IsNullOrEmpty(avatar))
                         {
-                            avatarUrl = avatar.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
-                                ? avatar
-                                : $"/JellyfinEnhanced/proxy/avatar?path={Uri.EscapeDataString(avatar)}";
+                            avatarUrl = $"/JellyfinEnhanced/proxy/avatar?path={Uri.EscapeDataString(avatar)}";
                         }
 
                         // Handle createdAt - could be string or DateTime


### PR DESCRIPTION
Reverts #798 (merge commit db78bee9fd126e15ff8e647b1e9f930289c07e0e), restoring the authenticated avatar proxy for every non-empty requester avatar returned by `GetRequests()`.

#798 returns any avatar beginning with `https://` directly to the browser. When that requester appears on a request card, the browser contacts the supplied host and bypasses the proxy's content-type checks and caching. This revert restores the previous behavior: relative Seerr avatars load through the proxy, while absolute URLs are rejected before an upstream avatar fetch.

**Known tradeoff:** this also restores the original local-user Gravatar limitation. Absolute Gravatar URLs receive HTTP 400 from the proxy and their avatars remain hidden. This PR is an exact, one-file revert; it does not add Gravatar proxy support or change avatar handling on other surfaces.

Verification completed with a controlled Seerr API fixture and isolated Docker containers:

- Release builds for `JellyfinTarget=jf10` and `jf12`: zero warnings and errors.
- Live reverted plugin on Jellyfin **10.11.11** and **12.0-rc6**, compared with current `main` on 12.0-rc6.
- Chromium using the actual request-card renderer and avatar helpers: the baseline attempted three external avatar requests on initial render; the revert attempted **zero**, including after rehydration. External requests in the baseline test were intercepted locally.
- `/avatarproxy/`, `/avatar/`, and `/api/v1/avatar/` images load; client cache reuse, server cache reuse, and ETag/304 responses pass.
- Arbitrary HTTPS, mixed-case HTTPS, Gravatar, traversal, and protocol-relative inputs are blocked; SVG/HTML responses are rejected; empty/missing avatars remain absent. Both endpoints still require authentication.
- No JavaScript exceptions in the browser harness; `git diff --check` passes.

Developed and verified with Codex assistance. Browser verification used real plugin modules and live plugin endpoints with fixture data, rather than a full Seerr installation.
