### PR TITLE
fix(analytics): refresh reports after build or host changes

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Configuration/PluginConfiguration.cs
@@ -395,6 +395,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
             AnalyticsLastReportedAt = 0;
             AnalyticsLastPayloadJson = string.Empty;
             AnalyticsLastReportedPluginVersion = string.Empty;
+            AnalyticsLastReportedJellyfinTarget = string.Empty;
+            AnalyticsLastReportedJellyfinVersion = string.Empty;
             AnalyticsForbiddenSinceLastSuccess = 0;
         }
 
@@ -998,8 +1000,12 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Configuration
         public long AnalyticsLastReportedAt { get; set; }
         /// <summary>Hidden field, no UI. The exact JSON payload from the last successful report, shown verbatim on the config page.</summary>
         public string AnalyticsLastPayloadJson { get; set; } = string.Empty;
-        /// <summary>Hidden field, no UI. Plugin version as of the last successful report; a mismatch against the running version forces an immediate report (bypassing AnalyticsReportIntervalDays) so version-adoption data isn't stale for up to 30 days after an upgrade.</summary>
+        /// <summary>Hidden field, no UI. Full plugin assembly version at the last successful report; changes bypass the reporting interval.</summary>
         public string AnalyticsLastReportedPluginVersion { get; set; } = string.Empty;
+        /// <summary>Hidden field, no UI. Compiled build target at the last successful report; detects same-version build corrections.</summary>
+        public string AnalyticsLastReportedJellyfinTarget { get; set; } = string.Empty;
+        /// <summary>Hidden field, no UI. Running Jellyfin version at the last successful report; detects host upgrades independently of plugin upgrades.</summary>
+        public string AnalyticsLastReportedJellyfinVersion { get; set; } = string.Empty;
         /// <summary>
         /// Hidden field, no UI. Count of report_stats 403 responses since the
         /// last successful report. PERSISTED (not an in-memory field) because

--- a/Jellyfin.Plugin.JellyfinEnhanced/JellyfinEnhanced.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/JellyfinEnhanced.cs
@@ -262,6 +262,8 @@ namespace Jellyfin.Plugin.JellyfinEnhanced
                         incoming.AnalyticsLastReportedAt = current.AnalyticsLastReportedAt;
                         incoming.AnalyticsLastPayloadJson = current.AnalyticsLastPayloadJson;
                         incoming.AnalyticsLastReportedPluginVersion = current.AnalyticsLastReportedPluginVersion;
+                        incoming.AnalyticsLastReportedJellyfinTarget = current.AnalyticsLastReportedJellyfinTarget;
+                        incoming.AnalyticsLastReportedJellyfinVersion = current.AnalyticsLastReportedJellyfinVersion;
                     }
                 }
 

--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/AnalyticsReportingService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/AnalyticsReportingService.cs
@@ -414,13 +414,11 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
         }
 
         /// <summary>
-        /// Runs on the scheduled task's cadence: no-ops unless analytics is
+        /// Runs at startup and on the scheduled task's cadence: no-ops unless analytics is
         /// enabled, AND either the configured interval has actually elapsed
-        /// since the last successful send, OR the plugin version has changed
-        /// since that last send. The version check exists because
-        /// v_version_adoption is only useful if it reflects upgrades promptly;
-        /// otherwise "how fast is everyone updating" would lag by up to 30
-        /// days behind reality, which defeats the point of tracking it at all.
+        /// since the last successful send, OR the full plugin version, compiled
+        /// build target or running Jellyfin version has changed. This also
+        /// refreshes same-version build corrections and host-only upgrades.
         /// </summary>
         public async Task ReportIfDueAsync(CancellationToken cancellationToken)
         {
@@ -428,9 +426,12 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             var config = instance?.Configuration;
             if (instance == null || config == null || !config.AnalyticsEnabled) return;
 
-            var currentPluginVersion = instance.Version?.ToString(3) ?? string.Empty;
-            var versionChanged = !string.IsNullOrEmpty(config.AnalyticsLastReportedPluginVersion)
-                && config.AnalyticsLastReportedPluginVersion != currentPluginVersion;
+            var currentPluginVersion = instance.Version?.ToString() ?? string.Empty;
+            // Missing fields from older configurations deliberately trigger one
+            // refresh; only a successful send records the complete combination.
+            var environmentChanged = config.AnalyticsLastReportedPluginVersion != currentPluginVersion
+                || config.AnalyticsLastReportedJellyfinTarget != JellyfinTarget
+                || config.AnalyticsLastReportedJellyfinVersion != (_appHost.ApplicationVersionString ?? string.Empty);
 
             var intervalDays = Math.Clamp(config.AnalyticsReportIntervalDays, 7, 30);
             var lastSent = config.AnalyticsLastReportedAt > 0
@@ -439,7 +440,7 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
 
             var intervalElapsed = !lastSent.HasValue || DateTimeOffset.UtcNow - lastSent.Value >= TimeSpan.FromDays(intervalDays);
 
-            if (!intervalElapsed && !versionChanged)
+            if (!intervalElapsed && !environmentChanged)
             {
                 return;
             }
@@ -502,6 +503,9 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
             }
 
             var snapshot = _counters.GetSnapshot();
+            // Keep the full version locally without changing the backend's
+            // three-component plugin_version payload format.
+            var currentPluginVersion = JellyfinEnhanced.Instance?.Version?.ToString() ?? string.Empty;
             var payload = BuildPayload(
                 config,
                 config.AnalyticsShareFeatureFlags,
@@ -583,7 +587,9 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                     live.AnalyticsForbiddenSinceLastSuccess = 0;
                     live.AnalyticsLastReportedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                     live.AnalyticsLastPayloadJson = JsonSerializer.Serialize(payload);
-                    live.AnalyticsLastReportedPluginVersion = payload.PluginVersion;
+                    live.AnalyticsLastReportedPluginVersion = currentPluginVersion;
+                    live.AnalyticsLastReportedJellyfinTarget = payload.JellyfinTarget;
+                    live.AnalyticsLastReportedJellyfinVersion = payload.JellyfinVersion;
                     try
                     {
                         JellyfinEnhanced.Instance?.SaveConfiguration();

--- a/docs/advanced/config-flag-groups.json
+++ b/docs/advanced/config-flag-groups.json
@@ -887,6 +887,8 @@
     "AnalyticsInstallSecret": "",
     "AnalyticsLastPayloadJson": "",
     "AnalyticsLastReportedAt": 0,
+    "AnalyticsLastReportedJellyfinTarget": "",
+    "AnalyticsLastReportedJellyfinVersion": "",
     "AnalyticsLastReportedPluginVersion": "",
     "AnalyticsReportIntervalDays": 15,
     "AnalyticsShareDataSizes": true,


### PR DESCRIPTION
Correcting a Jellyfin Enhanced installation from jf10 to jf12 at the same plugin version currently leaves analytics unchanged until the normal reporting interval elapses. Upgrading Jellyfin alone has the same problem because the due-check only compares the first three components of the plugin version.

Compare the full plugin assembly version, compiled build target and running Jellyfin version against the last successful report. Any change triggers a report at the next startup/scheduled check. Older configurations refresh once to populate the missing fields. Failed sends leave the previous combination intact so the next check retries; analytics opt-out still applies.

Store the full version locally while preserving the backend's existing three-component payload format. Include the new fields in configuration-state preservation and regenerate the documentation defaults. This improves reporting freshness; it does not replace an incorrectly installed plugin DLL.

Validation:
- Both jf10 and jf12 plugin builds pass with zero warnings or errors.
- 15 local offline regression cases pass, compiling the complete production reporting service against dependency stubs and an intercepted HTTP handler. Covers build/host/revision changes, legacy configurations, cadence, successful persistence, failed-send retries, opt-out and configuration replacement. The harness is outside this PR; no live Jellyfin/backend integration test was performed.
- `git diff --check` passes.

Follow-up to #799. AI-assisted implementation and validation.
