### PR TITLE
fix(activity): reduce feed query cost and protect history writes

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfiguration.cs
@@ -342,8 +342,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
 
     /// <summary>
     /// A single "recently watched" or "recently favorited" activity record for
-    /// the Activity Feed. One entry per (user, item, type) -- a repeat event
-    /// (re-watch, re-favorite) just bumps OccurredAt rather than duplicating.
+    /// the Activity Feed. One entry per (user, item, type). Re-watching bumps
+    /// OccurredAt; favorites keep their timestamp until removed and re-added.
     /// </summary>
     public class ActivityEntry
     {

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfigurationManager.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfigurationManager.cs
@@ -748,7 +748,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             finally
             {
                 try { File.Delete(temporaryPath); }
-                catch (Exception ex) { _logger.Warning($"Failed to clean up temporary activity file: {ex.Message}"); }
+                catch (IOException ex) { _logger.Warning($"Failed to clean up temporary activity file: {ex.Message}"); }
+                catch (UnauthorizedAccessException ex) { _logger.Warning($"Failed to clean up temporary activity file: {ex.Message}"); }
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfigurationManager.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/UserConfigurationManager.cs
@@ -673,6 +673,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         // ─── Shared activity file (Activity Feed) ──────────────────────────────
 
         private static readonly object _activityFileLock = new object();
+        private static readonly JsonSerializerSettings _activityReadSettings = new JsonSerializerSettings { CheckAdditionalContent = true };
 
         // Bounds activity.json's growth on a busy, long-running server -- the
         // Activity Feed only ever shows the newest handful anyway, so entries
@@ -681,7 +682,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
 
         private string ActivityFilePath => Path.Combine(_configBaseDir, "activity.json");
 
-        private AllActivityStore ReadActivityStoreUnlocked()
+        private AllActivityStore ReadActivityStoreUnlocked(bool throwOnCorruption = false)
         {
             var filePath = ActivityFilePath;
             if (!File.Exists(filePath)) return new AllActivityStore();
@@ -689,18 +690,29 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             try
             {
                 var json = File.ReadAllText(filePath);
-                if (string.IsNullOrWhiteSpace(json)) return new AllActivityStore();
-                return JsonConvert.DeserializeObject<AllActivityStore>(json) ?? new AllActivityStore();
+                if (string.IsNullOrWhiteSpace(json))
+                    throw new InvalidDataException("activity.json is empty.");
+                // Populate with no default dictionary so a missing Entries
+                // property is rejected instead of silently becoming empty.
+                var store = new AllActivityStore { Entries = null! };
+                JsonConvert.PopulateObject(json, store, _activityReadSettings);
+                if (store.Entries == null || store.Entries.Values.Any(entry => entry == null))
+                    throw new InvalidDataException("activity.json contains an invalid activity store.");
+                return store;
             }
             catch (Exception ex)
             {
                 _logger.Error($"Failed to read shared activity.json: {ex.Message}");
+                // Keep the original file intact for recovery. A failed read
+                // must never turn the next event into a destructive reset.
+                if (throwOnCorruption) throw;
                 return new AllActivityStore();
             }
         }
 
         private void WriteActivityStoreUnlocked(AllActivityStore store)
         {
+            var temporaryPath = ActivityFilePath + "." + Guid.NewGuid().ToString("N") + ".tmp";
             try
             {
                 // Prune oldest-first once over the cap, same trim point every
@@ -716,12 +728,27 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
                 }
 
                 var json = JsonConvert.SerializeObject(store, Formatting.Indented);
-                File.WriteAllText(ActivityFilePath, json);
+                // The temporary file is on the same filesystem as the store.
+                // Readers see either complete version if writing is interrupted.
+                using (var stream = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                {
+                    using (var writer = new StreamWriter(stream, new System.Text.UTF8Encoding(false), 4096, leaveOpen: true))
+                    {
+                        writer.Write(json);
+                    }
+                    stream.Flush(flushToDisk: true);
+                }
+                File.Move(temporaryPath, ActivityFilePath, overwrite: true);
             }
             catch (Exception ex)
             {
                 _logger.Error($"Failed to save shared activity.json: {ex.Message}");
                 throw;
+            }
+            finally
+            {
+                try { File.Delete(temporaryPath); }
+                catch (Exception ex) { _logger.Warning($"Failed to clean up temporary activity file: {ex.Message}"); }
             }
         }
 
@@ -735,21 +762,22 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         }
 
         /// <summary>
-        /// Records (or bumps the timestamp of) a watched/favorited activity
-        /// entry for a user+item. A repeat event just updates OccurredAt so
-        /// re-watching or re-favoriting resurfaces the item in the feed
-        /// instead of leaving a stale duplicate.
+        /// Records a watched/favorited activity entry for a user+item.
+        /// Re-watching updates OccurredAt. Favorites keep their original
+        /// timestamp until removed, so unrelated user-data saves cannot
+        /// invent a new favorite event. Re-favoriting after removal resurfaces it.
         /// </summary>
         public void RecordActivity(string userIdN, string itemIdN, string activityType, string nowIso, bool completed = false, double progress = 0)
         {
             lock (_activityFileLock)
             {
-                var store = ReadActivityStoreUnlocked();
+                var store = ReadActivityStoreUnlocked(throwOnCorruption: true);
                 var key = $"{userIdN}:{itemIdN}:{activityType}";
                 // Completed and Progress never downgrade: a later partial
                 // re-watch of something already finished (or watched
                 // further) once shouldn't erase that.
                 store.Entries.TryGetValue(key, out var existing);
+                if (existing != null && activityType == Services.ActivityService.ActivityTypeFavorited) return;
                 var wasCompleted = existing?.Completed == true;
                 var priorProgress = existing?.Progress ?? 0;
                 store.Entries[key] = new ActivityEntry
@@ -773,7 +801,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         {
             lock (_activityFileLock)
             {
-                var store = ReadActivityStoreUnlocked();
+                var store = ReadActivityStoreUnlocked(throwOnCorruption: true);
                 var key = $"{userIdN}:{itemIdN}:{activityType}";
                 if (!store.Entries.Remove(key)) return;
                 WriteActivityStoreUnlocked(store);

--- a/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Controllers/JellyfinEnhancedController.cs
@@ -6860,223 +6860,32 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Controllers
 
         // ─── Activity Feed (recently watched / favorited / reviewed) ─────────────
 
-        /// <summary>A single merged, ready-to-serialize Activity Feed row.</summary>
-        private sealed class ActivityFeedItem
-        {
-            public string ActivityType { get; set; } = string.Empty;
-            public string UserId { get; set; } = string.Empty;
-            public string UserName { get; set; } = string.Empty;
-            public long Timestamp { get; set; }
-            public object Item { get; set; } = new { };
-            public double? Rating { get; set; }
-            public string? Content { get; set; }
-            /// <summary>Watched-only: whether this was ever played to completion.</summary>
-            public bool Completed { get; set; }
-            /// <summary>Watched-only: highest fraction (0.0-1.0) of runtime ever observed played.</summary>
-            public double Progress { get; set; }
-        }
-
-        /// <summary>
-        /// Builds the card-rendering summary for an activity feed item. Series
-        /// name/id/episode numbering come off the Episode entity directly
-        /// (cheap, in-memory) -- no extra library lookup needed, same as
-        /// TagCacheService's approach. The series' own images are looked up
-        /// separately (one extra GetItemById) since an episode's own Primary
-        /// is often just an arbitrary auto-extracted video frame, not a
-        /// designed image -- the frontend prefers the series' Thumb/Primary
-        /// over the episode's own.
-        /// </summary>
-        private object BuildActivityItemSummary(BaseItem item)
-        {
-            string? seriesName = null;
-            string? seriesId = null;
-            int? seasonNumber = null;
-            int? episodeNumber = null;
-            bool seriesHasPrimaryImage = false;
-            bool seriesHasThumbImage = false;
-
-            if (item is MediaBrowser.Controller.Entities.TV.Episode ep)
-            {
-                seriesName = ep.SeriesName;
-                seasonNumber = ep.ParentIndexNumber;
-                episodeNumber = ep.IndexNumber;
-                if (ep.SeriesId != Guid.Empty)
-                {
-                    seriesId = ep.SeriesId.ToString("N");
-                    var series = _libraryManager.GetItemById(ep.SeriesId);
-                    if (series != null)
-                    {
-                        seriesHasPrimaryImage = series.HasImage(ImageType.Primary, 0);
-                        seriesHasThumbImage = series.HasImage(ImageType.Thumb, 0);
-                    }
-                }
-            }
-
-            return new
-            {
-                Id = item.Id.ToString("N"),
-                Name = item.Name,
-                Type = item.GetBaseItemKind().ToString(),
-                ProductionYear = item.ProductionYear,
-                SeriesName = seriesName,
-                SeriesId = seriesId,
-                SeasonNumber = seasonNumber,
-                EpisodeNumber = episodeNumber,
-                // No cache-busting tag needed -- /Items/{id}/Images/{type} always
-                // serves whatever is current; a boolean is enough to know
-                // whether to render an <img> at all.
-                HasPrimaryImage = item.HasImage(ImageType.Primary, 0),
-                HasThumbImage = item.HasImage(ImageType.Thumb, 0),
-                SeriesHasPrimaryImage = seriesHasPrimaryImage,
-                SeriesHasThumbImage = seriesHasThumbImage
-            };
-        }
-
-        /// <summary>
-        /// True if this author should be hidden from a non-self, non-admin
-        /// viewer under the admin's hide-hidden/hide-disabled settings. Mirrors
-        /// GetItemReviews' author-visibility logic so Activity applies the same
-        /// moderation rules reviews already do, rather than a second policy.
-        /// </summary>
-        private bool ShouldHideActivityAuthor(JUser? author, bool viewerIsAdmin, bool isSelf, bool hideHidden, bool hideDisabled)
-        {
-            if (viewerIsAdmin || isSelf) return false;
-            if (author == null) return hideHidden || hideDisabled;
-            if (hideHidden && author.HasPermission(PermissionKind.IsHidden)) return true;
-            if (hideDisabled && author.HasPermission(PermissionKind.IsDisabled)) return true;
-            return false;
-        }
-
         [HttpGet("activity")]
         [Authorize]
         [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         [Produces("application/json")]
-        public IActionResult GetActivityFeed([FromQuery] int limit = 50)
+        public IActionResult GetActivityFeed([FromQuery] int limit = 50, CancellationToken cancellationToken = default)
         {
             var config = JellyfinEnhanced.Instance?.Configuration;
             if (config?.ActivityFeedEnabled != true) return NotFound();
 
             var viewerUserId = UserHelper.GetCurrentUserId(User);
             if (!viewerUserId.HasValue || viewerUserId.Value == Guid.Empty) return Forbid();
-
             var viewer = _userManager.GetUserById(viewerUserId.Value);
             if (viewer == null) return Forbid();
 
-            limit = Math.Clamp(limit, 1, 200);
-            var viewerIsAdmin = IsAdminUser();
-            var hideHiddenAuthors = config.HideReviewsFromHiddenUsers;
-            var hideDisabledAuthors = config.HideReviewsFromDisabledUsers;
+            cancellationToken.ThrowIfCancellationRequested();
+            var activity = config.ActivityFeedShowWatched || config.ActivityFeedShowFavorited
+                ? _userConfigurationManager.GetAllActivity().Entries.Values.AsEnumerable()
+                : Enumerable.Empty<ActivityEntry>();
+            cancellationToken.ThrowIfCancellationRequested();
+            var reviews = config.ActivityFeedShowReviewed
+                ? _userConfigurationManager.GetAllReviews().Reviews.Values.AsEnumerable()
+                : Enumerable.Empty<UserReview>();
 
-            // Per-viewer accessible item ids -- an activity entry for an item
-            // the viewer can't see in their own library must never render,
-            // even just to prove someone else has it. Same technique as
-            // TagCacheService.GetCacheForUser's per-user access filtering.
-            var accessibleIds = new HashSet<Guid>(
-                _libraryManager.GetItemIds(new InternalItemsQuery(viewer) { Recursive = true }));
-
-            var results = new List<ActivityFeedItem>();
-
-            if (config.ActivityFeedShowWatched || config.ActivityFeedShowFavorited)
-            {
-                var activityStore = _userConfigurationManager.GetAllActivity();
-                foreach (var entry in activityStore.Entries.Values)
-                {
-                    try
-                    {
-                        var isWatched = entry.ActivityType == Services.ActivityService.ActivityTypeWatched;
-                        var isFavorited = entry.ActivityType == Services.ActivityService.ActivityTypeFavorited;
-                        if (isWatched && !config.ActivityFeedShowWatched) continue;
-                        if (isFavorited && !config.ActivityFeedShowFavorited) continue;
-                        if (!isWatched && !isFavorited) continue;
-
-                        if (!Guid.TryParseExact(entry.ItemId, "N", out var itemGuid)) continue;
-                        if (!accessibleIds.Contains(itemGuid)) continue;
-
-                        var item = _libraryManager.GetItemById<BaseItem>(itemGuid);
-                        if (item == null) continue;
-
-                        if (!Guid.TryParseExact(entry.UserId, "N", out var authorGuid)) continue;
-                        var author = _userManager.GetUserById(authorGuid);
-                        var isSelf = author != null && authorGuid == viewer.Id;
-                        if (ShouldHideActivityAuthor(author, viewerIsAdmin, isSelf, hideHiddenAuthors, hideDisabledAuthors)) continue;
-
-                        if (!DateTimeOffset.TryParse(entry.OccurredAt, out var occurred)) continue;
-
-                        results.Add(new ActivityFeedItem
-                        {
-                            ActivityType = entry.ActivityType,
-                            UserId = entry.UserId,
-                            UserName = author?.Username ?? entry.UserId,
-                            Timestamp = occurred.ToUnixTimeMilliseconds(),
-                            Item = BuildActivityItemSummary(item),
-                            Completed = entry.Completed,
-                            Progress = entry.Progress
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.Warning($"Skipping activity entry {entry.UserId}:{entry.ItemId}:{entry.ActivityType} due to error: {ex.Message}");
-                    }
-                }
-            }
-
-            if (config.ActivityFeedShowReviewed)
-            {
-                var reviewStore = _userConfigurationManager.GetAllReviews();
-                foreach (var review in reviewStore.Reviews.Values)
-                {
-                    try
-                    {
-                        // Season/episode review keys ("{tmdbId}:s{n}[:e{n}]") resolve
-                        // to their parent series/movie item for display -- drilling
-                        // into the exact season/episode poster isn't worth the extra
-                        // lookups for a feed row.
-                        var baseTmdbId = review.TmdbId.Split(':')[0];
-                        var providerIds = new Dictionary<string, string> { { "Tmdb", baseTmdbId } };
-                        var itemIds = _itemRepository.GetItemIdsByProviders(providerIds);
-                        if (itemIds == null || itemIds.Count == 0) continue;
-                        var itemGuid = itemIds[0];
-                        if (itemGuid == Guid.Empty) continue;
-                        if (!accessibleIds.Contains(itemGuid)) continue;
-
-                        var item = _libraryManager.GetItemById<BaseItem>(itemGuid);
-                        if (item == null) continue;
-
-                        JUser? author = null;
-                        if (Guid.TryParseExact(review.UserId, "N", out var authorGuid))
-                        {
-                            author = _userManager.GetUserById(authorGuid);
-                        }
-                        var isSelf = author != null && author.Id == viewer.Id;
-                        if (ShouldHideActivityAuthor(author, viewerIsAdmin, isSelf, hideHiddenAuthors, hideDisabledAuthors)) continue;
-
-                        var timestampSource = string.IsNullOrEmpty(review.UpdatedAt) ? review.CreatedAt : review.UpdatedAt;
-                        if (!DateTimeOffset.TryParse(timestampSource, out var occurred)) continue;
-
-                        results.Add(new ActivityFeedItem
-                        {
-                            ActivityType = "Reviewed",
-                            UserId = review.UserId,
-                            UserName = author?.Username ?? review.UserId,
-                            Timestamp = occurred.ToUnixTimeMilliseconds(),
-                            Item = BuildActivityItemSummary(item),
-                            Rating = review.Rating,
-                            Content = review.Content
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.Warning($"Skipping review activity for {review.UserId}:{review.MediaType}:{review.TmdbId} due to error: {ex.Message}");
-                    }
-                }
-            }
-
-            var ordered = results
-                .OrderByDescending(r => r.Timestamp)
-                .Take(limit)
-                .ToList();
-
-            return Ok(new { items = ordered });
+            var builder = new Services.ActivityFeedBuilder(_libraryManager, _userManager, _itemRepository, _logger);
+            var items = builder.Build(activity, reviews, viewer, IsAdminUser(), config, limit, cancellationToken);
+            return Ok(new { items });
         }
 
         [HttpGet("whats-new")]

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/ActivityFavoriteMonitor.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/ActivityFavoriteMonitor.cs
@@ -1,5 +1,6 @@
 using System;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
 
 namespace Jellyfin.Plugin.JellyfinEnhanced.Services
 {
@@ -7,7 +8,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
     /// Records Activity Feed "Favorited" entries by watching
     /// IUserDataManager.UserDataSaved -- Jellyfin has no dedicated
     /// favorite-toggled event; a favorite/unfavorite still lands here as a
-    /// user-data save, distinguished only by UserData.IsFavorite's new value.
+    /// user-data save with UpdateUserRating (also used for likes). Imports
+    /// and general user-data updates can change favorites as well.
     /// A Singleton subscribed for the plugin's lifetime, same pattern as
     /// SpoilerNextUnwatchedService.
     /// </summary>
@@ -30,11 +32,19 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         {
             try
             {
+                // Playback events are frequent and never toggle favorites.
+                // Filter before touching the shared JSON file, including for
+                // items that have never been favorited. These reasons exist
+                // on both Jellyfin 10.11 and 12.
+                if (e.SaveReason != UserDataSaveReason.UpdateUserRating
+                    && e.SaveReason != UserDataSaveReason.UpdateUserData
+                    && e.SaveReason != UserDataSaveReason.Import) return;
+
                 var cfg = JellyfinEnhanced.Instance?.Configuration;
                 if (cfg?.ActivityFeedEnabled != true || cfg.ActivityFeedShowFavorited != true) return;
 
                 var item = e.Item;
-                if (item == null || e.UserId == Guid.Empty) return;
+                if (item == null || e.UserId == Guid.Empty || e.UserData == null) return;
 
                 if (e.UserData?.IsFavorite == true)
                 {

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/ActivityFeedBuilder.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/ActivityFeedBuilder.cs
@@ -1,0 +1,227 @@
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.JellyfinEnhanced.Configuration;
+using Jellyfin.Plugin.JellyfinEnhanced.Extensions;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Persistence;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.JellyfinEnhanced.Services;
+
+/// <summary>A merged activity row; preserves the existing activity endpoint's JSON shape.</summary>
+internal sealed class ActivityFeedItem
+{
+    public string ActivityType { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string UserName { get; set; } = string.Empty;
+    public long Timestamp { get; set; }
+    public object Item { get; set; } = new { };
+    public double? Rating { get; set; }
+    public string? Content { get; set; }
+    public bool Completed { get; set; }
+    public double Progress { get; set; }
+}
+
+/// <summary>
+/// Selects the newest permitted activity before hydrating card metadata. All lookup
+/// caches live inside Build so permission, author and media changes are observed on
+/// the next request, and no result can be reused across viewers.
+/// </summary>
+internal sealed class ActivityFeedBuilder(
+    ILibraryManager libraryManager,
+    IUserManager userManager,
+    IItemRepository itemRepository,
+    Logger logger)
+{
+    private const int CandidatePageSize = 64;
+
+    private sealed record Candidate(ActivityFeedItem Row, Guid ItemId, Guid AuthorId, string? TmdbId = null);
+
+    /// <summary>
+    /// Merges lightweight records in stable timestamp order, checking access in
+    /// bounded pages and continuing past filtered/deleted records until limit is met.
+    /// </summary>
+    public List<ActivityFeedItem> Build(
+        IEnumerable<ActivityEntry> activity,
+        IEnumerable<UserReview> reviews,
+        JUser viewer,
+        bool viewerIsAdmin,
+        PluginConfiguration config,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        limit = Math.Clamp(limit, 1, 200);
+        var candidates = new List<Candidate>();
+        foreach (var entry in activity)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (entry == null) continue;
+            var enabled = entry.ActivityType switch
+            {
+                ActivityService.ActivityTypeWatched => config.ActivityFeedShowWatched,
+                ActivityService.ActivityTypeFavorited => config.ActivityFeedShowFavorited,
+                _ => false
+            };
+            if (!enabled || !Guid.TryParseExact(entry.ItemId, "N", out var itemId)
+                || !Guid.TryParseExact(entry.UserId, "N", out var authorId) || authorId == Guid.Empty
+                || !DateTimeOffset.TryParse(entry.OccurredAt, out var occurred)) continue;
+
+            candidates.Add(new Candidate(new ActivityFeedItem
+            {
+                ActivityType = entry.ActivityType,
+                UserId = entry.UserId,
+                Timestamp = occurred.ToUnixTimeMilliseconds(),
+                Completed = entry.Completed,
+                Progress = entry.Progress
+            }, itemId, authorId));
+        }
+
+        if (config.ActivityFeedShowReviewed)
+        {
+            foreach (var review in reviews)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (review == null || string.IsNullOrEmpty(review.TmdbId)) continue;
+                var timestamp = string.IsNullOrEmpty(review.UpdatedAt) ? review.CreatedAt : review.UpdatedAt;
+                if (!DateTimeOffset.TryParse(timestamp, out var occurred)) continue;
+                Guid.TryParseExact(review.UserId, "N", out var authorId);
+                candidates.Add(new Candidate(new ActivityFeedItem
+                {
+                    ActivityType = "Reviewed",
+                    UserId = review.UserId,
+                    Timestamp = occurred.ToUnixTimeMilliseconds(),
+                    Rating = review.Rating,
+                    Content = review.Content
+                }, Guid.Empty, authorId, review.TmdbId.Split(':')[0]));
+            }
+        }
+
+        // OrderBy is stable: equal timestamps retain activity-before-review and
+        // store enumeration order, matching the previous merged feed.
+        var ordered = candidates.OrderByDescending(c => c.Row.Timestamp).ToArray();
+        var authors = new Dictionary<Guid, JUser?> { [viewer.Id] = viewer };
+        var providerItems = new Dictionary<string, Guid>(StringComparer.Ordinal);
+        var items = new Dictionary<Guid, BaseItem?>();
+        var summaries = new Dictionary<Guid, object>();
+        var results = new List<ActivityFeedItem>(limit);
+#if !JF12
+        HashSet<Guid>? accessibleIds = null;
+#endif
+
+        JUser? GetAuthor(Guid id)
+        {
+            if (id == Guid.Empty) return null;
+            if (!authors.TryGetValue(id, out var author))
+                authors[id] = author = userManager.GetUserById(id);
+            return author;
+        }
+
+        BaseItem? GetItem(Guid id)
+        {
+            if (!items.TryGetValue(id, out var item))
+                items[id] = item = libraryManager.GetItemById(id);
+            return item;
+        }
+
+        var next = 0;
+        while (next < ordered.Length && results.Count < limit)
+        {
+            var page = new List<(Candidate Candidate, Guid ItemId, JUser? Author)>(CandidatePageSize);
+            while (next < ordered.Length && page.Count < CandidatePageSize)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var candidate = ordered[next++];
+                try
+                {
+                    var author = GetAuthor(candidate.AuthorId);
+                    if (!viewerIsAdmin && author?.Id != viewer.Id
+                        && ((config.HideReviewsFromHiddenUsers && (author == null || author.HasPermission(PermissionKind.IsHidden)))
+                            || (config.HideReviewsFromDisabledUsers && (author == null || author.HasPermission(PermissionKind.IsDisabled)))))
+                        continue;
+
+                    var itemId = candidate.ItemId;
+                    if (candidate.TmdbId != null && !providerItems.TryGetValue(candidate.TmdbId, out itemId))
+                    {
+                        // Keep existing provider resolution: episode/season reviews
+                        // use the parent TMDB id and the first repository match.
+                        var matches = itemRepository.GetItemIdsByProviders(new Dictionary<string, string>
+                        {
+                            ["Tmdb"] = candidate.TmdbId
+                        });
+                        providerItems[candidate.TmdbId] = itemId = matches?.FirstOrDefault() ?? Guid.Empty;
+                    }
+                    if (itemId != Guid.Empty) page.Add((candidate, itemId, author));
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    logger.Warning($"Skipping activity candidate for {candidate.Row.UserId}: {ex.Message}");
+                }
+            }
+
+            // Empty/invalid/hidden-author-only feeds never enumerate the library.
+            if (page.Count == 0) continue;
+            cancellationToken.ThrowIfCancellationRequested();
+#if JF12
+            var query = new InternalItemsQuery(viewer) { Recursive = true };
+            // Setting ItemIds first makes Jellyfin skip default library scoping.
+            // Establish its supported user scope BEFORE narrowing to this page;
+            // InternalItemsQuery(viewer) also retains parental/tag restrictions.
+            libraryManager.ConfigureUserAccess(query, viewer);
+            query.ItemIds = page.Select(p => p.ItemId).Distinct().ToArray();
+            var permitted = new HashSet<Guid>(libraryManager.GetItemIds(query));
+#else
+            // 10.11 has no ConfigureUserAccess API. Preserve its original safe
+            // recursive user query, lazily once per request; a naked ItemIds query
+            // would bypass allowed-library restrictions on that host.
+            accessibleIds ??= new HashSet<Guid>(libraryManager.GetItemIds(new InternalItemsQuery(viewer) { Recursive = true }));
+            var permitted = accessibleIds;
+#endif
+            foreach (var (candidate, itemId, author) in page)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!permitted.Contains(itemId)) continue;
+                try
+                {
+                    if (!summaries.TryGetValue(itemId, out var summary))
+                    {
+                        var item = GetItem(itemId);
+                        if (item == null) continue;
+                        summaries[itemId] = summary = BuildSummary(item, GetItem);
+                    }
+                    candidate.Row.UserName = author?.Username ?? candidate.Row.UserId;
+                    candidate.Row.Item = summary;
+                    results.Add(candidate.Row);
+                    if (results.Count == limit) break;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    logger.Warning($"Skipping activity item {itemId:N}: {ex.Message}");
+                }
+            }
+        }
+        return results;
+    }
+
+    /// <summary>Hydrates only emitted cards; episode series lookups share the request's item cache.</summary>
+    private static object BuildSummary(BaseItem item, Func<Guid, BaseItem?> getItem)
+    {
+        var episode = item as MediaBrowser.Controller.Entities.TV.Episode;
+        var series = episode != null && episode.SeriesId != Guid.Empty ? getItem(episode.SeriesId) : null;
+        return new
+        {
+            Id = item.Id.ToString("N"),
+            Name = item.Name,
+            Type = item.GetBaseItemKind().ToString(),
+            ProductionYear = item.ProductionYear,
+            SeriesName = episode?.SeriesName,
+            SeriesId = episode != null && episode.SeriesId != Guid.Empty ? episode.SeriesId.ToString("N") : null,
+            SeasonNumber = episode?.ParentIndexNumber,
+            EpisodeNumber = episode?.IndexNumber,
+            HasPrimaryImage = item.HasImage(ImageType.Primary, 0),
+            HasThumbImage = item.HasImage(ImageType.Thumb, 0),
+            SeriesHasPrimaryImage = series?.HasImage(ImageType.Primary, 0) == true,
+            SeriesHasThumbImage = series?.HasImage(ImageType.Thumb, 0) == true
+        };
+    }
+}

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/ActivityFeedBuilder.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/ActivityFeedBuilder.cs
@@ -135,9 +135,7 @@ internal sealed class ActivityFeedBuilder(
                 try
                 {
                     var author = GetAuthor(candidate.AuthorId);
-                    if (!viewerIsAdmin && author?.Id != viewer.Id
-                        && ((config.HideReviewsFromHiddenUsers && (author == null || author.HasPermission(PermissionKind.IsHidden)))
-                            || (config.HideReviewsFromDisabledUsers && (author == null || author.HasPermission(PermissionKind.IsDisabled)))))
+                    if (ShouldHideAuthor(author, viewer.Id, viewerIsAdmin, config))
                         continue;
 
                     var itemId = candidate.ItemId;
@@ -201,6 +199,16 @@ internal sealed class ActivityFeedBuilder(
             }
         }
         return results;
+    }
+
+    /// <summary>Preserves admin/self exceptions and the configured missing-author fallback.</summary>
+    private static bool ShouldHideAuthor(JUser? author, Guid viewerId, bool viewerIsAdmin, PluginConfiguration config)
+    {
+        if (viewerIsAdmin || author?.Id == viewerId) return false;
+        if (author == null)
+            return config.HideReviewsFromHiddenUsers || config.HideReviewsFromDisabledUsers;
+        if (config.HideReviewsFromHiddenUsers && author.HasPermission(PermissionKind.IsHidden)) return true;
+        return config.HideReviewsFromDisabledUsers && author.HasPermission(PermissionKind.IsDisabled);
     }
 
     /// <summary>Hydrates only emitted cards; episode series lookups share the request's item cache.</summary>


### PR DESCRIPTION
Opening the activity feed currently enumerates the viewer's accessible library and loads metadata for every activity/review before applying the response limit. Ordinary playback also refreshes existing favorite timestamps and rewrites shared activity history. This change reduces feed work and makes favorite persistence idempotent.

### Changes

- Sort lightweight records first, then fill the requested page after author and item-access filtering. Reuse author, provider, item and series lookups within each request; continue past inaccessible or deleted rows.
- On Jellyfin 12, establish viewer scope with `ConfigureUserAccess` before restricting permission queries to batches of at most 64 candidate IDs. Jellyfin 10.11 retains the existing safe recursive permission query, lazily once per nonempty request.
- Ignore playback and played-state events in the favorite monitor before activity-store I/O. Preserve favorite timestamps until unfavorite/re-favorite; keep watched progress/completion and rewatch behavior.
- Flush a unique same-directory temporary file before replacing `activity.json`. Preserve corrupt history and reject writes instead of resetting the store after a failed read.

The endpoint's response shape, ordering, author visibility rules and 500-entry history cap are preserved. Lookup caches are request-local. The diff contains five production C# files; test fixtures and lab artifacts are not included.

### Initial validation

Full release builds passed for JF12/.NET 10 and JF10/.NET 9 with zero warnings/errors. Local linked-production suites passed 25 feed tests and 22 storage/favorite tests against each dependency target. The storage harness runs on .NET 10 for both package sets; compatibility was additionally exercised on actual Jellyfin 10.11.11.

Disposable Docker validation used Jellyfin 12.0.0 final with 20,024 movies, 3 series and 18 episodes. Jellyfin 10.11.11 used only 24 movies, 3 series and 18 episodes. Both containers had 4 CPUs and 4 GiB RAM.

| JF12, 500 activity records | Before | After |
|---|---:|---:|
| Median response, limit 1 | 3,653 ms | 70 ms |
| Median response, limit 50 | 3,404 ms | 53 ms |
| Container CPU/request, limit 50 | 3,406 ms | 86 ms |
| Slowest of 8 concurrent requests, limit 50 | 7,671 ms | 122 ms |

Same instances/data before and after, changing the DLL and restarting. Medians use five requests after an initial request; concurrency is one eight-request burst. CPU includes container background work. These short synthetic runs are not sustained-load estimates; the performance fixture contains watched records with reviews disabled.

- 47 changed-build live assertions passed across both servers, including native favorite/playback events, author rules, allowed/no libraries, parental ratings, blocked/allowed tags, and continuation beyond 64 inaccessible candidates.
- All 10 complete parsed-response comparisons matched the original build; all 280 before/after benchmark responses had the expected status and item count.
- Storage checks covered malformed history, concurrent writers/readers, failed replacement cleanup, no-op file bytes/mtime, and retention.
- Independent code review and `git diff --check` passed.

### Remaining limits

Review-enabled requests still read the whole reviews JSON; indexed review persistence is separate work. JF10 still incurs the full-library permission query for a nonempty feed. Atomic replacement was tested during normal concurrent operation, not power loss. A favorite already pruned from history can be recorded again by a later rating/import/general-user-data event because Jellyfin does not provide its previous favorite value. No new browser matrix or long-duration soak was run for this backend change.

### Review follow-up and large Jellyfin 10.11.11 validation

Commit `629fdc815fb5559d1851650b96f8ec7460555840` addresses both CodeQL notes: simplify author visibility into an equivalent helper and restrict temporary-file cleanup catches to expected I/O/access errors. Independent review verified all 96 possible author-policy state combinations. Both full builds and all 47 local regression tests per dependency target passed again; all nine GitHub checks passed, and CodeQL reports both alerts fixed.

The updated commit was then tested on **Jellyfin 10.11.11 with 20,024 movies, 3 series, 18 episodes and 40,084 media-stream rows**, using a separate native 10.11 database and a Docker instance limited to 4 CPUs/4 GiB. The large-library test was explicitly added after the initial small-library compatibility run.

| JF10.11.11, 500 activity records | Original build | Updated PR |
|---|---:|---:|
| Median response, limit 1 | 4,360 ms | 219 ms |
| Median response, limit 50 | 4,142 ms | 242 ms |
| Container CPU/request, limit 50 | 4,121 ms | 319 ms |
| Slowest of 8 concurrent requests, limit 50 | 7,404 ms | 674 ms |

Same short benchmark method as above. All 24 changed-build live assertions passed (15 ordering/policy, 8 native favorite/playback, and refill after 70 inaccessible entries). Both complete fixed JSON responses matched the original; all 56 timed/initial benchmark responses had expected status/count. The original favorite timestamp/write defects were reproduced and passed after the update.

The native scanner populated the 10.11 database. During fixture setup only, repeated ffprobe calls for 20,000 hard links to identical media reused a result produced by that container's native ffprobe. The native binary was restored and checksum-verified before benchmarking, after scanning completed and a settling period. No scan-speed or decoded-playback claim is made from this fixture setup.

Developed with AI assistance (Codex), including independent review agents and local regression/integration validation.
