### PR TITLE
fix(cdn): continue asset refresh after request timeouts

### DIFF
--- a/Jellyfin.Plugin.JellyfinEnhanced/Services/CdnAssetService.cs
+++ b/Jellyfin.Plugin.JellyfinEnhanced/Services/CdnAssetService.cs
@@ -432,7 +432,9 @@ namespace Jellyfin.Plugin.JellyfinEnhanced.Services
                 var etag = $"\"{Convert.ToHexString(SHA256.HashData(bytes))}\"";
                 return new CdnAsset(bytes, contentType, etag);
             }
-            catch (OperationCanceledException)
+            // HttpClient timeouts also throw OperationCanceledException. Only
+            // caller cancellation should abort the refresh or bypass stale cache.
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
             }


### PR DESCRIPTION
An upstream HttpClient timeout currently cancels the entire CDN asset refresh and skips later assets. It also bypasses the on-demand stale-disk fallback, even when a usable cached copy exists.

Only rethrow OperationCanceledException when the caller token is cancelled. Request timeouts instead reach the existing warning-and-null failure path, allowing refresh to continue and GetAsync to use its existing cache fallback. Genuine caller cancellation still propagates.

Validation:
- Reproduced the original failure with the complete service/task code and a real 20-second HttpClient timeout: refresh aborted after 1/59 assets. The patched code attempted all 59 and logged 58/59 usable assets in the same no-fallback fixture.
- All 9 local native regression cases passed, covering stale fallback, negative caching, caller/task/queued cancellation, semaphore reuse and existing response validation. HTTP was intercepted; no live CDN or Jellyfin server was used. The harness is outside this PR.
- Both jf10 and jf12 builds passed with zero warnings/errors; `git diff --check` passed.

Closes #823.

AI-assisted implementation and validation.
